### PR TITLE
Prevent libruby-static from linking unless `link-ruby` is specified

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -16,7 +16,7 @@ runs:
   steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
-      if: inputs.ruby_version != "skip"
+      if: inputs.ruby_version != 'skip'
       with:
         ruby-version: ${{ inputs.ruby_version }}
         bundler-cache: true

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -16,7 +16,7 @@ runs:
   steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
-      if: inputs.ruby_version
+      if: inputs.ruby_version != "skip"
       with:
         ruby-version: ${{ inputs.ruby_version }}
         bundler-cache: true

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -22,6 +22,7 @@ runs:
         bundler-cache: true
     - name: Bundle install
       if: inputs.ruby_version == 'skip'
+      shell: bash
       run: bundle install -j3
     - name: 🐛 Print debug info
       run: ruby -rrbconfig -ryaml -e 'puts RbConfig::CONFIG.to_yaml'

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -16,7 +16,7 @@ runs:
   steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
-      if: ${{ inputs.ruby_version != false }}
+      if: inputs.ruby_version
       with:
         ruby-version: ${{ inputs.ruby_version }}
         bundler-cache: true

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -20,6 +20,9 @@ runs:
       with:
         ruby-version: ${{ inputs.ruby_version }}
         bundler-cache: true
+    - name: Bundle install
+      if: inputs.ruby_version == 'skip'
+      run: bundle install -j3
     - name: 🐛 Print debug info
       run: ruby -rrbconfig -ryaml -e 'puts RbConfig::CONFIG.to_yaml'
       shell: bash

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -16,6 +16,7 @@ runs:
   steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
+      if: ${{ inputs.ruby_version != false }}
       with:
         ruby-version: ${{ inputs.ruby_version }}
         bundler-cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,12 +73,23 @@ jobs:
     runs-on: ${{ matrix.sys.os }}
     steps:
       - uses: actions/checkout@v3
+      - name: ⚡ Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            /opt/rubies/${{ matrix.ruby_version }}
+            ~/.gem/ruby/${{ matrix.ruby_version }}
+        key: ${{ matrix.sys.os }}-${{ matrix.ruby_version }}
+      - name: Setup env
+        run: |
+          echo "PATH=/opt/rubies/${{ matrix.ruby_version }}/bin:$PATH" >> $GITHUB_ENV
+          echo "GEM_HOME=~/.gem/ruby/${{ matrix.ruby_version }}" >> $GITHUB_ENV
       - name: 🔘 Build static ruby
         working-directory: /tmp
         run: |
           git clone https://github.com/rbenv/ruby-build.git
           PREFIX=/usr/local sudo ./ruby-build/install.sh
-          RUBY_CONFIGURE_OPTS="--disable-shared --disable-install-doc" sudo ruby-build ${{ matrix.ruby_version }} /usr/local --verbose
+          RUBY_CONFIGURE_OPTS="--disable-shared --disable-install-doc" sudo ruby-build ${{ matrix.ruby_version }} /opt/rubies/${{ matrix.ruby_version }} --verbose
       - uses: ./.github/actions/setup
         with:
           rust_toolchain: ${{ matrix.sys.rust_toolchain }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,16 +73,16 @@ jobs:
     runs-on: ${{ matrix.sys.os }}
     steps:
       - uses: actions/checkout@v3
-      - uses: ./.github/actions/setup
-        with:
-          rust_toolchain: ${{ matrix.sys.rust_toolchain }}
-          ruby_version: false
-          os: ${{ matrix.sys.os }}
       - name: 🔘 Build static ruby
         working-directory: /tmp
         run: |
           git clone https://github.com/rbenv/ruby-build.git
           PREFIX=/usr/local sudo ./ruby-build/install.sh
           RUBY_CONFIGURE_OPTS="--disable-shared --disable-install-doc" sudo ruby-build ${{ matrix.ruby_version }} /usr/local --verbose
+      - uses: ./.github/actions/setup
+        with:
+          rust_toolchain: ${{ matrix.sys.rust_toolchain }}
+          ruby_version: skip
+          os: ${{ matrix.sys.os }}
       - name: 🧪 Run tests
         run: bundle exec rake test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,6 @@ jobs:
         run: |
           git clone https://github.com/rbenv/ruby-build.git
           PREFIX=/usr/local sudo ./ruby-build/install.sh
-          RUBY_CONFIGURE_OPTS="--disable-shared" sudo ruby-build ${{ matrix.ruby_version }} /usr/local --verbose
+          RUBY_CONFIGURE_OPTS="--disable-shared --disable-install-doc" sudo ruby-build ${{ matrix.ruby_version }} /usr/local --verbose
       - name: 🧪 Run tests
         run: bundle exec rake test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           rust_toolchain: ${{ matrix.sys.rust_toolchain }}
-          ruby_version: ${{ matrix.ruby_version }}
+          ruby_version: false
           os: ${{ matrix.sys.os }}
       - name: 🔘 Build static ruby
         working-directory: /tmp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           bundle exec rake test:examples
 
   build_and_test_static:
-    name: 🌫 Test static Ruby
+    name: 🔘 Test static Ruby
     strategy:
       fail-fast: false
       matrix:
@@ -78,8 +78,8 @@ jobs:
           rust_toolchain: ${{ matrix.sys.rust_toolchain }}
           ruby_version: ${{ matrix.ruby_version }}
           os: ${{ matrix.sys.os }}
-      - name: 🌫 Build static ruby
-        working-directory: tmp
+      - name: 🔘 Build static ruby
+        working-directory: /tmp
         run: |
           git clone https://github.com/rbenv/ruby-build.git
           PREFIX=/usr/local ./ruby-build/install.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           bundle exec rake test:examples
 
   build_and_test_static:
-    name: 🧪 Build and test
+    name: 🌫 Test static Ruby
     strategy:
       fail-fast: false
       matrix:
@@ -79,7 +79,7 @@ jobs:
           ruby_version: ${{ matrix.ruby_version }}
           os: ${{ matrix.sys.os }}
       - name: 🌫 Build static ruby
-        working-directory: ./tmp
+        working-directory: tmp
         run: |
           git clone https://github.com/rbenv/ruby-build.git
           PREFIX=/usr/local ./ruby-build/install.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
           path: |
             /opt/rubies/${{ matrix.ruby_version }}
             ~/.gem/ruby/${{ matrix.ruby_version }}
-        key: ${{ matrix.sys.os }}-${{ matrix.ruby_version }}
+          key: ${{ matrix.sys.os }}-${{ matrix.ruby_version }}
       - name: Setup env
         run: |
           echo "PATH=/opt/rubies/${{ matrix.ruby_version }}/bin:$PATH" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,9 @@ jobs:
         run: |
           git clone https://github.com/rbenv/ruby-build.git
           PREFIX=/usr/local sudo ./ruby-build/install.sh
-          RUBY_CONFIGURE_OPTS="--disable-shared --disable-install-doc" sudo ruby-build ${{ matrix.ruby_version }} /opt/rubies/${{ matrix.ruby_version }} --verbose
+          export MAKEFLAGS="-j$(nproc)"
+          export RUBY_CONFIGURE_OPTS="--disable-shared --disable-install-doc --disable-install-rdoc" 
+          sudo ruby-build ${{ matrix.ruby_version }} /opt/rubies/${{ matrix.ruby_version }}
       - uses: ./.github/actions/setup
         with:
           rust_toolchain: ${{ matrix.sys.rust_toolchain }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
         working-directory: /tmp
         run: |
           git clone https://github.com/rbenv/ruby-build.git
-          PREFIX=/usr/local ./ruby-build/install.sh
-          RUBY_CONFIGURE_OPTS="--disable-shared" ruby-build ${{ matrix.ruby_version }} /usr/local --verbose
+          PREFIX=/usr/local sudo ./ruby-build/install.sh
+          RUBY_CONFIGURE_OPTS="--disable-shared" sudo ruby-build ${{ matrix.ruby_version }} /usr/local --verbose
       - name: 🧪 Run tests
         run: bundle exec rake test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,3 +60,29 @@ jobs:
           PROFILE: "release"
         run: |
           bundle exec rake test:examples
+
+  build_and_test_static:
+    name: 🧪 Build and test
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby_version: ["3.1.2"]
+        sys:
+          - os: ubuntu-latest
+            rust_toolchain: stable
+    runs-on: ${{ matrix.sys.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/setup
+        with:
+          rust_toolchain: ${{ matrix.sys.rust_toolchain }}
+          ruby_version: ${{ matrix.ruby_version }}
+          os: ${{ matrix.sys.os }}
+      - name: 🌫 Build static ruby
+        working-directory: ./tmp
+        run: |
+          git clone https://github.com/rbenv/ruby-build.git
+          PREFIX=/usr/local ./ruby-build/install.sh
+          RUBY_CONFIGURE_OPTS="--disable-shared" ruby-build ${{ matrix.ruby_version }} /usr/local --verbose
+      - name: 🧪 Run tests
+        run: bundle exec rake test

--- a/.github/workflows/publish-book.yml
+++ b/.github/workflows/publish-book.yml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
 
 jobs:
   deploy:

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,67 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Debug rust_reverse example",
+      "sourceLanguages": ["rust"],
+      "program": "/opt/rubies/3.1.1/bin/ruby",
+      "env": {
+        "RB_SYS_CARGO_PROFILE": "1"
+      },
+      "args": ["-Ilib", "test/test_helper.rb"],
+      "cwd": "${workspaceFolder}/examples/rust_reverse"
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Debug unit tests in library 'rb-sys'",
+      "cargo": {
+        "args": ["test", "--no-run", "--lib", "--package=rb-sys"],
+        "filter": {
+          "name": "rb-sys",
+          "kind": "lib"
+        }
+      },
+      "args": [],
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Debug unit tests in library 'rb-sys-build'",
+      "cargo": {
+        "args": ["test", "--no-run", "--lib", "--package=rb-sys-build"],
+        "filter": {
+          "name": "rb-sys-build",
+          "kind": "lib"
+        }
+      },
+      "args": [],
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Debug integration test 'rb-sys-tests'",
+      "cargo": {
+        "args": [
+          "test",
+          "--no-run",
+          "--test=rb-sys-tests",
+          "--package=rb-sys-tests"
+        ],
+        "filter": {
+          "name": "rb-sys-tests",
+          "kind": "test"
+        }
+      },
+      "args": [],
+      "cwd": "${workspaceFolder}"
+    }
+  ]
+}

--- a/Rakefile
+++ b/Rakefile
@@ -27,8 +27,10 @@ namespace :test do
 
   namespace :examples do
     task :rust_reverse do
+      cargo_args = extra_args || []
+
       Dir.chdir("examples/rust_reverse") do
-        sh "rake clean compile test"
+        sh "rake", "clean", "compile", "test", *cargo_args
       end
     end
   end
@@ -73,7 +75,7 @@ task :bump do
   printf "What is the new version (current: #{old_version})?: "
   new_version = $stdin.gets.chomp
 
-  sh "fastmod", "--extensions=toml", "^version = \"#{old_version}\"", "version = #{new_version.inspect}"
+  sh "fastmod", "--extensions=toml", "version = \"#{old_version}\"", "version = #{new_version.inspect}"
   sh "fastmod", "--extensions=rb", "^  VERSION = \"#{old_version}\"", "  VERSION = #{new_version.inspect}"
   sh "cargo check"
   sh "bundle"

--- a/crates/rb-sys-build/src/rb_config/library.rs
+++ b/crates/rb-sys-build/src/rb_config/library.rs
@@ -1,5 +1,5 @@
 /// Represents the kind of library.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum LibraryKind {
     Framework,
     Dylib,
@@ -12,6 +12,13 @@ pub enum LibraryKind {
 pub struct Library {
     pub kind: LibraryKind,
     pub name: String,
+}
+
+impl Library {
+    /// Creates a new library.
+    pub fn new(name: String, kind: LibraryKind) -> Self {
+        Self { kind, name }
+    }
 }
 
 impl From<&str> for LibraryKind {

--- a/crates/rb-sys/Cargo.toml
+++ b/crates/rb-sys/Cargo.toml
@@ -16,7 +16,7 @@ repository = "https://github.com/oxidize-rb/rb-sys"
 bindgen = "0.60"
 linkify = "0.8"
 regex = "1"
-rb-sys-build = { path = "../rb-sys-build", version = "0.9.5" }
+rb-sys-build = { path = "../rb-sys-build", version = "0.9.7" }
 
 [build-dependencies.cc]
 optional = true
@@ -34,7 +34,7 @@ default = ["ruby-macros", "gem"]
 gem = ["ruby-abi-version"]
 link-ruby = []
 ruby-macros = ["cc", "shell-words"]
-ruby-static = ["link-ruby"]
+ruby-static = []
 ruby-abi-version = []
 global-allocator = []
 bindgen-rbimpls = []

--- a/crates/rb-sys/build/main.rs
+++ b/crates/rb-sys/build/main.rs
@@ -27,10 +27,6 @@ fn main() {
         println!("cargo:rerun-if-changed={}", file.unwrap().path().display());
     }
 
-    if cfg!(feature = "link-ruby") {
-        link_libruby(&mut rbconfig);
-    }
-
     bindings::generate(&rbconfig);
     export_cargo_cfg(&mut rbconfig);
     add_platform_link_args(&mut rbconfig);
@@ -41,6 +37,14 @@ fn main() {
             link_libruby(&mut rbconfig);
         }
         compile_ruby_macros(&mut rbconfig);
+    }
+
+    // Only link libruby if it is explicitly requested... except on Windows
+    // where its required.
+    if cfg!(feature = "link-ruby") {
+        link_libruby(&mut rbconfig);
+    } else if !cfg!(windows) {
+        rbconfig.blocklist_lib("ruby");
     }
 
     rbconfig.print_cargo_args();

--- a/gem/README.md
+++ b/gem/README.md
@@ -32,5 +32,16 @@ create_rust_makefile("rust_reverse") do |r|
   # If your Cargo.toml is in a different directory, you can specify it here
   # (optional)
   r.ext_dir = "."
+
+  # You can add extra rustc args for Cargo
+  # (optional)
+  r.extra_rustc_args = ["-C", "foo=bar"]
 end
 ```
+
+## Tips and Tricks
+
+- When using `rake-compiler` to build your gem, you can use the `RB_SYS_CARGO_PROFILE` environment variable to set the
+  Cargo profile (i.e. `release` or `dev`).
+
+- You can pass Cargo arguments to `rake-compiler` like so: `rake compile -- --verbose`


### PR DESCRIPTION
So it looks like a `cargo:rustc-link-lib=static=ruby-static` was able to evade detection, causing rb-sys to link libruby-static even though the `link-ruby` flag was supplied. we don't actually want to link ruby unless we are in an embedded environment. Otherwise, we insta-segfault because the extension will be accessing the incorrect global symbols from libruby-static. 