### PR TITLE
Add flags to opt into deprecated functions and impls

### DIFF
--- a/crates/rb-sys/Cargo.toml
+++ b/crates/rb-sys/Cargo.toml
@@ -33,7 +33,9 @@ libc = "0.2.126"
 default = ["ruby-macros"]
 link-ruby = []
 ruby-macros = ["cc", "shell-words"]
-ruby-static = []
+ruby-static = ["link-ruby"]
+include-rbimpls = []
+include-deprecated = []
 
 [lib]
 doctest = false

--- a/crates/rb-sys/build/bindings.rs
+++ b/crates/rb-sys/build/bindings.rs
@@ -17,12 +17,25 @@ pub fn generate(rbconfig: &RbConfig) {
         .header("wrapper.h")
         .allowlist_file(".*ruby.*")
         .blocklist_item("ruby_abi_version")
-        .blocklist_item("^rbimpl_.*")
-        .blocklist_item("^RBIMPL_.*")
-        .blocklist_item("ruby_fl_type")
         .blocklist_function("^__.*")
         .blocklist_item("RData")
         .parse_callbacks(Box::new(bindgen::CargoCallbacks));
+
+    let bindings = if cfg!(feature = "include-rbimpls") {
+        bindings
+    } else {
+        bindings
+            .blocklist_item("^rbimpl_.*")
+            .blocklist_item("^RBIMPL_.*")
+    };
+
+    let bindings = if cfg!(feature = "include-deprecated") {
+        bindings
+    } else {
+        bindings
+            .blocklist_item("^ruby_fl_type.*")
+            .blocklist_item("^_bindgen_ty_9.*")
+    };
 
     write_bindings(bindings, "bindings-raw.rs");
     clean_docs();

--- a/crates/rb-sys/readme.md
+++ b/crates/rb-sys/readme.md
@@ -25,15 +25,25 @@ feature:
 rb-sys = { version = "0.9",  features = ["link-ruby"] }
 ```
 
+If you are authoring a Ruby gem, you do not need to enable this feature.
+
 ### Static libruby
 
-You can also force the `link-ruby` feature to be static:
+You can also force static linking of libruby:
 
 ```rust
-rb-sys = { version = "0.9", features = ["link-ruby", "ruby-static"] }
+rb-sys = { version = "0.9", features = ["ruby-static"] }
 ```
 
 Alternatively, you can set the `RUBY_STATIC=true` environment variable.
+
+### Other features
+
+- `ruby-macros`: Generate Rust functions for Ruby macros (i.e. `RSTRING_PTR`).
+- `ruby-static`: Link the static version of libruby.
+- `link-ruby`: Link libruby.
+- `include-rbimpls`: Include the Ruby impl types in bindings.
+- `include-deprecated`: Include deprecated Ruby methods in bindings.
 
 ## License
 


### PR DESCRIPTION
When trying to upgrade magnus to the newest rb-sys, I noticed that it needs some impls and deprecated items. This PR makes it so they can be used.