### PR TITLE
Add support for `extra_rustflags` in `rb_sys/mkmf`

### DIFF
--- a/.standard.yml
+++ b/.standard.yml
@@ -4,3 +4,5 @@
 ruby_version: 2.3
 ignore:
   - "examples/rust_reverse/tmp/**/*"
+  - "target/**/*"
+  - "tmp/**/*"

--- a/Rakefile
+++ b/Rakefile
@@ -35,9 +35,12 @@ namespace :test do
   namespace :examples do
     task :rust_reverse do
       cargo_args = extra_args || []
+      envs = [{}, {"ALTERNATE_CONFIG_SCRIPT" => "extconf_bare.rb"}]
 
       Dir.chdir("examples/rust_reverse") do
-        sh "rake", "clean", "compile", "test", *cargo_args
+        envs.each do |env|
+          sh env, "rake", "clean", "compile", "test", *cargo_args
+        end
       end
     end
   end

--- a/examples/rust_reverse/Rakefile
+++ b/examples/rust_reverse/Rakefile
@@ -15,6 +15,7 @@ Rake::ExtensionTask.new("rust_reverse") do |ext|
   ext.source_pattern = "*.{rs,toml}"
   ext.cross_compile = true
   ext.cross_platform = %w[x86-mingw32 x64-mingw-ucrt x64-mingw32 x86-linux x86_64-linux x86_64-darwin arm64-darwin aarch64-linux]
+  ext.config_script = ENV["ALTERNATE_CONFIG_SCRIPT"] || "extconf.rb"
 end
 
 task default: %i[compile test]

--- a/examples/rust_reverse/ext/rust_reverse/Cargo.lock
+++ b/examples/rust_reverse/ext/rust_reverse/Cargo.lock
@@ -153,7 +153,7 @@ dependencies = [
 
 [[package]]
 name = "rb-sys"
-version = "0.9.18"
+version = "0.9.19"
 dependencies = [
  "bindgen",
  "linkify",
@@ -162,7 +162,7 @@ dependencies = [
 
 [[package]]
 name = "rb-sys-build"
-version = "0.9.18"
+version = "0.9.19"
 dependencies = [
  "regex",
  "shell-words",
@@ -187,7 +187,7 @@ checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
 
 [[package]]
 name = "rust-reverse"
-version = "0.9.18"
+version = "0.9.19"
 dependencies = [
  "rb-sys",
 ]

--- a/examples/rust_reverse/ext/rust_reverse/extconf.rb
+++ b/examples/rust_reverse/ext/rust_reverse/extconf.rb
@@ -18,4 +18,7 @@ create_rust_makefile("rust_reverse") do |r|
 
   # If your Cargo.toml is in a different directory, you can specify it here (optional)
   r.ext_dir = "."
+
+  # Extra flags to pass to the $RUSTFLAGS environment variable (optional)
+  r.extra_rustflags = ["--cfg=some_nested_config_var_for_crate"]
 end

--- a/examples/rust_reverse/ext/rust_reverse/extconf_bare.rb
+++ b/examples/rust_reverse/ext/rust_reverse/extconf_bare.rb
@@ -1,0 +1,8 @@
+# Use local rb_sys gem (only needed for developing in this repo)
+$LOAD_PATH.unshift(File.expand_path("../../../../gem/lib", __dir__))
+
+# We need to require mkmf *first* this since `rake-compiler` injects code here for cross compilation
+require "mkmf"
+require "rb_sys/mkmf"
+
+create_rust_makefile("rust_reverse")

--- a/gem/lib/rb_sys/cargo_builder.rb
+++ b/gem/lib/rb_sys/cargo_builder.rb
@@ -1,6 +1,6 @@
 module RbSys
   class CargoBuilder < Gem::Ext::Builder
-    attr_accessor :spec, :runner, :profile, :env, :features, :target, :extra_rustc_args, :dry_run, :ext_dir
+    attr_accessor :spec, :runner, :profile, :env, :features, :target, :extra_rustc_args, :dry_run, :ext_dir, :extra_rustflags
 
     def initialize(spec)
       require "rubygems/command"
@@ -15,6 +15,7 @@ module RbSys
       @extra_rustc_args = []
       @dry_run = true
       @ext_dir = nil
+      @extra_rustflags = []
     end
 
     def build(_extension, dest_path, results, args = [], lib_dir = nil, cargo_dir = Dir.pwd)

--- a/gem/lib/rb_sys/mkmf.rb
+++ b/gem/lib/rb_sys/mkmf.rb
@@ -59,6 +59,7 @@ module RbSys
 
         RB_SYS_CARGO_PROFILE ?= #{builder.profile}
         RB_SYS_CARGO_FEATURES ?= #{builder.features.join(",")}
+        RB_SYS_EXTRA_RUSTFLAGS ?= #{builder.extra_rustflags.join(" ")}
 
         # Set dirname for the profile, since the profiles do not directly map to target dir (i.e. dev -> debug)
         ifeq ($(RB_SYS_CARGO_PROFILE),dev)
@@ -100,6 +101,7 @@ module RbSys
         endif
 
         #{env_vars(builder)}
+        $(DLLIB): export RUSTFLAGS := $(RUSTFLAGS) $(RB_SYS_EXTRA_RUSTFLAGS)
 
         FORCE: ;
 

--- a/gem/test/test_rb_sys.rb
+++ b/gem/test/test_rb_sys.rb
@@ -53,6 +53,17 @@ class TestRbSys < Minitest::Test
     assert_match(/-C debuginfo=42$/, makefile.read)
   end
 
+  def test_uses_extra_rustflags
+    makefile = create_makefile do |b|
+      b.extra_rustflags = ["--cfg=foo"]
+    end
+
+    content = makefile.read
+
+    assert content.include?("$(DLLIB): export RUSTFLAGS := $(RUSTFLAGS) $(RB_SYS_EXTRA_RUSTFLAGS)")
+    assert content.include?("RB_SYS_EXTRA_RUSTFLAGS ?= --cfg=foo")
+  end
+
   def test_uses_custom_target
     makefile = create_makefile do |b|
       b.target = "wasm32-unknown-unknown"


### PR DESCRIPTION
Sometimes, you always want to pass global `$RUSTFLAGS`. I've had to do this to configure nested crates in the future and it can be a pain to get right, since you have to honor pre-existing `$RUSTFLAGS` as well. This feature makes that easier.

```ruby
require "mkmf"
require "rb_sys/mkmf"

create_rust_makefile("rust_reverse") do |r|
  # Extra flags to pass to the $RUSTFLAGS environment variable (optional)
  r.extra_rustflags = ["--cfg=some_nested_config_var_for_crate"]
end
```