### PR TITLE
Make `create_rust_makefile` more configurable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,5 +57,7 @@ jobs:
           command: test
           args: --workspace --exclude rust-reverse
       - name: 💨 Smoke test
+        env:
+          CARGO_BUILD_PROFILE: "release"
         run: |
           bundle exec rake test:examples

--- a/crates/rb-allocator/src/lib.rs
+++ b/crates/rb-allocator/src/lib.rs
@@ -34,7 +34,7 @@ unsafe impl GlobalAlloc for RbAllocator {
     unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
         let ret = System.realloc(ptr, layout, new_size);
         if !ret.is_null() {
-            rb_gc_adjust_memory_usage((new_size - layout.size()) as ssize_t);
+            rb_gc_adjust_memory_usage((new_size as isize - layout.size() as isize) as ssize_t);
         }
         ret
     }

--- a/examples/rust_reverse/Rakefile
+++ b/examples/rust_reverse/Rakefile
@@ -17,4 +17,4 @@ Rake::ExtensionTask.new("rust_reverse") do |ext|
   ext.cross_platform = %w[x86-mingw32 x64-mingw-ucrt x64-mingw32 x86-linux x86_64-linux x86_64-darwin arm64-darwin aarch64-linux]
 end
 
-task default: %i[clobber compile test]
+task default: %i[compile test]

--- a/examples/rust_reverse/ext/rust_reverse/extconf.rb
+++ b/examples/rust_reverse/ext/rust_reverse/extconf.rb
@@ -1,4 +1,7 @@
 require "mkmf"
 require_relative "./../../../../gem/lib/rb_sys/mkmf"
 
-create_rust_makefile("rust_reverse/rust_reverse")
+create_rust_makefile("rust_reverse/rust_reverse") do |r|
+  r.profile = ENV.fetch("CARGO_BUILD_PROFILE", :dev).to_sym
+  r.env = {"NO_LINK_RUTIE" => "true"}
+end

--- a/examples/rust_reverse/ext/rust_reverse/extconf.rb
+++ b/examples/rust_reverse/ext/rust_reverse/extconf.rb
@@ -1,7 +1,10 @@
+# We need to require mkmr this since `rake-compiler` injects code here for cross compilation
 require "mkmf"
+
+# In a real gem, this would just be: `require "rb_sys/mkmf"`
 require_relative "./../../../../gem/lib/rb_sys/mkmf"
 
 create_rust_makefile("rust_reverse/rust_reverse") do |r|
+  # Create debug builds in dev. Make sure that release gems are compiled with `CARGO_BUILD_PROFILE=release`
   r.profile = ENV.fetch("CARGO_BUILD_PROFILE", :dev).to_sym
-  r.env = {"NO_LINK_RUTIE" => "true"}
 end

--- a/gem/lib/rb_sys/mkmf.rb
+++ b/gem/lib/rb_sys/mkmf.rb
@@ -8,7 +8,7 @@ require_relative "./../../vendor/rubygems/ext/cargo_builder"
 module RbSys
   # Helpers for creating a Ruby compatible makefile for Rust
   module Mkmf
-    def create_rust_makefile(target, srcprefix = nil)
+    def create_rust_makefile(target, srcprefix = nil, &blk)
       if target.include?("/")
         target_prefix, target = File.split(target)
         target_prefix[0, 0] = "/"
@@ -18,6 +18,9 @@ module RbSys
 
       spec = Struct.new(:name, :metadata).new(target, {})
       builder = Gem::Ext::CargoBuilder.new(spec)
+
+      yield builder if blk
+
       srcprefix ||= "$(srcdir)/#{srcprefix}".chomp("/")
       RbConfig.expand(srcdir = srcprefix.dup)
 

--- a/gem/lib/rb_sys/mkmf.rb
+++ b/gem/lib/rb_sys/mkmf.rb
@@ -6,8 +6,28 @@ require_relative "./../../vendor/rubygems/ext/cargo_builder"
 
 # Root module
 module RbSys
-  # Helpers for creating a Ruby compatible makefile for Rust
+  # Helper class for creating Rust Makefiles
   module Mkmf
+    # Helper for building Rust extensions by creating a Ruby compatible makefile
+    # for Rust. By using this class, your rust extension will be 100% compatible
+    # with the rake-compiler gem, which allows for easy cross compilation.
+    #
+    # @example Basic
+    #   require 'mkmf'
+    # . require 'rb_sys/mkmf'
+    #
+    # . create_rust_makefile("my_extension") #=> Generate a Makefile in the current directory
+    #
+    # @example Configure a custom build profile
+    #   require 'mkmf'
+    # . require 'rb_sys/mkmf'
+    #
+    # . create_rust_makefile("my_extension") do |r|
+    # .   # All of these are optional
+    # .   r.env = { 'FOO' => 'bar' }
+    # .   r.profile = ENV.fetch('CARGO_BUILD_PROFILE', :dev).to_sym
+    # .   r.features = %w[some_cargo_feature]
+    # . end
     def create_rust_makefile(target, srcprefix = nil, &blk)
       if target.include?("/")
         target_prefix, target = File.split(target)

--- a/gem/vendor/rubygems/ext/cargo_builder.rb
+++ b/gem/vendor/rubygems/ext/cargo_builder.rb
@@ -3,17 +3,6 @@
 # This class is used by rubygems to build Rust extensions. It is a thin-wrapper
 # over the `cargo rustc` command which takes care of building Rust code in a way
 # that Ruby can use.
-#
-# @example
-#   require 'mkmf'
-# . require 'rb_sys/mkmf'
-#
-# . create_rust_makefile("my_extension") do |r|
-# .   # All of these are optional
-# .   r.env = { 'FOO' => 'bar' }
-# .   r.profile = ENV.fetch('BUILD_ENV', 'release')
-# .   r.features = %w[some_cargo_feature]
-# . end
 class Gem::Ext::CargoBuilder < Gem::Ext::Builder
   attr_accessor :spec, :runner, :profile, :env, :features, :target, :extra_rustc_args
 

--- a/gem/vendor/rubygems/ext/cargo_builder.rb
+++ b/gem/vendor/rubygems/ext/cargo_builder.rb
@@ -3,8 +3,19 @@
 # This class is used by rubygems to build Rust extensions. It is a thin-wrapper
 # over the `cargo rustc` command which takes care of building Rust code in a way
 # that Ruby can use.
+#
+# @example
+#   require 'mkmf'
+# . require 'rb_sys/mkmf'
+#
+# . create_rust_makefile("my_extension") do |r|
+# .   # All of these are optional
+# .   r.env = { 'FOO' => 'bar' }
+# .   r.profile = ENV.fetch('BUILD_ENV', 'release')
+# .   r.features = %w[some_cargo_feature]
+# . end
 class Gem::Ext::CargoBuilder < Gem::Ext::Builder
-  attr_accessor :spec, :runner, :profile
+  attr_accessor :spec, :runner, :profile, :env, :features, :target, :extra_rustc_args
 
   def initialize(spec)
     require "rubygems/command"
@@ -12,7 +23,11 @@ class Gem::Ext::CargoBuilder < Gem::Ext::Builder
 
     @spec = spec
     @runner = self.class.method(:run)
-    @profile = :release
+    @profile = ENV.fetch("CARGO_BUILD_PROFILE", :release).to_sym
+    @env = {}
+    @features = []
+    @target = ENV['CARGO_BUILD_TARGET']
+    @extra_rustc_args = []
   end
 
   def build(_extension, dest_path, results, args = [], lib_dir = nil, cargo_dir = Dir.pwd)
@@ -37,7 +52,7 @@ class Gem::Ext::CargoBuilder < Gem::Ext::Builder
   def build_env
     build_env = rb_config_env
     build_env["RUBY_STATIC"] = "true" if ruby_static? && ENV.key?("RUBY_STATIC")
-    build_env
+    build_env.merge(env)
   end
 
   def cargo_command(cargo_dir, dest_path, args = [])
@@ -46,23 +61,25 @@ class Gem::Ext::CargoBuilder < Gem::Ext::Builder
 
     cmd = []
     cmd += [cargo, "rustc"]
-    cmd += ["--target", ENV["CARGO_BUILD_TARGET"]] if ENV["CARGO_BUILD_TARGET"]
+    cmd += ["--target", target] if target
     cmd += ["--target-dir", dest_path]
+    cmd += ["--features", features.join(",")] unless features.empty?
     cmd += ["--manifest-path", manifest]
     cmd += ["--lib"]
     cmd += ["--profile", profile.to_s]
-    cmd += ["--locked"] if profile == :release
+    cmd += ["--locked"] if profile.to_s == 'release'
     cmd += Gem::Command.build_args
     cmd += args
     cmd += ["--"]
     cmd += [*cargo_rustc_args(dest_path)]
+    cmd += extra_rustc_args
     cmd
   end
 
   def cargo_dylib_path(dest_path)
     prefix = so_ext == "dll" ? "" : "lib"
     path_parts = [dest_path]
-    path_parts << ENV["CARGO_BUILD_TARGET"] if ENV["CARGO_BUILD_TARGET"]
+    path_parts << target if target 
     path_parts += [profile_target_directory, "#{prefix}#{cargo_crate_name}.#{so_ext}"]
     File.join(*path_parts)
   end


### PR DESCRIPTION
Previously, `create_rust_makefile` was sorely lacking configuration. This made creating dev builds a lot harder than it should be. This PR fixes that.


```ruby
# extconf.rb

require 'mkmf'
require 'rb_sys/mkmf'

create_rust_makefile("my_extension") do |r|
  # All of these are optional
  r.env = { 'FOO' => 'bar' }
  r.profile = ENV.fetch('CARGO_BUILD_PROFILE', :dev).to_sym
  r.features = %w[some_cargo_feature]
end
```