### PR TITLE
Make RUBYARCHDIR before installing the DLLIB to it

### DIFF
--- a/gem/lib/rb_sys/mkmf.rb
+++ b/gem/lib/rb_sys/mkmf.rb
@@ -89,6 +89,7 @@ module RbSys
 
         install: $(DLLIB) Makefile
         \t$(ECHO) installing $(DLLIB)
+        \t$(Q) $(MAKEDIRS) $(RUBYARCHDIR)
         \t$(Q) $(INSTALL_PROG) $(DLLIB) $(RUBYARCHDIR)
 
         all: #{$extout ? "install" : "$(DLLIB)"}


### PR DESCRIPTION
## Problem

When the target given to `create_rust_makefile` contains a directory prefix, then the generated Makefile tries to install to `$(RUBYARCHDIR)` even when it doesn't exist.  When the `install` command references a path that doesn't exist, then it assumes it is trying to create a file at that path, instead of trying to install a file with the same name into the destination directory.

For example, if the target it `'foo/bar'`, then it will end up installing the `$(DLLIB)` to `$(sitearchdir)/foo` instead of to `$(sitearchdir)/foo/$(DLLIB)`

## Solution

I used `$(MAKEDIRS) $(RUBYARCHDIR)` as `create_makefile` does. That just creates the directory if it doesn't exist (e.g. using `mkdir -p` on unix) so I just did that as part of the install make task for simplicity.