### PR TITLE
Cleanup target dir by default after `gem install`

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -37,7 +37,7 @@ runs:
           ~/.cargo/git/db/
           target/
           examples/rust_reverse/tmp/
-        key: ${{ inputs.os }}-${{ inputs.ruby_version }}-${{ inputs.rust_toolchain }}-cargo-v4-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ inputs.os }}-${{ inputs.ruby_version }}-${{ inputs.rust_toolchain }}-cargo-v4-${{ hashFiles('**/Cargo.lock', '**/extconf.rb') }}
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: ${{ inputs.rust_toolchain }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
           path: |
             /opt/rubies/${{ matrix.ruby_version }}
             ~/.gem/ruby/${{ matrix.ruby_version }}
-          key: ${{ matrix.sys.os }}-${{ matrix.ruby_version }}
+          key: rb-sys-ruby-static-${{ matrix.sys.os }}-${{ matrix.ruby_version }}
       - name: 🔘 Build static ruby
         working-directory: /tmp
         run: |

--- a/examples/rust_reverse/Rakefile
+++ b/examples/rust_reverse/Rakefile
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "bundler/gem_tasks"
 require "rake/testtask"
 require "rake/extensiontask"
 
@@ -16,6 +15,30 @@ Rake::ExtensionTask.new("rust_reverse") do |ext|
   ext.cross_compile = true
   ext.cross_platform = %w[x86-mingw32 x64-mingw-ucrt x64-mingw32 x86-linux x86_64-linux x86_64-darwin arm64-darwin aarch64-linux]
   ext.config_script = ENV["ALTERNATE_CONFIG_SCRIPT"] || "extconf.rb"
+end
+
+task :build do
+  require "bundler"
+
+  spec = Bundler.load_gemspec("rust_reverse.gemspec")
+
+  FileUtils.rm_rf("pkg/rust_reverse-0.9.21")
+
+  spec.files.each do |file|
+    FileUtils.mkdir_p("pkg/rust_reverse-0.9.21/#{File.dirname(file)}")
+    FileUtils.cp(file, "pkg/rust_reverse-0.9.21/#{file}")
+  end
+
+  FileUtils.cp("rust_reverse.gemspec", "pkg/rust_reverse-0.9.21")
+
+  cargo_toml_path = "pkg/rust_reverse-0.9.21/ext/rust_reverse/Cargo.toml"
+  new_contents = File.read(cargo_toml_path).gsub(' path = "./../../../../crates/rb-sys",', "")
+  FileUtils.rm(cargo_toml_path)
+  File.write(cargo_toml_path, new_contents)
+
+  Dir.chdir("pkg/rust_reverse-0.9.21") do
+    sh "gem build rust_reverse.gemspec --output=../rust_reverse-0.9.21.gem"
+  end
 end
 
 task default: %i[compile test]

--- a/examples/rust_reverse/ext/rust_reverse/extconf.rb
+++ b/examples/rust_reverse/ext/rust_reverse/extconf.rb
@@ -25,4 +25,7 @@ create_rust_makefile("rust_reverse") do |r|
   # Force a rust toolchain to be installed via rustup (optional)
   # You can also set the env var `RB_SYS_FORCE_INSTALL_RUST_TOOLCHAIN=true`
   r.force_install_rust_toolchain = false
+
+  # Clean up the target/ dir after `gem install` to reduce bloat (optional)
+  r.clean_after_install = false # default: true if rubygems invoked the command
 end

--- a/examples/rust_reverse/ext/rust_reverse/extconf.rb
+++ b/examples/rust_reverse/ext/rust_reverse/extconf.rb
@@ -27,5 +27,5 @@ create_rust_makefile("rust_reverse") do |r|
   r.force_install_rust_toolchain = false
 
   # Clean up the target/ dir after `gem install` to reduce bloat (optional)
-  r.clean_after_install = false # default: true if rubygems invoked the command
+  r.clean_after_install = true # default: true if rubygems invoked the command
 end

--- a/examples/rust_reverse/rust_reverse.gemspec
+++ b/examples/rust_reverse/rust_reverse.gemspec
@@ -16,11 +16,7 @@ Gem::Specification.new do |spec|
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files = Dir.chdir(__dir__) do
-    `git ls-files -z`.split("\x0").reject do |f|
-      (f == __FILE__) || f.match(%r{\A(?:(?:bin|test|spec|features)/|\.(?:git|travis|circleci)|appveyor)})
-    end
-  end
+  spec.files = Dir["lib/**/*.rb", "ext/**/*.{rs,toml,lock,rb}"]
   spec.bindir = "exe"
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]

--- a/gem/README.md
+++ b/gem/README.md
@@ -34,7 +34,10 @@ create_rust_makefile("rust_reverse") do |r|
 
   # Force a rust toolchain to be installed via rustup (optional)
   # You can also set the env var `RB_SYS_FORCE_INSTALL_RUST_TOOLCHAIN=true`
-  r.force_install_rust_toolchain = "nightly"
+  r.force_install_rust_toolchain = "stable"
+
+  # Clean up the target/ dir after `gem install` to reduce bloat (optional)
+  r.clean_after_install = false # default: true if invoked by rubygems
 end
 ```
 

--- a/gem/lib/rb_sys/mkmf.rb
+++ b/gem/lib/rb_sys/mkmf.rb
@@ -95,7 +95,7 @@ module RbSys
         TARGET_DIR = #{Dir.pwd}/$(RB_SYS_CARGO_BUILD_TARGET_DIR)/$(RB_SYS_CARGO_PROFILE_DIR)
         RUSTLIB = $(TARGET_DIR)/$(SOEXT_PREFIX)$(TARGET_NAME).$(SOEXT)
 
-        CLEANOBJS = $(RB_SYS_CARGO_BUILD_TARGET_DIR) $(RB_SYS_BUILD_DIR)
+        CLEANOBJS = $(TARGET_DIR)/.fingerprint $(TARGET_DIR)/incremental $(TARGET_DIR)/examples $(TARGET_DIR)/deps $(TARGET_DIR)/build $(TARGET_DIR)/.cargo-lock $(TARGET_DIR)/*.d $(RB_SYS_BUILD_DIR)
         DEFFILE = $(TARGET_DIR)/$(TARGET)-$(arch).def
         #{base_makefile(srcdir)}
 

--- a/gem/lib/rb_sys/mkmf/config.rb
+++ b/gem/lib/rb_sys/mkmf/config.rb
@@ -4,11 +4,12 @@ module RbSys
   module Mkmf
     # Config that delegates to CargoBuilder if needded
     class Config
-      attr_accessor :force_install_rust_toolchain
+      attr_accessor :force_install_rust_toolchain, :clean_after_install
 
       def initialize(builder)
         @builder = builder
         @force_install_rust_toolchain = false
+        @clean_after_install = rubygems_invoked?
       end
 
       def method_missing(name, *args, &blk)
@@ -17,6 +18,15 @@ module RbSys
 
       def respond_to_missing?(name, include_private = false)
         @builder.respond_to?(name) || super
+      end
+
+      private
+
+      # Seems to be the only way to reliably know if we were invoked by Rubygems.
+      # We want to know this so we can cleanup the target directory after an
+      # install, to remove bloat.
+      def rubygems_invoked?
+        ENV.key?("SOURCE_DATE_EPOCH")
       end
     end
   end


### PR DESCRIPTION
By default, Rubygems does not run a `make clean` after installing a gem. This is a problem for Rust gems since there can be a lot of junk left over in the `target/` directory. I've seen it be 1200mb in one gem.

This PR makes it so `rb_sys` will clean the `target/` build directory by default after installing the gem. This can be turned of with the `clean_after_install = false` config option.

See: https://github.com/rubygems/rubygems/issues/3958