### PR TITLE
Rust  1.51 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
           bundle exec rake test:examples
 
   build_and_test_static:
-    name: 🔘 Static 
+    name: 🔘 Static
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,12 +59,12 @@ jobs:
         run: bundle exec rake test:gem
       - name: 💨 Smoke test
         env:
-          PROFILE: "release"
+          RB_SYS_CARGO_PROFILE: "release"
         run: |
           bundle exec rake test:examples
 
   build_and_test_static:
-    name: 🔘 Test static Ruby
+    name: 🔘 Static 
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
         ruby_version: ["2.6", "2.7", "3.0", "3.1", "head"]
         sys:
           - os: ubuntu-latest
+            rust_toolchain: "1.51"
+          - os: ubuntu-latest
             rust_toolchain: stable
           - os: macos-latest
             rust_toolchain: stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         run: bundle exec standardrb --format github
 
   build_and_test:
-    name: 🧪 Build and test
+    name: 🧪 Test
     strategy:
       fail-fast: false
       matrix:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,6 +175,7 @@ dependencies = [
  "cc",
  "linkify",
  "rb-sys-build",
+ "shell-words",
 ]
 
 [[package]]
@@ -182,6 +183,7 @@ name = "rb-sys-build"
 version = "0.9.13"
 dependencies = [
  "regex",
+ "shell-words",
 ]
 
 [[package]]
@@ -221,6 +223,12 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "shlex"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,23 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "autocfg"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
 name = "bindgen"
 version = "0.60.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -37,18 +20,14 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "clap",
- "env_logger",
  "lazy_static",
  "lazycell",
- "log",
  "peeking_take_while",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash",
  "shlex",
- "which",
 ]
 
 [[package]]
@@ -90,30 +69,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap"
-version = "3.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53da17d37dba964b9b3ecb5c5a1f193a2762c700e6829201e645b9381c99dc7"
-dependencies = [
- "atty",
- "bitflags",
- "clap_lex",
- "indexmap",
- "strsim",
- "termcolor",
- "textwrap",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5538cd660450ebeb4234cfecf8f2284b844ffc4c50531e66d584ad5b91293613"
-dependencies = [
- "os_str_bytes",
-]
-
-[[package]]
 name = "ctor"
 version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,60 +79,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "either"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
-
-[[package]]
-name = "env_logger"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
-
-[[package]]
-name = "hashbrown"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
-name = "indexmap"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c6392766afd7964e2531940894cffe4bd8d7d17dbc3c1c4857040fd4b33bdb3"
-dependencies = [
- "autocfg",
- "hashbrown",
-]
 
 [[package]]
 name = "lazy_static"
@@ -217,15 +122,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "log"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -246,12 +142,6 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
-
-[[package]]
-name = "os_str_bytes"
-version = "6.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
 
 [[package]]
 name = "peeking_take_while"
@@ -339,12 +229,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
 name = "syn"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,36 +240,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
-
-[[package]]
-name = "which"
-version = "4.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c4fb54e6113b6a8772ee41c3404fb0301ac79604489467e0a9ce1f3e97c24ae"
-dependencies = [
- "either",
- "lazy_static",
- "libc",
-]
 
 [[package]]
 name = "winapi"
@@ -402,15 +260,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,12 +180,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itoa"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,7 +286,6 @@ dependencies = [
  "libc",
  "linkify",
  "rb-sys-build",
- "regex",
  "shell-words",
 ]
 
@@ -301,7 +294,6 @@ name = "rb-sys-build"
 version = "0.9.13"
 dependencies = [
  "regex",
- "serde_json",
  "shell-words",
 ]
 
@@ -342,29 +334,6 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "ryu"
-version = "1.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
-
-[[package]]
-name = "serde"
-version = "1.0.137"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
-
-[[package]]
-name = "serde_json"
-version = "1.0.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
-dependencies = [
- "itoa",
- "ryu",
- "serde",
-]
 
 [[package]]
 name = "shell-words"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,10 +283,8 @@ version = "0.9.13"
 dependencies = [
  "bindgen",
  "cc",
- "libc",
  "linkify",
  "rb-sys-build",
- "shell-words",
 ]
 
 [[package]]
@@ -294,7 +292,6 @@ name = "rb-sys-build"
 version = "0.9.13"
 dependencies = [
  "regex",
- "shell-words",
 ]
 
 [[package]]
@@ -334,12 +331,6 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "shell-words"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "shlex"

--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ namespace :test do
   desc "Run cargo test against current Ruby"
   task :cargo do
     cargo_args = extra_args || ["--quiet", "--workspace", "--exclude", "rust-reverse"]
-    sh "cargo", "+1.51", "test", *cargo_args
+    sh "cargo", "test", *cargo_args
   end
 
   desc "Test against all installed Rubies"

--- a/Rakefile
+++ b/Rakefile
@@ -8,8 +8,9 @@ end
 namespace :test do
   desc "Run cargo test against current Ruby"
   task :cargo do
-    cargo_args = extra_args || ["--quiet", "--workspace", "--exclude", "rust-reverse"]
-    sh "cargo", "test", *cargo_args
+    rust = ENV["RUST_VERSION"] || "stable"
+    cargo_args = extra_args || ["--workspace", "--exclude", "rust-reverse"]
+    sh "cargo", "+#{rust}", "test", *cargo_args
   end
 
   desc "Test against all installed Rubies"

--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ namespace :test do
   desc "Run cargo test against current Ruby"
   task :cargo do
     cargo_args = extra_args || ["--quiet", "--workspace", "--exclude", "rust-reverse"]
-    sh "cargo", "test", *cargo_args
+    sh "cargo", "+1.51", "test", *cargo_args
   end
 
   desc "Test against all installed Rubies"

--- a/crates/rb-sys-build/Cargo.toml
+++ b/crates/rb-sys-build/Cargo.toml
@@ -10,4 +10,3 @@ repository = "https://github.com/oxidize-rb/rb-sys"
 [dependencies]
 regex = "1" 
 shell-words = "1.1.0"
-serde_json = "1.0"

--- a/crates/rb-sys-build/Cargo.toml
+++ b/crates/rb-sys-build/Cargo.toml
@@ -9,3 +9,4 @@ repository = "https://github.com/oxidize-rb/rb-sys"
 
 [dependencies]
 regex = "1" 
+shell-words = "1.1"

--- a/crates/rb-sys-build/Cargo.toml
+++ b/crates/rb-sys-build/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-edition = "2021"
 name = "rb-sys-build"
 version = "0.9.13"
+edition = "2018"
 description = "Build system for rb-sys"
 homepage = "https://github.com/oxidize-rb/rb-sys"
 license = "MIT OR Apache-2.0"
@@ -9,4 +9,3 @@ repository = "https://github.com/oxidize-rb/rb-sys"
 
 [dependencies]
 regex = "1" 
-shell-words = "1.1.0"

--- a/crates/rb-sys-build/src/rb_config.rs
+++ b/crates/rb-sys-build/src/rb_config.rs
@@ -133,7 +133,12 @@ impl RbConfig {
 
     /// Push cflags string
     pub fn push_cflags(&mut self, cflags: &str) -> &mut Self {
-        for flag in cflags.split_whitespace() {
+        for flag in shell_words::split(cflags).unwrap_or_else(|_| {
+            cflags
+                .split_whitespace()
+                .map(|s| s.to_string())
+                .collect::<Vec<_>>()
+        }) {
             self.cflags.push(flag.to_string());
         }
 

--- a/crates/rb-sys-build/src/rb_config.rs
+++ b/crates/rb-sys-build/src/rb_config.rs
@@ -136,6 +136,7 @@ impl RbConfig {
         for flag in cflags.split_whitespace() {
             self.cflags.push(flag.to_string());
         }
+
         self
     }
 

--- a/crates/rb-sys-build/src/rb_config.rs
+++ b/crates/rb-sys-build/src/rb_config.rs
@@ -133,12 +133,9 @@ impl RbConfig {
 
     /// Push cflags string
     pub fn push_cflags(&mut self, cflags: &str) -> &mut Self {
-        shell_words::split(cflags)
-            .expect("cannot split cflags")
-            .iter()
-            .for_each(|cflag| {
-                self.cflags.push(cflag.to_owned());
-            });
+        for flag in cflags.split_whitespace() {
+            self.cflags.push(flag.to_string());
+        }
         self
     }
 

--- a/crates/rb-sys-tests/Cargo.toml
+++ b/crates/rb-sys-tests/Cargo.toml
@@ -6,10 +6,15 @@ autotests = false
 publish = false
 
 [dependencies]
-rb-sys = { path = "../rb-sys", default-features = false, features = ["link-ruby", "ruby-macros"] } 
+rb-sys = { path = "../rb-sys", default-features = false } 
 ctor = "0.1"
+
+[features]
+link-ruby = ["rb-sys/link-ruby"]
+ruby-macros = ["rb-sys/ruby-macros"]
 
 [[test]]
 name = "rb-sys-tests"
 path = "tests/lib.rs"
 harness = true
+required-features = ["link-ruby", "ruby-macros"]

--- a/crates/rb-sys-tests/Cargo.toml
+++ b/crates/rb-sys-tests/Cargo.toml
@@ -6,7 +6,7 @@ autotests = false
 publish = false
 
 [dependencies]
-rb-sys = { path = "../rb-sys" } 
+rb-sys = { path = "../rb-sys", default-features = false } 
 ctor = "0.1"
 
 [features]

--- a/crates/rb-sys-tests/Cargo.toml
+++ b/crates/rb-sys-tests/Cargo.toml
@@ -6,15 +6,10 @@ autotests = false
 publish = false
 
 [dependencies]
-rb-sys = { path = "../rb-sys", default-features = false } 
+rb-sys = { path = "../rb-sys", default-features = false, features = ["link-ruby", "ruby-macros"] } 
 ctor = "0.1"
-
-[features]
-link-ruby = ["rb-sys/link-ruby"]
-ruby-macros = ["rb-sys/ruby-macros"]
 
 [[test]]
 name = "rb-sys-tests"
 path = "tests/lib.rs"
 harness = true
-required-features = ["link-ruby", "ruby-macros"]

--- a/crates/rb-sys/Cargo.toml
+++ b/crates/rb-sys/Cargo.toml
@@ -13,7 +13,7 @@ links = "rb"
 repository = "https://github.com/oxidize-rb/rb-sys"
 
 [build-dependencies]
-bindgen = "0.60"
+bindgen = { version = "0.60", default-features = false, features = ["runtime"] }
 linkify = "0.8"
 rb-sys-build = { path = "../rb-sys-build", version = "0.9.13" }
 cc = { version = "1.0", optional = true }

--- a/crates/rb-sys/Cargo.toml
+++ b/crates/rb-sys/Cargo.toml
@@ -4,7 +4,7 @@ name = "rb-sys"
 version = "0.9.13"
 edition = "2018"
 readme = "readme.md"
-categories = ["ruby", "external-ffi-bindings"]
+categories = ["external-ffi-bindings"]
 description = "Rust bindings for the CRuby API"
 documentation = "https://docs.rs/rb-sys"
 homepage = "https://github.com/oxidize-rb/rb-sys"
@@ -16,24 +16,14 @@ repository = "https://github.com/oxidize-rb/rb-sys"
 bindgen = "0.60"
 linkify = "0.8"
 rb-sys-build = { path = "../rb-sys-build", version = "0.9.13" }
-
-[build-dependencies.cc]
-optional = true
-version = "1.0"
-
-[build-dependencies.shell-words]
-optional = true
-version = "1.1.0"
-
-[dependencies]
-libc = "0.2.126"
+cc = { version = "1.0", optional = true }
 
 [features]
 default = ["ruby-macros", "gem"]
 gem = ["ruby-abi-version"]
 link-ruby = []
 no-link-ruby = []
-ruby-macros = ["cc", "shell-words"]
+ruby-macros = ["cc"]
 ruby-static = []
 ruby-abi-version = []
 global-allocator = []

--- a/crates/rb-sys/Cargo.toml
+++ b/crates/rb-sys/Cargo.toml
@@ -19,7 +19,6 @@ rb-sys-build = { path = "../rb-sys-build", version = "0.9.13" }
 cc = { version = "1.0", optional = true }
 
 [features]
-default = ["gem"]
 gem = ["ruby-abi-version"]
 link-ruby = []
 no-link-ruby = []

--- a/crates/rb-sys/Cargo.toml
+++ b/crates/rb-sys/Cargo.toml
@@ -19,7 +19,7 @@ rb-sys-build = { path = "../rb-sys-build", version = "0.9.13" }
 cc = { version = "1.0", optional = true }
 
 [features]
-default = ["ruby-macros", "gem"]
+default = ["gem"]
 gem = ["ruby-abi-version"]
 link-ruby = []
 no-link-ruby = []

--- a/crates/rb-sys/Cargo.toml
+++ b/crates/rb-sys/Cargo.toml
@@ -17,12 +17,14 @@ bindgen = { version = "0.60", default-features = false, features = ["runtime"] }
 linkify = "0.8"
 rb-sys-build = { path = "../rb-sys-build", version = "0.9.13" }
 cc = { version = "1.0", optional = true }
+shell-words = { version = "1.1", optional = true }
 
 [features]
+default = []
 gem = ["ruby-abi-version"]
 link-ruby = []
 no-link-ruby = []
-ruby-macros = ["cc"]
+ruby-macros = ["cc", "shell-words"]
 ruby-static = []
 ruby-abi-version = []
 global-allocator = []

--- a/crates/rb-sys/Cargo.toml
+++ b/crates/rb-sys/Cargo.toml
@@ -15,7 +15,6 @@ repository = "https://github.com/oxidize-rb/rb-sys"
 [build-dependencies]
 bindgen = "0.60"
 linkify = "0.8"
-regex = "1"
 rb-sys-build = { path = "../rb-sys-build", version = "0.9.13" }
 
 [build-dependencies.cc]

--- a/crates/rb-sys/build/bindings.rs
+++ b/crates/rb-sys/build/bindings.rs
@@ -79,6 +79,7 @@ fn default_bindgen(clang_args: Vec<String>) -> bindgen::Builder {
     bindgen::Builder::default()
         .use_core()
         .rustified_enum("*")
+        .no_copy("rb_data_type_struct")
         .derive_eq(true)
         .derive_debug(true)
         .clang_args(clang_args)

--- a/crates/rb-sys/build/features.rs
+++ b/crates/rb-sys/build/features.rs
@@ -9,7 +9,7 @@ pub fn is_ruby_abi_version_enabled() -> bool {
 }
 
 pub fn is_ruby_macros_enabled() -> bool {
-    is_env_variable_defined("CARGO_FEATURE_RUBY_MACROS")
+    !is_linting() && is_env_variable_defined("CARGO_FEATURE_RUBY_MACROS")
 }
 
 pub fn is_gem_enabled() -> bool {
@@ -21,6 +21,10 @@ pub fn is_no_link_ruby_enabled() -> bool {
 }
 
 pub fn is_debug_build_enabled() -> bool {
+    if is_linting() {
+        return false;
+    }
+
     println!("cargo:rerun-if-env-changed=RB_SYS_DEBUG_BUILD");
 
     is_env_variable_defined("CARGO_FEATURE_DEBUG_BUILD")

--- a/crates/rb-sys/build/features.rs
+++ b/crates/rb-sys/build/features.rs
@@ -9,7 +9,7 @@ pub fn is_ruby_abi_version_enabled() -> bool {
 }
 
 pub fn is_ruby_macros_enabled() -> bool {
-    !is_linting() && is_env_variable_defined("CARGO_FEATURE_RUBY_MACROS")
+    !is_linting() && is_env_variable_defined("CARGO_FEATURE_RUBY_MACROS") && !cfg!(windows)
 }
 
 pub fn is_gem_enabled() -> bool {

--- a/crates/rb-sys/build/features.rs
+++ b/crates/rb-sys/build/features.rs
@@ -40,12 +40,18 @@ pub fn is_ruby_static_enabled(rbconfig: &RbConfig) -> bool {
 }
 
 pub fn is_link_ruby_enabled() -> bool {
-    if is_no_link_ruby_enabled() {
+    if is_linting() {
+        return false;
+    } else if is_no_link_ruby_enabled() {
         false
     } else if is_gem_enabled() {
         if cfg!(windows) {
             true
         } else if is_env_variable_defined("CARGO_FEATURE_LINK_RUBY") {
+            // print all env vars
+            for (key, value) in std::env::vars() {
+                println!("{}={}", key, value);
+            }
             let msg = "
                 The `gem` and `link-ruby` features are mutually exclusive on this
                 platform, since the libruby symbols will be available at runtime.
@@ -57,7 +63,7 @@ pub fn is_link_ruby_enabled() -> bool {
                 [dependencies.rb-sys] 
                 features = [\"link-ruby\", \"ruby-abi-version\"] # Living dangerously! 
             "
-            .split("\n")
+            .split('\n')
             .map(|line| line.trim())
             .collect::<Vec<_>>()
             .join("\n");
@@ -74,4 +80,18 @@ pub fn is_link_ruby_enabled() -> bool {
 
 fn is_env_variable_defined(name: &str) -> bool {
     std::env::var(name).is_ok()
+}
+
+fn is_linting() -> bool {
+    let clippy = match std::env::var_os("CARGO_CFG_FEATURE") {
+        Some(val) => val.to_str().unwrap_or("").contains("clippy"),
+        _ => false,
+    };
+
+    let rust_analyzer = match std::env::var_os("RUSTC_WRAPPER") {
+        Some(val) => val.to_str().unwrap_or("").contains("rust-analyzer"),
+        _ => false,
+    };
+
+    clippy || rust_analyzer
 }

--- a/crates/rb-sys/build/main.rs
+++ b/crates/rb-sys/build/main.rs
@@ -109,32 +109,34 @@ fn export_cargo_cfg(rbconfig: &mut RbConfig) {
 
     let version = Version::current(rbconfig);
 
-    for v in SUPPORTED_RUBY_VERSIONS {
-        if version < v {
+    for v in SUPPORTED_RUBY_VERSIONS.iter() {
+        let v = v.to_owned();
+
+        if &version < v {
             println!(r#"cargo:lt_{}_{}=true"#, v.major(), v.minor());
         } else {
             println!(r#"cargo:lt_{}_{}=false"#, v.major(), v.minor());
         }
 
-        if version <= v {
+        if &version <= v {
             println!(r#"cargo:lte_{}_{}=true"#, v.major(), v.minor());
         } else {
             println!(r#"cargo:lte_{}_{}=false"#, v.major(), v.minor());
         }
 
-        if version == v {
+        if &version == v {
             println!(r#"cargo:eq_{}_{}=true"#, v.major(), v.minor());
         } else {
             println!(r#"cargo:eq_{}_{}=false"#, v.major(), v.minor());
         }
 
-        if version >= v {
+        if &version >= v {
             println!(r#"cargo:gte_{}_{}=true"#, v.major(), v.minor());
         } else {
             println!(r#"cargo:gte_{}_{}=false"#, v.major(), v.minor());
         }
 
-        if version > v {
+        if &version > v {
             println!(r#"cargo:gt_{}_{}=true"#, v.major(), v.minor());
         } else {
             println!(r#"cargo:gt_{}_{}=false"#, v.major(), v.minor());

--- a/crates/rb-sys/build/ruby_macros.rs
+++ b/crates/rb-sys/build/ruby_macros.rs
@@ -13,6 +13,8 @@ fn shellsplit(s: &str) -> Vec<String> {
 
 #[cfg(feature = "ruby-macros")]
 pub fn compile(rbconfig: &mut RbConfig) {
+    use std::path::Path;
+
     println!("cargo:rerun-if-changed=src/ruby_macros/ruby_macros.h");
     println!("cargo:rerun-if-changed=src/ruby_macros/ruby_macros.c");
 
@@ -32,7 +34,8 @@ pub fn compile(rbconfig: &mut RbConfig) {
         build.flag(&lib);
     }
 
-    build.file("src/macros/ruby_macros.c");
+    let path = Path::new("src").join("macros").join("ruby_macros.c");
+    build.file(path);
     build.include(format!("{}/include/internal", rbconfig.get("rubyhdrdir")));
     build.include(format!("{}/include/impl", rbconfig.get("rubyhdrdir")));
     build.include(rbconfig.get("rubyhdrdir"));

--- a/crates/rb-sys/build/ruby_macros.rs
+++ b/crates/rb-sys/build/ruby_macros.rs
@@ -15,8 +15,8 @@ fn shellsplit(s: &str) -> Vec<String> {
 pub fn compile(rbconfig: &mut RbConfig) {
     use std::path::Path;
 
-    println!("cargo:rerun-if-changed=src/ruby_macros/ruby_macros.h");
-    println!("cargo:rerun-if-changed=src/ruby_macros/ruby_macros.c");
+    println!("cargo:rerun-if-changed=src/macros/ruby_macros.h");
+    println!("cargo:rerun-if-changed=src/macros/ruby_macros.c");
 
     let mut build = cc::Build::new();
     let mut cc_args = shellsplit(&rbconfig.get("CC"));

--- a/crates/rb-sys/build/ruby_macros.rs
+++ b/crates/rb-sys/build/ruby_macros.rs
@@ -1,5 +1,6 @@
 use rb_sys_build::RbConfig;
 
+#[cfg(feature = "ruby-macros")]
 fn shellsplit(s: &str) -> Vec<String> {
     s.split_whitespace().map(|s| s.to_owned()).collect()
 }
@@ -41,4 +42,4 @@ pub fn compile(rbconfig: &mut RbConfig) {
 }
 
 #[cfg(not(feature = "ruby-macros"))]
-fn compile(_rbconfig: &mut RbConfig) {}
+pub fn compile(_rbconfig: &mut RbConfig) {}

--- a/crates/rb-sys/build/ruby_macros.rs
+++ b/crates/rb-sys/build/ruby_macros.rs
@@ -2,7 +2,13 @@ use rb_sys_build::RbConfig;
 
 #[cfg(feature = "ruby-macros")]
 fn shellsplit(s: &str) -> Vec<String> {
-    s.split_whitespace().map(|s| s.to_owned()).collect()
+    match shell_words::split(s) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("shellsplit failed: {}", e);
+            s.split_whitespace().map(|s| s.to_string()).collect()
+        }
+    }
 }
 
 #[cfg(feature = "ruby-macros")]
@@ -32,7 +38,7 @@ pub fn compile(rbconfig: &mut RbConfig) {
     build.include(rbconfig.get("rubyhdrdir"));
     build.include(rbconfig.get("rubyarchhdrdir"));
     build.flag("-fms-extensions");
-    build.flag("-Wunused-parameter");
+    build.flag("-Wno-error"); // not actionable by user
 
     for flag in &rbconfig.cflags {
         build.flag(flag);

--- a/crates/rb-sys/build/ruby_macros.rs
+++ b/crates/rb-sys/build/ruby_macros.rs
@@ -1,0 +1,44 @@
+use rb_sys_build::RbConfig;
+
+fn shellsplit(s: &str) -> Vec<String> {
+    s.split_whitespace().map(|s| s.to_owned()).collect()
+}
+
+#[cfg(feature = "ruby-macros")]
+pub fn compile(rbconfig: &mut RbConfig) {
+    println!("cargo:rerun-if-changed=src/ruby_macros/ruby_macros.h");
+    println!("cargo:rerun-if-changed=src/ruby_macros/ruby_macros.c");
+
+    let mut build = cc::Build::new();
+    let mut cc_args = shellsplit(&rbconfig.get("CC"));
+    let libs = shellsplit(&rbconfig.get("LIBS"));
+
+    cc_args.reverse();
+    build.compiler(cc_args.pop().expect("CC is empty"));
+    cc_args.reverse();
+
+    for arg in cc_args {
+        build.flag(&arg);
+    }
+
+    for lib in libs {
+        build.flag(&lib);
+    }
+
+    build.file("src/macros/ruby_macros.c");
+    build.include(format!("{}/include/internal", rbconfig.get("rubyhdrdir")));
+    build.include(format!("{}/include/impl", rbconfig.get("rubyhdrdir")));
+    build.include(rbconfig.get("rubyhdrdir"));
+    build.include(rbconfig.get("rubyarchhdrdir"));
+    build.flag("-fms-extensions");
+    build.flag("-Wunused-parameter");
+
+    for flag in &rbconfig.cflags {
+        build.flag(flag);
+    }
+
+    build.compile("ruby_macros");
+}
+
+#[cfg(not(feature = "ruby-macros"))]
+fn compile(_rbconfig: &mut RbConfig) {}

--- a/crates/rb-sys/readme.md
+++ b/crates/rb-sys/readme.md
@@ -14,31 +14,36 @@ If you actually _need_ raw/unsafe bindings to libruby, the this crate if for you
 
 ## Usage
 
-1. Add the following to your `Cargo.toml`:
+### Writing a Ruby gem
 
-   ```toml
-   [dependencies]
-   rb-sys = "0.9"
-   ```
+Ruby gems require a bit of boilerplate to be defined to be usable from Ruby. `rb-sys` makes this process painless by
+doing the work for you, by simply enabling the `gem` feature.
 
-2. [See this example of creating a Ruby gem in Rust](./examples/rust_reverse)
+```toml
+rb-sys = { version = "0.9",  features = ["gem"] }
+```
 
-### Linking libruby
+Under the hood this ensures we do not link libruby (unless on Windows), and defines a `ruby_abi_version` function for
+Ruby 3.2+.
+
+[See this example of creating a Ruby gem in Rust](./examples/rust_reverse)
+
+### Embedding libruby in your Rust app
+
+_IMPORTANT_: If you are authoring a Ruby gem, you do not need to enable this feature.
 
 If you need to link libruby (i.e. you are initializing a Ruby VM in your Rust code), use can enable the `link-ruby`
 feature:
 
-```rust
+```toml
 rb-sys = { version = "0.9",  features = ["link-ruby"] }
 ```
-
-If you are authoring a Ruby gem, you do not need to enable this feature.
 
 ### Static libruby
 
 You can also force static linking of libruby:
 
-```rust
+```toml
 rb-sys = { version = "0.9", features = ["ruby-static"] }
 ```
 
@@ -58,9 +63,9 @@ rb-sys = { version = "0.9",  features = ["ruby-macros"] }
 
 ### Other features
 
-- `gem`: Setup boilerplate for a Ruby gem (enabled by default).
-- `ruby-abi-version`: Set the Ruby ABI version. (enabled by default).
-- `ruby-macros`: Generate Rust functions for Ruby macros like `RSTRING_PTR` (enabled by default).
+- `gem`: Setup boilerplate for a Ruby gem.
+- `ruby-abi-version`: Set the Ruby ABI version.
+- `ruby-macros`: Generate Rust functions for Ruby macros like `RSTRING_PTR`.
 - `global-allocator`: Report Rust memory allocations to the Ruby GC (_recommended_).
 - `ruby-static`: Link the static version of libruby.
 - `link-ruby`: Link libruby.

--- a/crates/rb-sys/readme.md
+++ b/crates/rb-sys/readme.md
@@ -44,6 +44,18 @@ rb-sys = { version = "0.9", features = ["ruby-static"] }
 
 Alternatively, you can set the `RUBY_STATIC=true` environment variable.
 
+## Ruby Macros
+
+The `rb-sys` crates comes with an optional [`ruby-macros` feature](./crates/rb-sys/src/macros/mod.rs). This feature
+compiles a small bit of C code to give access to some commonly used C macros in Ruby.
+
+```toml
+# Cargo.toml
+
+[dependencies]
+rb-sys = { version = "0.9",  features = ["ruby-macros"] }
+```
+
 ### Other features
 
 - `gem`: Setup boilerplate for a Ruby gem (enabled by default).

--- a/crates/rb-sys/src/bindings.rs
+++ b/crates/rb-sys/src/bindings.rs
@@ -9,4 +9,5 @@
 #![allow(deref_nullptr)]
 #![warn(unknown_lints)]
 #![allow(unaligned_references)]
+#![allow(clippy::all)]
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/examples/rust_reverse/ext/rust_reverse/Cargo.toml
+++ b/examples/rust_reverse/ext/rust_reverse/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rust-reverse"
 version = "0.9.13"
 autotests = false # set true if you want to use "cargo test"
-edition = "2021"
+edition = "2018"
 
 [dependencies]
 rb-sys = { path = "./../../../../crates/rb-sys", features = ["global-allocator"] }

--- a/examples/rust_reverse/ext/rust_reverse/Cargo.toml
+++ b/examples/rust_reverse/ext/rust_reverse/Cargo.toml
@@ -5,7 +5,7 @@ autotests = false # set true if you want to use "cargo test"
 edition = "2018"
 
 [dependencies]
-rb-sys = { path = "./../../../../crates/rb-sys", features = ["global-allocator"] }
+rb-sys = { path = "./../../../../crates/rb-sys", features = ["gem", "global-allocator"] }
 
 [lib]
 crate-type = ["cdylib"]

--- a/gem/lib/rb_sys/mkmf.rb
+++ b/gem/lib/rb_sys/mkmf.rb
@@ -58,6 +58,12 @@ module RbSys
           RB_SYS_TARGET_DIR ?= $(RB_SYS_CARGO_PROFILE)
         endif
 
+        ifeq ($(RB_SYS_CARGO_PROFILE),release)
+          RB_SYS_CARGO_PROFILE_FLAG = --release
+        else
+          RB_SYS_CARGO_PROFILE_FLAG = --profile $(RB_SYS_CARGO_PROFILE)
+        endif
+
         target_prefix = #{target_prefix}
         TARGET_NAME = #{target[/\A\w+/]}
         TARGET_ENTRY = #{RbConfig::CONFIG["EXPORT_PREFIX"]}Init_$(TARGET_NAME)
@@ -141,7 +147,7 @@ module RbSys
     end
 
     def gsub_cargo_command!(cargo_command, builder:)
-      cargo_command.gsub!("--profile #{builder.profile}", "--profile $(RB_SYS_CARGO_PROFILE)")
+      cargo_command.gsub!(/--profile \w+/, "$(RB_SYS_CARGO_PROFILE_FLAG)")
       cargo_command.gsub!(%r{--features \S+}, "--features $(RB_SYS_CARGO_FEATURES)")
       cargo_command.gsub!(%r{/target/\w+/}, "/target/$(RB_SYS_TARGET_DIR)/")
       cargo_command


### PR DESCRIPTION
This PR adds official support for Rust 1.51, so users can use Rust installed from more OS package managers. It also removes some deps for lightweight compilation.