### PR TITLE
Add `RARRAY_PTR` macro

### DIFF
--- a/crates/rb-sys-tests/tests/ruby_macros_test.rs
+++ b/crates/rb-sys-tests/tests/ruby_macros_test.rs
@@ -2,6 +2,12 @@ use rb_sys::macros::*;
 use rb_sys::*;
 use std::{slice, str};
 
+macro_rules! rstring {
+    ($s:expr) => {
+        unsafe { rb_str_new($s.as_ptr() as _, $s.len() as _) }
+    };
+}
+
 #[test]
 fn test_nil_p() {
     assert!(unsafe { NIL_P(Qnil as u64) });
@@ -40,19 +46,17 @@ fn test_rb_float_type_p() {
 #[cfg(not(windows_broken_vm_init_3_1))]
 #[test]
 fn test_rstring_len() {
-    let cstr = std::ffi::CString::new("foo").unwrap();
-    let rstring: VALUE = unsafe { rb_str_new_cstr(cstr.as_ptr()) };
+    let rstr = rstring!("foo");
 
-    assert_eq!(unsafe { RSTRING_LEN(rstring) }, 3);
+    assert_eq!(unsafe { RSTRING_LEN(rstr) }, 3);
 }
 
 #[cfg(not(windows_broken_vm_init_3_1))]
 #[test]
 fn test_rarray_len() {
-    let cstr = std::ffi::CString::new("foo").unwrap();
-    let rstring: VALUE = unsafe { rb_str_new_cstr(cstr.as_ptr()) };
+    let rstr: VALUE = rstring!("foo");
     let rarray = unsafe { rb_ary_new() };
-    unsafe { rb_ary_push(rarray, rstring) };
+    unsafe { rb_ary_push(rarray, rstr) };
 
     assert_eq!(unsafe { RARRAY_LEN(rarray) }, 1);
 }
@@ -60,15 +64,35 @@ fn test_rarray_len() {
 #[cfg(not(windows_broken_vm_init_3_1))]
 #[test]
 fn test_rstring_ptr() {
-    let cstr = std::ffi::CString::new("foo").unwrap();
-    let rstring: VALUE = unsafe { rb_str_new_cstr(cstr.as_ptr()) };
+    let rstr = rstring!("foo");
 
     let rust_str = unsafe {
-        let ptr = RSTRING_PTR(rstring);
-        let len = RSTRING_LEN(rstring);
+        let ptr = RSTRING_PTR(rstr);
+        let len = RSTRING_LEN(rstr);
 
         str::from_utf8(slice::from_raw_parts(ptr as _, len as _))
     };
 
     assert_eq!(rust_str.unwrap(), "foo");
+}
+
+#[cfg(not(windows_broken_vm_init_3_1))]
+#[test]
+fn test_rarray_ptr() {
+    let ary = unsafe { rb_ary_new() };
+    let foo = rstring!("foo");
+
+    unsafe { rb_ary_push(ary, Qtrue as _) };
+    unsafe { rb_ary_push(ary, Qnil as _) };
+    unsafe { rb_ary_push(ary, Qfalse as _) };
+    unsafe { rb_ary_push(ary, foo) };
+
+    let slice = unsafe {
+        let ptr = RARRAY_PTR(ary);
+        let len = RARRAY_LEN(ary);
+
+        slice::from_raw_parts(ptr as _, len as _)
+    };
+
+    assert_eq!(slice, [Qtrue as _, Qnil as _, Qfalse as _, foo]);
 }

--- a/crates/rb-sys/src/macros/mod.rs
+++ b/crates/rb-sys/src/macros/mod.rs
@@ -108,4 +108,19 @@ extern "C" {
     /// @pre        `a` must be an instance of ::RArray.
     #[link_name = "ruby_macros_RARRAY_LEN"]
     pub fn RARRAY_LEN(a: VALUE) -> c_long;
+
+    /// Wild  use of  a  C  pointer.  This  function  accesses  the backend  storage
+    /// directly.   This is  slower  than  #RARRAY_PTR_USE_TRANSIENT.  It  exercises
+    /// extra manoeuvres  to protect our generational  GC.  Use of this  function is
+    /// considered archaic.  Use a modern way instead.
+
+    /// @param[in]  ary  An object of ::RArray.
+    /// @return     The backend C array.
+
+    /// @internal
+
+    /// That said...  there are  extension libraries  in the wild  who uses  it.  We
+    /// cannot but continue supporting.
+    #[link_name = "ruby_macros_RARRAY_PTR"]
+    pub fn RARRAY_PTR(a: VALUE) -> *const VALUE;
 }

--- a/crates/rb-sys/src/macros/ruby_macros.c
+++ b/crates/rb-sys/src/macros/ruby_macros.c
@@ -55,3 +55,8 @@ long
 ruby_macros_RARRAY_LEN(VALUE obj) {
   return RARRAY_LEN(obj);
 }
+
+const VALUE*
+ruby_macros_RARRAY_PTR(VALUE ary) {
+  return RARRAY_PTR(ary);
+}


### PR DESCRIPTION
Although considered "archaic" to use, there are [certain times](https://github.com/matsadler/magnus/blob/6b526259b585e34acde01e7bf673b7b66b722366/src/r_array.rs#L676) where this macro could be useful, and safer than the alternatives.

Also, `RARRAY_PTR_USE_TRANSIENT` is not really feasible to use from Rust, since it performs some wild preprocessor tricks in order to work.