### PR TITLE
Include additional header files in wrapper.h

### DIFF
--- a/crates/rb-sys/wrapper.h
+++ b/crates/rb-sys/wrapper.h
@@ -1,1 +1,70 @@
 #include "ruby.h"
+#ifdef HAVE_RUBY_ATOMIC_H
+#include "ruby/atomic.h"
+#endif
+#ifdef HAVE_RUBY_DEBUG_H
+#include "ruby/debug.h"
+#endif
+#ifdef HAVE_RUBY_DEFINES_H
+#include "ruby/defines.h"
+#endif
+#ifdef HAVE_RUBY_ENCODING_H
+#include "ruby/encoding.h"
+#endif
+#ifdef HAVE_RUBY_FIBER_SCHEDULER_H
+#include "ruby/fiber/scheduler.h"
+#endif
+#ifdef HAVE_RUBY_INTERN_H
+#include "ruby/intern.h"
+#endif
+#ifdef HAVE_RUBY_IO_H
+#include "ruby/io.h"
+#endif
+#ifdef HAVE_RUBY_MEMORY_VIEW_H
+#include "ruby/memory_view.h"
+#endif
+#ifdef HAVE_RUBY_MISSING_H
+#include "ruby/missing.h"
+#endif
+#ifdef HAVE_RUBY_ONIGMO_H
+#include "ruby/onigmo.h"
+#endif
+#ifdef HAVE_RUBY_ONIGURUMA_H
+#include "ruby/oniguruma.h"
+#endif
+#ifdef HAVE_RUBY_RACTOR_H
+#include "ruby/ractor.h"
+#endif
+#ifdef HAVE_RUBY_RANDOM_H
+#include "ruby/random.h"
+#endif
+#ifdef HAVE_RUBY_RE_H
+#include "ruby/re.h"
+#endif
+#ifdef HAVE_RUBY_REGEX_H
+#include "ruby/regex.h"
+#endif
+#ifdef HAVE_RUBY_RUBY_H
+#include "ruby/ruby.h"
+#endif
+#ifdef HAVE_RUBY_ST_H
+#include "ruby/st.h"
+#endif
+#ifdef HAVE_RUBY_THREAD_H
+#include "ruby/thread.h"
+#endif
+#ifdef HAVE_RUBY_THREAD_NATIVE_H
+#include "ruby/thread_native.h"
+#endif
+#ifdef HAVE_RUBY_UTIL_H
+#include "ruby/util.h"
+#endif
+#ifdef HAVE_RUBY_VERSION_H
+#include "ruby/version.h"
+#endif
+#ifdef HAVE_RUBY_VM_H
+#include "ruby/vm.h"
+#endif
+#ifdef HAVE_RUBY_WIN32_H
+#include "ruby/win32.h"
+#endif


### PR DESCRIPTION
There are some functions part of Ruby's C API that are listed in their own headers rather than in `ruby.h`.

The one I really want is `ruby/encoding.h`, as I'm using it in Magnus, but when I took a look at it, it seemed like why not include the others.

Not all of these are guaranteed to exist, but the base `ruby.h` defines some macro constants when they exist, so I made use of that to conditionally include them.