### PR TITLE
Use literal newline in osxcross wrapper scripts

### DIFF
--- a/docker/setup/osxcross-shebang.sh
+++ b/docker/setup/osxcross-shebang.sh
@@ -5,7 +5,7 @@
 main() {
   for file in /opt/osxcross/target/bin/*; do
     if [ "$(file -b --mime-type "$file")" = "text/plain" ]; then
-      printf "#!/bin/sh\n%s" "$(cat "$file")\n" > "$file"
+      printf "#!/bin/sh\n%s\n" "$(cat "$file")" > "$file"
     fi
   done
 


### PR DESCRIPTION
Before:

```
$ cat /opt/osxcross/target/bin/aarch64-apple-darwin-cc
#!/bin/sh
/opt/osxcross/target/bin/aarch64-apple-darwin20.2-cc "$@"\n$
```

After:

```
$ cat /opt/osxcross/target/bin/aarch64-apple-darwin-cc
/opt/osxcross/target/bin/aarch64-apple-darwin20.2-cc "$@"
$
```