### PR TITLE
Remove dependency on libc crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,7 +269,6 @@ dependencies = [
  "bindgen",
  "cc",
  "lazy_static",
- "libc",
  "linkify",
  "pkg-config",
  "shell-words",

--- a/crates/rb-sys/Cargo.toml
+++ b/crates/rb-sys/Cargo.toml
@@ -18,9 +18,6 @@ ruby-static = []
 link-ruby = []
 ruby-macros = ["cc", "shell-words"]
 
-[dependencies]
-libc = "0.2.126"
-
 [lib]
 doctest = false
 

--- a/crates/rb-sys/build/bindings.rs
+++ b/crates/rb-sys/build/bindings.rs
@@ -103,7 +103,6 @@ fn clean_docs() {
 fn default_bindgen(clang_args: Vec<String>) -> bindgen::Builder {
     bindgen::Builder::default()
         .use_core()
-        .ctypes_prefix("::libc")
         .rustified_enum("*")
         .derive_eq(true)
         .derive_debug(true)

--- a/crates/rb-sys/src/ruby_macros/mod.rs
+++ b/crates/rb-sys/src/ruby_macros/mod.rs
@@ -1,3 +1,5 @@
+use std::os::raw::{c_char, c_long};
+
 use crate::{ruby_value_type, ID, VALUE};
 
 extern "C" {
@@ -83,7 +85,7 @@ extern "C" {
     /// @return     Pointer to its contents.
     /// @pre        `str` must be an instance of ::RString.
     #[link_name = "ruby_macros_RSTRING_PTR"]
-    pub fn RSTRING_PTR(obj: VALUE) -> *mut ::libc::c_char;
+    pub fn RSTRING_PTR(obj: VALUE) -> *mut c_char;
 
     /// Queries the length of the string.
     ///
@@ -91,7 +93,7 @@ extern "C" {
     /// @return     Its length, in bytes.
     /// @pre        `str` must be an instance of ::RString.
     #[link_name = "ruby_macros_RSTRING_LEN"]
-    pub fn RSTRING_LEN(obj: VALUE) -> ::libc::c_long;
+    pub fn RSTRING_LEN(obj: VALUE) -> c_long;
 
     /// Queries the length of the array.
     ///
@@ -99,5 +101,5 @@ extern "C" {
     /// @return     Its number of elements.
     /// @pre        `a` must be an instance of ::RArray.
     #[link_name = "ruby_macros_RARRAY_LEN"]
-    pub fn RARRAY_LEN(a: VALUE) -> ::libc::c_long;
+    pub fn RARRAY_LEN(a: VALUE) -> c_long;
 }


### PR DESCRIPTION
I might be missing some context, but it seems that as only basic types like `c_char`, `c_long`, etc are used, and we could instead use the ones from `std::os::raw` and skip the dependency.