### PR TITLE
Fix clean target/, it's a directory.

### DIFF
--- a/gem/lib/rb_sys/mkmf.rb
+++ b/gem/lib/rb_sys/mkmf.rb
@@ -25,7 +25,8 @@ module RbSys
       make_install = <<~MAKE
         target_prefix = #{target_prefix}
         CARGO_PROFILE = release
-        CLEANLIBS = target/ $(RUSTLIB) $(DLLIB)
+        CLEANLIBS = $(RUSTLIB) $(DLLIB)
+        DISTCLEANDIRS = target/
         RUBYARCHDIR   = $(sitearchdir)$(target_prefix)
         RUSTLIB = #{dllib_path(builder)}
         TARGET = #{target}


### PR DESCRIPTION
`RM` method is `rm -f`, `target/` need use `RMDIRS`

```
distclean: clean distclean-so distclean-static distclean-rb-default distclean-rb
		-$(Q)$(RM) Makefile $(RUBY_EXTCONF_H) conftest.* mkmf.log
		-$(Q)$(RM) core ruby$(EXEEXT) *~ $(DISTCLEANFILES)
		-$(Q)$(RMDIRS) $(DISTCLEANDIRS) 2> /dev/null || true
```