### PR TITLE
Make linking behavior much more strict and debuggable

### DIFF
--- a/crates/rb-sys-build/src/rb_config.rs
+++ b/crates/rb-sys-build/src/rb_config.rs
@@ -43,8 +43,24 @@ impl RbConfig {
         }
     }
 
+    /// Sets a value for a key
     pub fn set_value_for_key(&mut self, key: &str, value: Value) {
         self.value_map.insert(key.to_owned(), value);
+    }
+
+    /// Get the name for libruby-static (i.e. `ruby.3.1-static`)
+    pub fn libruby_static_name(&self) -> String {
+        self.get("LIBRUBY_A")
+            .strip_prefix("lib")
+            .unwrap()
+            .strip_suffix(".a")
+            .unwrap()
+            .to_string()
+    }
+
+    /// Get the name for libruby (i.e. `ruby.3.1`)
+    pub fn libruby_so_name(&self) -> String {
+        self.get("RUBY_SO_NAME")
     }
 
     /// Instantiates a new `RbConfig` for the current Ruby.

--- a/crates/rb-sys-tests/Cargo.toml
+++ b/crates/rb-sys-tests/Cargo.toml
@@ -3,13 +3,13 @@ name = "rb-sys-tests"
 version = "0.9.9"
 edition = "2018"
 autotests = false
+publish = false
 
 [dependencies]
-rb-sys = { path = "../rb-sys", features = ["link-ruby", "ruby-macros"] } 
+rb-sys = { path = "../rb-sys" } 
 ctor = "0.1"
 
 [features]
-default = ["link-ruby", "ruby-macros"]
 link-ruby = ["rb-sys/link-ruby"]
 ruby-macros = ["rb-sys/ruby-macros"]
 

--- a/crates/rb-sys/Cargo.toml
+++ b/crates/rb-sys/Cargo.toml
@@ -33,12 +33,14 @@ libc = "0.2.126"
 default = ["ruby-macros", "gem"]
 gem = ["ruby-abi-version"]
 link-ruby = []
+no-link-ruby = []
 ruby-macros = ["cc", "shell-words"]
 ruby-static = []
 ruby-abi-version = []
 global-allocator = []
 bindgen-rbimpls = []
 bindgen-deprecated-types = []
+debug-build = []
 
 [lib]
 doctest = false

--- a/crates/rb-sys/build/features.rs
+++ b/crates/rb-sys/build/features.rs
@@ -1,0 +1,77 @@
+use rb_sys_build::RbConfig;
+
+pub fn is_global_allocator_enabled() -> bool {
+    is_env_variable_defined("CARGO_FEATURE_GLOBAL_ALLOCATOR")
+}
+
+pub fn is_ruby_abi_version_enabled() -> bool {
+    is_env_variable_defined("CARGO_FEATURE_RUBY_ABI_VERSION")
+}
+
+pub fn is_ruby_macros_enabled() -> bool {
+    is_env_variable_defined("CARGO_FEATURE_RUBY_MACROS")
+}
+
+pub fn is_gem_enabled() -> bool {
+    is_env_variable_defined("CARGO_FEATURE_GEM")
+}
+
+pub fn is_no_link_ruby_enabled() -> bool {
+    is_env_variable_defined("CARGO_FEATURE_NO_LINK_RUBY")
+}
+
+pub fn is_debug_build_enabled() -> bool {
+    println!("cargo:rerun-if-env-changed=RB_SYS_DEBUG_BUILD");
+
+    is_env_variable_defined("CARGO_FEATURE_DEBUG_BUILD")
+        || is_env_variable_defined("RB_SYS_DEBUG_BUILD")
+}
+
+pub fn is_ruby_static_enabled(rbconfig: &RbConfig) -> bool {
+    println!("cargo:rerun-if-env-changed=RUBY_STATIC");
+
+    match std::env::var("RUBY_STATIC") {
+        Ok(val) => val == "true" || val == "1",
+        _ => {
+            is_env_variable_defined("CARGO_FEATURE_RUBY_STATIC")
+                || rbconfig.get("ENABLE_SHARED") == "no"
+        }
+    }
+}
+
+pub fn is_link_ruby_enabled() -> bool {
+    if is_no_link_ruby_enabled() {
+        false
+    } else if is_gem_enabled() {
+        if cfg!(windows) {
+            true
+        } else if is_env_variable_defined("CARGO_FEATURE_LINK_RUBY") {
+            let msg = "
+                The `gem` and `link-ruby` features are mutually exclusive on this
+                platform, since the libruby symbols will be available at runtime.
+                
+                If you for some reason want to dangerously link libruby for your gem
+                (*not recommended*), you can remove the `gem` feature and add this
+                to your `Cargo.toml`:
+                
+                [dependencies.rb-sys] 
+                features = [\"link-ruby\", \"ruby-abi-version\"] # Living dangerously! 
+            "
+            .split("\n")
+            .map(|line| line.trim())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+            eprintln!("ERROR: {}", msg);
+            std::process::exit(1);
+        } else {
+            false
+        }
+    } else {
+        is_env_variable_defined("CARGO_FEATURE_LINK_RUBY")
+    }
+}
+
+fn is_env_variable_defined(name: &str) -> bool {
+    std::env::var(name).is_ok()
+}


### PR DESCRIPTION
At work, we are running into an issue where Cargo seems to add the `link-ruby` flag without it ever being requested, which should never happen. This happens when using magnus, and it's perplexing as to why it is being added.

These changes should allow us to get around the issue, and make the whole linking process a bit more debuggable and rigid.