### PR TITLE
Test against ruby 2.4+ for rubygems

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -46,10 +46,5 @@ runs:
       if: ${{ contains(inputs.os, 'windows') }}
       shell: bash
       run: |
-        if [ -n "$MINGW_PACKAGE_PREFIX" ]; then
-          pacman --remove --cascade --noconfirm mingw-w64-x86_64-clang
-          pacman --sync --noconfirm --needed $MINGW_PACKAGE_PREFIX-clang 
-        else
-          pacman --remove --cascade --noconfirm mingw-w64-x86_64-clang
-          pacman --sync --noconfirm --needed mingw-w64-x86_64-gnu
-        fi
+        pacman --remove --cascade --noconfirm mingw-w64-x86_64-clang
+        pacman --sync --noconfirm --needed $MINGW_PACKAGE_PREFIX-clang

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -43,8 +43,10 @@ runs:
         toolchain: ${{ inputs.rust_toolchain }}
         default: true
     - name: Fix clang dep for rust-bindgen (see https://github.com/rubygems/rubygems/pull/5175#discussion_r794873977)
-      if: ${{ inputs.os == 'windows-2019' }}
+      if: ${{ contains(inputs.os, 'windows') }}
       shell: bash
       run: |
-        pacman --remove --cascade --noconfirm mingw-w64-x86_64-clang
-        pacman --sync --noconfirm --needed $MINGW_PACKAGE_PREFIX-clang || true
+        if [[ -z $MINGW_PACKAGE_PREFIX ]]; then
+          pacman --remove --cascade --noconfirm mingw-w64-x86_64-clang
+          pacman --sync --noconfirm --needed $MINGW_PACKAGE_PREFIX-clang 
+        fi

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -46,7 +46,7 @@ runs:
       if: ${{ contains(inputs.os, 'windows') }}
       shell: bash
       run: |
-        if [[ -z $MINGW_PACKAGE_PREFIX ]]; then
+        if [ -n "$MINGW_PACKAGE_PREFIX" ]; then
           pacman --remove --cascade --noconfirm mingw-w64-x86_64-clang
           pacman --sync --noconfirm --needed $MINGW_PACKAGE_PREFIX-clang 
         fi

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -42,9 +42,9 @@ runs:
       with:
         toolchain: ${{ inputs.rust_toolchain }}
         default: true
-    - name: Fix clang dep for rust-bindgen (see https://github.com/rubygems/rubygems/pull/5175#discussion_r794873977)
-      if: ${{ contains(inputs.os, 'windows') }}
-      shell: bash
-      run: |
-        pacman --remove --cascade --noconfirm mingw-w64-x86_64-clang
-        pacman --sync --noconfirm --needed $MINGW_PACKAGE_PREFIX-clang
+    # - name: Fix clang dep for rust-bindgen (see https://github.com/rubygems/rubygems/pull/5175#discussion_r794873977)
+    #   if: ${{ contains(inputs.os, 'windows') }}
+    #   shell: bash
+    #   run: |
+    #     pacman --remove --cascade --noconfirm mingw-w64-x86_64-clang
+    #     pacman --sync --noconfirm --needed $MINGW_PACKAGE_PREFIX-clang

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -49,4 +49,7 @@ runs:
         if [ -n "$MINGW_PACKAGE_PREFIX" ]; then
           pacman --remove --cascade --noconfirm mingw-w64-x86_64-clang
           pacman --sync --noconfirm --needed $MINGW_PACKAGE_PREFIX-clang 
+        else
+          pacman --remove --cascade --noconfirm mingw-w64-x86_64-clang
+          pacman --sync --noconfirm --needed mingw-w64-x86_64-clang
         fi

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -42,9 +42,8 @@ runs:
       with:
         toolchain: ${{ inputs.rust_toolchain }}
         default: true
-    # - name: Fix clang dep for rust-bindgen (see https://github.com/rubygems/rubygems/pull/5175#discussion_r794873977)
-    #   if: ${{ contains(inputs.os, 'windows') }}
-    #   shell: bash
-    #   run: |
-    #     pacman --remove --cascade --noconfirm mingw-w64-x86_64-clang
-    #     pacman --sync --noconfirm --needed $MINGW_PACKAGE_PREFIX-clang
+    - name: Fix clang dep for rust-bindgen (see https://github.com/rubygems/rubygems/pull/5175#discussion_r794873977)
+      if: ${{ contains(inputs.os, 'windows') }}
+      shell: bash
+      run: |
+        pacman --sync --noconfirm --needed $MINGW_PACKAGE_PREFIX-clang

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -51,5 +51,5 @@ runs:
           pacman --sync --noconfirm --needed $MINGW_PACKAGE_PREFIX-clang 
         else
           pacman --remove --cascade --noconfirm mingw-w64-x86_64-clang
-          pacman --sync --noconfirm --needed mingw-w64-x86_64-clang
+          pacman --sync --noconfirm --needed mingw-w64-x86_64-gnu
         fi

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -47,4 +47,4 @@ runs:
       shell: bash
       run: |
         pacman --remove --cascade --noconfirm mingw-w64-x86_64-clang
-        pacman --sync --noconfirm --needed $MINGW_PACKAGE_PREFIX-clang
+        pacman --sync --noconfirm --needed $MINGW_PACKAGE_PREFIX-clang || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,9 @@ jobs:
             rust_toolchain: stable
           - os: macos-latest
             rust_toolchain: stable
-          - os: windows-2019
+          # - os: windows-2019
+          #   rust_toolchain: stable-x86_64-pc-windows-gnu
+          - os: windows-2022
             rust_toolchain: stable-x86_64-pc-windows-gnu
     runs-on: ${{ matrix.sys.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,10 @@ jobs:
     runs-on: ${{ matrix.sys.os }}
     steps:
       - uses: actions/checkout@v3
+      - name: Setup env
+        run: |
+          echo "PATH=/opt/rubies/${{ matrix.ruby_version }}/bin:$PATH" >> $GITHUB_ENV
+          echo "GEM_HOME=~/.gem/ruby/${{ matrix.ruby_version }}" >> $GITHUB_ENV
       - name: ⚡ Cache
         uses: actions/cache@v3
         with:
@@ -83,10 +87,6 @@ jobs:
             /opt/rubies/${{ matrix.ruby_version }}
             ~/.gem/ruby/${{ matrix.ruby_version }}
           key: ${{ matrix.sys.os }}-${{ matrix.ruby_version }}
-      - name: Setup env
-        run: |
-          echo "PATH=/opt/rubies/${{ matrix.ruby_version }}/bin:$PATH" >> $GITHUB_ENV
-          echo "GEM_HOME=~/.gem/ruby/${{ matrix.ruby_version }}" >> $GITHUB_ENV
       - name: 🔘 Build static ruby
         working-directory: /tmp
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,14 +92,14 @@ jobs:
       - name: 🔘 Build static ruby
         working-directory: /tmp
         run: |
-          if [ ! -d /opt/rubies/${{matrix.ruby_version }}]; then
+          if [ -d /opt/rubies/${{matrix.ruby_version }} ]; then
+            echo "Ruby ${{ matrix.ruby_version }} already installed, skipping build"
+          else
             git clone https://github.com/rbenv/ruby-build.git
             PREFIX=/usr/local sudo ./ruby-build/install.sh
             export MAKEFLAGS="-j$(nproc)"
             export RUBY_CONFIGURE_OPTS="--disable-shared --disable-install-doc --disable-install-rdoc" 
             sudo ruby-build ${{ matrix.ruby_version }} /opt/rubies/${{ matrix.ruby_version }}
-          else
-            echo "Ruby ${{ matrix.ruby_version }} already installed, skipping build"
           fi
       - uses: ./.github/actions/setup
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby_version: ["2.6", "2.7", "3.0", "3.1", "head"]
+        # Test against all versions supported by rubygems
+        ruby_version: ["2.3", "2.4", "2.5", "2.6", "2.7", "3.0", "3.1", "head"]
         sys:
           - os: ubuntu-latest
             rust_toolchain: "1.51"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         # Test against all versions supported by rubygems
-        ruby_version: ["2.3", "2.4", "2.5", "2.6", "2.7", "3.0", "3.1", "head"]
+        ruby_version: ["2.4", "2.5", "2.6", "2.7", "3.0", "3.1", "head"]
         sys:
           - os: ubuntu-latest
             rust_toolchain: "1.51"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,11 +92,15 @@ jobs:
       - name: 🔘 Build static ruby
         working-directory: /tmp
         run: |
-          git clone https://github.com/rbenv/ruby-build.git
-          PREFIX=/usr/local sudo ./ruby-build/install.sh
-          export MAKEFLAGS="-j$(nproc)"
-          export RUBY_CONFIGURE_OPTS="--disable-shared --disable-install-doc --disable-install-rdoc" 
-          sudo ruby-build ${{ matrix.ruby_version }} /opt/rubies/${{ matrix.ruby_version }}
+          if [ ! -d /opt/rubies/${{matrix.ruby_version }}]; then
+            git clone https://github.com/rbenv/ruby-build.git
+            PREFIX=/usr/local sudo ./ruby-build/install.sh
+            export MAKEFLAGS="-j$(nproc)"
+            export RUBY_CONFIGURE_OPTS="--disable-shared --disable-install-doc --disable-install-rdoc" 
+            sudo ruby-build ${{ matrix.ruby_version }} /opt/rubies/${{ matrix.ruby_version }}
+          else
+            echo "Ruby ${{ matrix.ruby_version }} already installed, skipping build"
+          fi
       - uses: ./.github/actions/setup
         with:
           rust_toolchain: ${{ matrix.sys.rust_toolchain }}

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,8 @@
 require: standard
 
 inherit_gem:
-  standard: config/base.yml
+  standard: config/ruby-2.3.yml
+
+AllCops:
+  Exclude:
+    - examples/rust_reverse/tmp/

--- a/.standard.yml
+++ b/.standard.yml
@@ -1,6 +1,6 @@
 # For available configuration options, see:
 #   https://github.com/testdouble/standard
-ruby_version: 2.4
+ruby_version: 2.3
 ignore:
   - "examples/rust_reverse/tmp/**/*"
   - "gem/vendor/**/*"

--- a/.standard.yml
+++ b/.standard.yml
@@ -1,6 +1,6 @@
 # For available configuration options, see:
 #   https://github.com/testdouble/standard
+---
 ruby_version: 2.3
 ignore:
   - "examples/rust_reverse/tmp/**/*"
-  - "gem/vendor/**/*"

--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,10 @@
 
 source "https://rubygems.org"
 
+gemspec path: "gem"
 gemspec path: "examples/rust_reverse"
 
 gem "rake", "~> 13.0"
-gem "minitest", "~> 5.0"
-gem "standard", "~> 1.3"
-gem "rake-compiler"
+gem "minitest", "~> 5.16.2"
+gem "standard", "~> 1.12.1" if RUBY_VERSION >= "2.6.0"
+gem "rake-compiler", "~> 1.2.0"

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,6 @@ gemspec path: "gem"
 gemspec path: "examples/rust_reverse"
 
 gem "rake", "~> 13.0"
-gem "minitest", "~> 5.16.2"
+gem "minitest", "~> 5.15.0"
 gem "standard", "~> 1.12.1" if RUBY_VERSION >= "2.6.0"
 gem "rake-compiler", "~> 1.2.0"

--- a/Rakefile
+++ b/Rakefile
@@ -57,7 +57,7 @@ task test: ["test:cargo", "test:gem", "test:examples"]
 desc "Pretty the files"
 task :fmt do
   sh "cargo fmt"
-  sh "standardrb --fix"
+  sh "bundle exec standardrb --fix" if RUBY_VERSION >= "2.6.0"
   sh "npx prettier --write $(git ls-files '*.yml')"
   md_files = `git ls-files '*.md'`.split("\n").select { |f| File.exist?(f) }
   sh "npx", "prettier", "--write", "--print-width=120", "--prose-wrap=always", *md_files
@@ -66,7 +66,7 @@ task format: [:fmt]
 
 desc "Lint"
 task :lint do
-  sh "bundle exec standardrb --format #{ENV.key?("CI") ? "github" : "progress"}"
+  sh "bundle exec standardrb --format #{ENV.key?("CI") ? "github" : "progress"}" if RUBY_VERSION >= "2.6.0"
   sh "cargo fmt --check"
   sh "cargo clippy"
   sh "shellcheck $(git ls-files '*.sh')"

--- a/Rakefile
+++ b/Rakefile
@@ -8,15 +8,17 @@ end
 namespace :test do
   desc "Run cargo test against current Ruby"
   task :cargo do
-    cargo_args = extra_args || ["--workspace"]
-    sh "cargo", "test", *cargo_args
-  rescue
-    if ENV["CI"]
-      ENV["RB_SYS_DEBUG_BUILD"] = "1"
+    begin
+      cargo_args = extra_args || ["--workspace"]
       sh "cargo", "test", *cargo_args
-    end
+    rescue
+      if ENV["CI"]
+        ENV["RB_SYS_DEBUG_BUILD"] = "1"
+        sh "cargo", "test", *cargo_args
+      end
 
-    raise
+      raise
+    end
   end
 
   desc "Test against all installed Rubies"

--- a/crates/rb-sys-build/src/rb_config.rs
+++ b/crates/rb-sys-build/src/rb_config.rs
@@ -660,7 +660,7 @@ fn append_ld_library_path(search_paths: Vec<&str>) {
         Some(val) => {
             format!("{}:{}", val.to_str().unwrap(), search_paths.join(":"))
         }
-        None => search_paths.join(":").to_string(),
+        None => search_paths.join(":"),
     };
 
     println!("cargo:rustc-env={}={}", env_var_name, new_path);

--- a/crates/rb-sys-build/src/rb_config.rs
+++ b/crates/rb-sys-build/src/rb_config.rs
@@ -152,6 +152,12 @@ impl RbConfig {
         self
     }
 
+    pub fn major_minor(&self) -> (u32, u32) {
+        let major = self.get("MAJOR").parse::<u32>().unwrap();
+        let minor = self.get("MINOR").parse::<u32>().unwrap();
+        (major, minor)
+    }
+
     /// Get the rb_config output for cargo
     pub fn cargo_args(&self) -> Vec<String> {
         let mut result = vec![];

--- a/crates/rb-sys/build/features.rs
+++ b/crates/rb-sys/build/features.rs
@@ -1,7 +1,21 @@
 use rb_sys_build::RbConfig;
 
-pub fn is_global_allocator_enabled() -> bool {
-    is_env_variable_defined("CARGO_FEATURE_GLOBAL_ALLOCATOR")
+use crate::version::Version;
+
+pub fn is_global_allocator_enabled(rb_config: &RbConfig) -> bool {
+    let (major, minor) = rb_config.major_minor();
+    let current_version = Version::new(major, minor);
+    let two_four = Version::new(2, 4);
+    let is_enabled = is_env_variable_defined("CARGO_FEATURE_GLOBAL_ALLOCATOR");
+
+    if current_version >= two_four {
+        is_enabled
+    } else {
+        if is_enabled {
+            eprintln!("WARN: The global allocator feature is only supported on Ruby 2.4+.");
+        }
+        false
+    }
 }
 
 pub fn is_ruby_abi_version_enabled() -> bool {

--- a/crates/rb-sys/build/main.rs
+++ b/crates/rb-sys/build/main.rs
@@ -10,7 +10,11 @@ use rb_sys_build::RbConfig;
 use std::fs;
 use version::Version;
 
-const SUPPORTED_RUBY_VERSIONS: [Version; 4] = [
+const SUPPORTED_RUBY_VERSIONS: [Version; 8] = [
+    Version::new(2, 3),
+    Version::new(2, 4),
+    Version::new(2, 5),
+    Version::new(2, 6),
     Version::new(2, 7),
     Version::new(3, 0),
     Version::new(3, 1),

--- a/crates/rb-sys/build/main.rs
+++ b/crates/rb-sys/build/main.rs
@@ -109,7 +109,7 @@ fn export_cargo_cfg(rbconfig: &mut RbConfig) {
         println!("cargo:rustc-cfg=has_ruby_abi_version");
     }
 
-    if is_global_allocator_enabled() {
+    if is_global_allocator_enabled(&rbconfig) {
         println!("cargo:rustc-cfg=use_global_allocator");
     }
 
@@ -123,30 +123,35 @@ fn export_cargo_cfg(rbconfig: &mut RbConfig) {
         let v = v.to_owned();
 
         if &version < v {
+            println!(r#"cargo:rustc-cfg=ruby_lt_{}_{}"#, v.major(), v.minor());
             println!(r#"cargo:version_lt_{}_{}=true"#, v.major(), v.minor());
         } else {
             println!(r#"cargo:version_lt_{}_{}=false"#, v.major(), v.minor());
         }
 
         if &version <= v {
+            println!(r#"cargo:rustc-cfg=ruby_lte_{}_{}"#, v.major(), v.minor());
             println!(r#"cargo:version_lte_{}_{}=true"#, v.major(), v.minor());
         } else {
             println!(r#"cargo:version_lte_{}_{}=false"#, v.major(), v.minor());
         }
 
         if &version == v {
+            println!(r#"cargo:rustc-cfg=ruby_eq_{}_{}"#, v.major(), v.minor());
             println!(r#"cargo:version_eq_{}_{}=true"#, v.major(), v.minor());
         } else {
             println!(r#"cargo:version_eq_{}_{}=false"#, v.major(), v.minor());
         }
 
         if &version >= v {
+            println!(r#"cargo:rustc-cfg=ruby_gte_{}_{}"#, v.major(), v.minor());
             println!(r#"cargo:version_gte_{}_{}=true"#, v.major(), v.minor());
         } else {
             println!(r#"cargo:version_gte_{}_{}=false"#, v.major(), v.minor());
         }
 
         if &version > v {
+            println!(r#"cargo:rustc-cfg=ruby_gt_{}_{}"#, v.major(), v.minor());
             println!(r#"cargo:version_gt_{}_{}=true"#, v.major(), v.minor());
         } else {
             println!(r#"cargo:version_gt_{}_{}=false"#, v.major(), v.minor());

--- a/crates/rb-sys/build/version.rs
+++ b/crates/rb-sys/build/version.rs
@@ -1,6 +1,6 @@
 use crate::RbConfig;
 
-#[derive(Debug, PartialEq, PartialOrd)]
+#[derive(Debug, PartialEq, Eq, PartialOrd)]
 pub struct Version(u32, u32);
 
 impl Version {

--- a/crates/rb-sys/src/macros/ruby_macros.c
+++ b/crates/rb-sys/src/macros/ruby_macros.c
@@ -1,62 +1,77 @@
 #include "ruby.h"
 #include "stdbool.h"
 
-bool
-ruby_macros_RB_TYPE_P(VALUE obj, enum ruby_value_type t) {
+#ifndef RB_INTEGER_TYPE_P
+#define RB_INTEGER_TYPE_P(c) (FIXNUM_P(c) || RB_TYPE_P(c, T_BIGNUM))
+#endif
+
+#ifndef RB_NIL_P
+#define RB_NIL_P(c) NIL_P(c)
+#endif
+
+#ifndef RB_TEST
+#define RB_TEST(c) RTEST(c)
+#endif
+
+bool ruby_macros_RB_TYPE_P(VALUE obj, enum ruby_value_type t)
+{
   return RB_TYPE_P(obj, (int)t);
 };
 
-bool
-ruby_macros_RB_INTEGER_TYPE_P(VALUE obj) {
+bool ruby_macros_RB_INTEGER_TYPE_P(VALUE obj)
+{
   return RB_INTEGER_TYPE_P(obj);
 }
 
-bool
-ruby_macros_SYMBOL_P(VALUE obj) {
+bool ruby_macros_SYMBOL_P(VALUE obj)
+{
   return SYMBOL_P(obj);
 }
 
-bool
-ruby_macros_RB_FLOAT_TYPE_P(VALUE obj) {
+bool ruby_macros_RB_FLOAT_TYPE_P(VALUE obj)
+{
   return RB_FLOAT_TYPE_P(obj);
 }
 
-bool
-ruby_macros_NIL_P(VALUE obj) {
+bool ruby_macros_NIL_P(VALUE obj)
+{
   return RB_NIL_P(obj);
 }
 
-bool
-ruby_macros_RB_TEST(VALUE obj) {
+bool ruby_macros_RB_TEST(VALUE obj)
+{
   return RB_TEST(obj);
 }
 
 VALUE
-ruby_macros_ID2SYM(ID obj) {
+ruby_macros_ID2SYM(ID obj)
+{
   return ID2SYM(obj);
 }
 
-ID
-ruby_macros_SYM2ID(VALUE obj) {
+ID ruby_macros_SYM2ID(VALUE obj)
+{
   return SYM2ID(obj);
 }
 
 char *
-ruby_macros_RSTRING_PTR(VALUE obj) {
+ruby_macros_RSTRING_PTR(VALUE obj)
+{
   return RSTRING_PTR(obj);
 }
 
-long
-ruby_macros_RSTRING_LEN(VALUE obj) {
+long ruby_macros_RSTRING_LEN(VALUE obj)
+{
   return RSTRING_LEN(obj);
 }
 
-long
-ruby_macros_RARRAY_LEN(VALUE obj) {
+long ruby_macros_RARRAY_LEN(VALUE obj)
+{
   return RARRAY_LEN(obj);
 }
 
-const VALUE*
-ruby_macros_RARRAY_PTR(VALUE ary) {
+const VALUE *
+ruby_macros_RARRAY_PTR(VALUE ary)
+{
   return RARRAY_PTR(ary);
 }

--- a/examples/rust_reverse/ext/rust_reverse/Cargo.lock
+++ b/examples/rust_reverse/ext/rust_reverse/Cargo.lock
@@ -153,7 +153,7 @@ dependencies = [
 
 [[package]]
 name = "rb-sys"
-version = "0.9.17"
+version = "0.9.18"
 dependencies = [
  "bindgen",
  "linkify",
@@ -162,7 +162,7 @@ dependencies = [
 
 [[package]]
 name = "rb-sys-build"
-version = "0.9.17"
+version = "0.9.18"
 dependencies = [
  "regex",
  "shell-words",
@@ -187,7 +187,7 @@ checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
 
 [[package]]
 name = "rust-reverse"
-version = "0.9.17"
+version = "0.9.18"
 dependencies = [
  "rb-sys",
 ]

--- a/examples/rust_reverse/rust_reverse.gemspec
+++ b/examples/rust_reverse/rust_reverse.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = "A test gem"
   spec.homepage = "https://github.com/oxidize-rb/rb-sys"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 2.4.0"
+  spec.required_ruby_version = ">= 2.3.0"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.

--- a/examples/rust_reverse/test/test_rust_reverse.rb
+++ b/examples/rust_reverse/test/test_rust_reverse.rb
@@ -12,14 +12,16 @@ class TestRustReverse < Minitest::Test
   end
 
   def test_stressing_it_out
-    GC.stress = true
+    begin
+      GC.stress = true
 
-    expected = "a" * 10000
+      expected = "a" * 10000
 
-    1000.times do
-      assert_equal expected, RustReverse.reverse("a" * 10000)
+      1000.times do
+        assert_equal expected, RustReverse.reverse("a" * 10000)
+      end
+    ensure
+      GC.stress = false
     end
-  ensure
-    GC.stress = false
   end
 end

--- a/gem/rb_sys.gemspec
+++ b/gem/rb_sys.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.summary = "Helpers for compiling Rust extensions for ruby"
   spec.homepage = "https://github.com/oxidize-rb/rb-sys"
   spec.licenses = ["MIT", "Apache-2.0"]
-  spec.required_ruby_version = ">= 2.4.0"
+  spec.required_ruby_version = ">= 2.3.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/oxidize-rb/rb-sys"

--- a/gem/rb_sys.gemspec
+++ b/gem/rb_sys.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |spec|
 
   # Security
   spec.cert_chain = ["certs/ianks.pem"]
-  spec.signing_key = File.expand_path("~/.ssh/gem-private_key.pem") if /gem\z/.match?($0) # rubocop:disable Performance/EndWith
+  spec.signing_key = File.expand_path("~/.ssh/gem-private_key.pem") if $0.end_with?("gem")
   spec.metadata = {"rubygems_mfa_required" => "true"}
 end

--- a/gem/rb_sys.gemspec
+++ b/gem/rb_sys.gemspec
@@ -23,8 +23,6 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  # spec.add_dependency "rubygems", "~> 3.4"
-
   # Security
   spec.cert_chain = ["certs/ianks.pem"]
   spec.signing_key = File.expand_path("~/.ssh/gem-private_key.pem") if /gem\z/.match?($0) # rubocop:disable Performance/EndWith

--- a/rakelib/docker.rake
+++ b/rakelib/docker.rake
@@ -9,17 +9,19 @@ DOCKERFILE_PLATFORM_PAIRS = DOCKERFILES.zip(DOCKERFILE_PLATFORMS)
 DOCKER = ENV.fetch("RBSYS_DOCKER", "docker")
 
 def run_gh_workflow(file_name)
-  require "json"
-  require "yaml"
+  begin
+    require "json"
+    require "yaml"
 
-  workflow = YAML.safe_load(File.read(file_name))
+    workflow = YAML.safe_load(File.read(file_name))
 
-  sh "gh workflow run \"#{workflow["name"]}\" && sleep 3"
-  id = JSON.parse(`gh run list --workflow=#{File.basename(file_name)} --limit=1 --json="databaseId"`).first["databaseId"]
-  system "gh run watch #{id}"
-  sh "osascript -e 'display notification \"#{workflow["name"]} workflow finished (#{id})\" with title \"GitHub Workflow\"'"
-rescue Interrupt
-  sh "gh run cancel #{id}"
+    sh "gh workflow run \"#{workflow["name"]}\" && sleep 3"
+    id = JSON.parse(`gh run list --workflow=#{File.basename(file_name)} --limit=1 --json="databaseId"`).first["databaseId"]
+    system "gh run watch #{id}"
+    sh "osascript -e 'display notification \"#{workflow["name"]} workflow finished (#{id})\" with title \"GitHub Workflow\"'"
+  rescue Interrupt
+    sh "gh run cancel #{id}"
+  end
 end
 
 desc "Build the docker images on github"


### PR DESCRIPTION
Rubygems tests all the way down to Ruby 2.3, so we should too. Github actions for Ruby 2.3 doesn't set the MINGW_PACKAGE_PREFIX, and I cannot figure out how to make it pass for Ruby 2.3, so only testing against 2.4+ (although 2.3 could feasibly work).