### PR TITLE
Tailor docker images settings for Cargo

### DIFF
--- a/crates/rb-sys/build/main.rs
+++ b/crates/rb-sys/build/main.rs
@@ -109,7 +109,7 @@ fn export_cargo_cfg(rbconfig: &mut RbConfig) {
         println!("cargo:rustc-cfg=has_ruby_abi_version");
     }
 
-    if is_global_allocator_enabled(&rbconfig) {
+    if is_global_allocator_enabled(rbconfig) {
         println!("cargo:rustc-cfg=use_global_allocator");
     }
 

--- a/docker/Dockerfile.aarch64-linux
+++ b/docker/Dockerfile.aarch64-linux
@@ -6,7 +6,15 @@ ENV RUBY_TARGET="aarch64-linux" \
     PKG_CONFIG_ALLOW_CROSS="1" \
     RUSTUP_HOME="/usr/local/rustup" \
     CARGO_HOME="/usr/local/cargo" \
-    PATH="/usr/local/cargo/bin:$PATH"
+    PATH="/usr/local/cargo/bin:$PATH" \
+    LIBCLANG_PATH="/usr/lib/llvm-10/lib" \
+    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER="aarch64-linux-gnu-ld" \
+    CC_aarch64_unknown_linux_gnu="aarch64-linux-gnu-gcc" \
+    CXX_aarch64_unknown_linux_gnu="aarch64-linux-gnu-g++" \
+    AR_aarch64_unknown_linux_gnu="aarch64-linux-gnu-ar" \
+    BINDGEN_EXTRA_CLANG_ARGS_aarch64_unknown_linux_gnu="--sysroot=/usr/aarch64-linux-gnu" \
+    QEMU_LD_PREFIX="/usr/aarch64-linux-gnu" \
+    PKG_CONFIG_PATH="/usr/lib/aarch64-linux-gnu/pkgconfig/:${PKG_CONFIG_PATH}"
 
 COPY setup/lib.sh /lib.sh
 
@@ -16,10 +24,10 @@ RUN /rustup.sh x86_64-unknown-linux-gnu $RUST_TARGET $RUSTUP_DEFAULT_TOOLCHAIN
 COPY setup/rubygems.sh /
 RUN /rubygems.sh
 
-RUN bash -c "source /lib.sh && install_packages libclang-dev clang llvm-dev libc6-arm64-cross libc6-dev-arm64-cross"
+COPY setup/cmake.sh /
+RUN /cmake.sh
 
-ENV LIBCLANG_PATH="/usr/lib/llvm-10/lib" \
-    BINDGEN_EXTRA_CLANG_ARGS="--sysroot=/usr/aarch64-linux-gnu"
+RUN bash -c "source /lib.sh && install_packages libclang-dev clang llvm-dev libc6-arm64-cross libc6-dev-arm64-cross"
 
 COPY setup/rubybashrc.sh /
 RUN /rubybashrc.sh

--- a/docker/Dockerfile.arm-linux
+++ b/docker/Dockerfile.arm-linux
@@ -6,7 +6,15 @@ ENV RUBY_TARGET="arm-linux" \
     PKG_CONFIG_ALLOW_CROSS="1" \
     RUSTUP_HOME="/usr/local/rustup" \
     CARGO_HOME="/usr/local/cargo" \
-    PATH="/usr/local/cargo/bin:$PATH"
+    PATH="/usr/local/cargo/bin:$PATH" \
+    LIBCLANG_PATH="/usr/lib/llvm-10/lib" \
+    CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_LINKER="arm-linux-gnueabihf-ld" \
+    CC_arm_unknown_linux_gnueabihf="arm-linux-gnueabihf-gcc" \
+    CXX_arm_unknown_linux_gnueabihf="arm-linux-gnueabihf-g++" \
+    AR_arm_unknown_linux_gnueabihf="arm-linux-gnueabihf-ar" \
+    BINDGEN_EXTRA_CLANG_ARGS_arm_unknown_linux_gnueabihf="--sysroot=/usr/arm-linux-gnueabihf" \
+    QEMU_LD_PREFIX="/usr/arm-linux-gnueabihf"
+
 
 COPY setup/lib.sh /lib.sh
 
@@ -16,10 +24,10 @@ RUN /rustup.sh x86_64-unknown-linux-gnu $RUST_TARGET $RUSTUP_DEFAULT_TOOLCHAIN
 COPY setup/rubygems.sh /
 RUN /rubygems.sh
 
-RUN bash -c "source /lib.sh && install_packages libclang-dev clang llvm-dev libc6-armhf-cross libc6-dev-armhf-cross"
+COPY setup/cmake.sh /
+RUN /cmake.sh
 
-ENV LIBCLANG_PATH="/usr/lib/llvm-10/lib" \
-    BINDGEN_EXTRA_CLANG_ARGS="--sysroot=/usr/arm-linux-gnueabihf"
+RUN bash -c "source /lib.sh && install_packages libclang-dev clang llvm-dev libc6-armhf-cross libc6-dev-armhf-cross"
 
 COPY setup/rubybashrc.sh /
 RUN /rubybashrc.sh

--- a/docker/Dockerfile.arm64-darwin
+++ b/docker/Dockerfile.arm64-darwin
@@ -7,8 +7,14 @@ ENV RUBY_TARGET="arm64-darwin" \
     RUSTUP_HOME="/usr/local/rustup" \
     CARGO_HOME="/usr/local/cargo" \
     PATH="/usr/local/cargo/bin:$PATH" \
+    CARGO_TARGET_AARCH64_APPLE_DARWIN_LINKER="aarch64-apple-darwin-clang" \
     LIBCLANG_PATH="/usr/lib/llvm-10/lib/" \
-    BINDGEN_EXTRA_CLANG_ARGS="--sysroot=/opt/osxcross/target/SDK/MacOSX11.1.sdk/"
+    CC_aarch64_apple_darwin="aarch64-apple-darwin-cc" \
+    CXX_aarch64_apple_darwin="aarch64-apple-darwin-c++" \
+    AR_aarch64_apple_darwin="aarch64-apple-darwin-ar" \
+    BINDGEN_EXTRA_CLANG_ARGS_aarch64_apple_darwin="--sysroot=/opt/osxcross/target/SDK/MacOSX11.1.sdk/" \
+    QEMU_LD_PREFIX="/opt/osxcross/target/SDK/MacOSX11.1.sdk/"
+
 
 COPY setup/lib.sh /lib.sh
 
@@ -20,6 +26,9 @@ RUN /rustup.sh x86_64-unknown-linux-gnu $RUST_TARGET $RUSTUP_DEFAULT_TOOLCHAIN
 
 COPY setup/rubygems.sh /
 RUN /rubygems.sh
+
+COPY setup/cmake.sh /
+RUN /cmake.sh
 
 RUN bash -c "source /lib.sh && install_packages libclang-dev clang libc6-arm64-cross libc6-dev-arm64-cross"
 

--- a/docker/Dockerfile.x64-mingw-ucrt
+++ b/docker/Dockerfile.x64-mingw-ucrt
@@ -6,7 +6,15 @@ ENV RUBY_TARGET="x64-mingw-ucrt" \
     PKG_CONFIG_ALLOW_CROSS="1" \
     RUSTUP_HOME="/usr/local/rustup" \
     CARGO_HOME="/usr/local/cargo" \
-    PATH="/usr/local/cargo/bin:$PATH"
+    PATH="/usr/local/cargo/bin:$PATH" \
+    BINDGEN_EXTRA_CLANG_ARGS_x86_64_pc_windows_gnu="--sysroot=/usr/x86_64-w64-mingw32 -I/usr/lib/llvm-10/lib/clang/10.0.0/include" \
+    LIBCLANG_PATH="/usr/lib/llvm-10/lib/" \
+    CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="x86_64-w64-mingw32-ld" \
+    CC_x86_64_pc_windows_gnu="x86_64-w64-mingw32-gcc" \
+    CXX_x86_64_pc_windows_gnu="x86_64-w64-mingw32-g++" \
+    AR_x86_64_pc_windows_gnu="x86_64-w64-mingw32-ar" \
+    QEMU_LD_PREFIX="/usr/x86_64-w64-mingw32"
+
 
 COPY setup/lib.sh /lib.sh
 
@@ -16,16 +24,10 @@ RUN /rustup.sh x86_64-unknown-linux-gnu $RUST_TARGET $RUSTUP_DEFAULT_TOOLCHAIN
 COPY setup/rubygems.sh /
 RUN /rubygems.sh
 
+COPY setup/cmake.sh /
+RUN /cmake.sh
+
 RUN bash -c "source /lib.sh && install_packages libclang-dev"
-
-# RUN set -ex; \
-#     curl -Lo /llvm-mingw.tar.xz https://github.com/mstorsjo/llvm-mingw/releases/download/20220323/llvm-mingw-20220323-ucrt-ubuntu-18.04-x86_64.tar.xz; \
-#     mkdir /llvm-mingw; \
-#     tar xf /llvm-mingw.tar.xz -C /llvm-mingw --strip-components=1; \
-#     rm /llvm-mingw.tar.xz;
-
-ENV BINDGEN_EXTRA_CLANG_ARGS="--sysroot=/usr/x86_64-w64-mingw32 -I/usr/lib/llvm-10/lib/clang/10.0.0/include" \
-    LIBCLANG_PATH="/usr/lib/llvm-10/lib/"
 
 COPY setup/rubybashrc.sh /
 RUN /rubybashrc.sh

--- a/docker/Dockerfile.x64-mingw32
+++ b/docker/Dockerfile.x64-mingw32
@@ -6,7 +6,15 @@ ENV RUBY_TARGET="x64-mingw32" \
     PKG_CONFIG_ALLOW_CROSS="1" \
     RUSTUP_HOME="/usr/local/rustup" \
     CARGO_HOME="/usr/local/cargo" \
-    PATH="/usr/local/cargo/bin:$PATH"
+    PATH="/usr/local/cargo/bin:$PATH" \
+    BINDGEN_EXTRA_CLANG_ARGS_x86_64_pc_windows_gnu="--sysroot=/usr/x86_64-w64-mingw32 -I/usr/lib/llvm-10/lib/clang/10.0.0/include" \
+    LIBCLANG_PATH="/usr/lib/llvm-10/lib/" \
+    CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="x86_64-w64-mingw32-ld" \
+    CC_x86_64_pc_windows_gnu="x86_64-w64-mingw32-gcc" \
+    CXX_x86_64_pc_windows_gnu="x86_64-w64-mingw32-g++" \
+    AR_x86_64_pc_windows_gnu="x86_64-w64-mingw32-ar" \
+    QEMU_LD_PREFIX="/usr/x86_64-w64-mingw32"
+
 
 COPY setup/lib.sh /lib.sh
 
@@ -16,16 +24,10 @@ RUN /rustup.sh x86_64-unknown-linux-gnu $RUST_TARGET $RUSTUP_DEFAULT_TOOLCHAIN
 COPY setup/rubygems.sh /
 RUN /rubygems.sh
 
+COPY setup/cmake.sh /
+RUN /cmake.sh
+
 RUN bash -c "source /lib.sh && install_packages libclang-dev"
-
-# RUN set -ex; \
-#     curl -Lo /llvm-mingw.tar.xz https://github.com/mstorsjo/llvm-mingw/releases/download/20220323/llvm-mingw-20220323-msvcrt-ubuntu-18.04-x86_64.tar.xz; \
-#     mkdir /llvm-mingw; \
-#     tar xf /llvm-mingw.tar.xz -C /llvm-mingw --strip-components=1; \
-#     rm /llvm-mingw.tar.xz;
-
-ENV BINDGEN_EXTRA_CLANG_ARGS="--sysroot=/usr/x86_64-w64-mingw32 -I/usr/lib/llvm-10/lib/clang/10.0.0/include" \
-    LIBCLANG_PATH="/usr/lib/llvm-10/lib/"
 
 COPY setup/rubybashrc.sh /
 RUN /rubybashrc.sh

--- a/docker/Dockerfile.x86-linux
+++ b/docker/Dockerfile.x86-linux
@@ -6,7 +6,16 @@ ENV RUBY_TARGET="x86-linux" \
     PKG_CONFIG_ALLOW_CROSS="1" \
     RUSTUP_HOME="/usr/local/rustup" \
     CARGO_HOME="/usr/local/cargo" \
-    PATH="/usr/local/cargo/bin:$PATH"
+    RUSTUP_UNPACK_RAM="63554432" \
+    RUSTUP_IO_THREADS="1" \
+    PATH="/usr/local/cargo/bin:$PATH" \
+    LIBCLANG_PATH="/usr/lib" \
+    CARGO_TARGET_I686_UNKNOWN_LINUX_GNU_LINKER="ld" \
+    CC_i686_unknown_linux_gnu="i686-redhat-linux-gcc" \
+    CXX_i686_unknown_linux_gnu="i686-redhat-linux-g++" \
+    AR_i686_unknown_linux_gnu="ar" \
+    BINDGEN_EXTRA_CLANG_ARGS_i686_unknown_linux_gnu="--sysroot=/usr -I/usr/lib/gcc/i686-redhat-linux/4.8.2/include" \
+    QEMU_LD_PREFIX="/usr"
 
 COPY setup/lib.sh /lib.sh
 
@@ -17,8 +26,8 @@ RUN /rustup.sh i686-unknown-linux-gnu $RUST_TARGET $RUSTUP_DEFAULT_TOOLCHAIN
 
 RUN set -ex; \
     wget https://vault.centos.org/centos/8/AppStream/x86_64/os/Packages/clang-libs-12.0.1-4.module_el8.5.0+1025+93159d6c.i686.rpm \
-         https://vault.centos.org/centos/8/AppStream/x86_64/os/Packages/llvm-libs-12.0.1-2.module_el8.5.0+918+ed335b90.i686.rpm \
-         https://vault.centos.org/centos/8/BaseOS/x86_64/os/Packages/ncurses-libs-6.1-9.20180224.el8.i686.rpm; \
+    https://vault.centos.org/centos/8/AppStream/x86_64/os/Packages/llvm-libs-12.0.1-2.module_el8.5.0+918+ed335b90.i686.rpm \
+    https://vault.centos.org/centos/8/BaseOS/x86_64/os/Packages/ncurses-libs-6.1-9.20180224.el8.i686.rpm; \
     rpm -Uvh --nodeps *.rpm; \
     ln -s /usr/lib/libtinfo.so.6 /usr/lib/libtinfo.so.5; \
     rm *.rpm;
@@ -26,8 +35,8 @@ RUN set -ex; \
 COPY setup/rubygems.sh /
 RUN /rubygems.sh
 
-ENV LIBCLANG_PATH="/usr/lib" \
-    BINDGEN_EXTRA_CLANG_ARGS="--sysroot=/usr -I/usr/lib/gcc/i686-redhat-linux/4.8.2/include"
+COPY setup/cmake.sh /
+RUN /cmake.sh
 
 COPY setup/rubybashrc.sh /
 RUN /rubybashrc.sh

--- a/docker/Dockerfile.x86-mingw32
+++ b/docker/Dockerfile.x86-mingw32
@@ -6,7 +6,14 @@ ENV RUBY_TARGET="x86-mingw32" \
     PKG_CONFIG_ALLOW_CROSS="1" \
     RUSTUP_HOME="/usr/local/rustup" \
     CARGO_HOME="/usr/local/cargo" \
-    PATH="/usr/local/cargo/bin:$PATH"
+    PATH="/usr/local/cargo/bin:$PATH" \
+    BINDGEN_EXTRA_CLANG_ARGS_i686_pc_windows_gnu="--sysroot=/usr/i686-w64-mingw32 -I/llvm-mingw/llvm-mingw-20220323-msvcrt-i686/include -I/llvm-mingw/llvm-mingw-20220323-msvcrt-i686/lib/clang/14.0.0/include" \
+    LIBCLANG_PATH="/usr/lib/llvm-10/lib/" \
+    CARGO_TARGET_I686_PC_WINDOWS_GNU_LINKER="i686-w64-mingw32-ld" \
+    CC_i686_pc_windows_gnu="i686-w64-mingw32-gcc" \
+    CXX_i686_pc_windows_gnu="i686-w64-mingw32-g++" \
+    AR_i686_pc_windows_gnu="i686-w64-mingw32-gcc-ar" \
+    QEMU_LD_PREFIX="/usr/i686-w64-mingw32"
 
 COPY setup/lib.sh /lib.sh
 
@@ -16,6 +23,9 @@ RUN /rustup.sh x86_64-unknown-linux-gnu $RUST_TARGET $RUSTUP_DEFAULT_TOOLCHAIN
 COPY setup/rubygems.sh /
 RUN /rubygems.sh
 
+COPY setup/cmake.sh /
+RUN /cmake.sh
+
 RUN bash -c "source /lib.sh && install_packages libclang-dev"
 
 RUN set -ex; \
@@ -23,9 +33,6 @@ RUN set -ex; \
     mkdir /llvm-mingw; \
     unzip /llvm-mingw.zip -d /llvm-mingw; \
     rm /llvm-mingw.zip;
-
-ENV BINDGEN_EXTRA_CLANG_ARGS="--sysroot=/usr/i686-w64-mingw32 -I/llvm-mingw/llvm-mingw-20220323-msvcrt-i686/include -I/llvm-mingw/llvm-mingw-20220323-msvcrt-i686/lib/clang/14.0.0/include" \
-    LIBCLANG_PATH="/usr/lib/llvm-10/lib/"
 
 COPY setup/rubybashrc.sh /
 RUN /rubybashrc.sh

--- a/docker/Dockerfile.x86_64-darwin
+++ b/docker/Dockerfile.x86_64-darwin
@@ -8,7 +8,15 @@ ENV RUBY_TARGET="x86_64-darwin" \
     CARGO_HOME="/usr/local/cargo" \
     BINDGEN_EXTRA_CLANG_ARGS="-I/usr/include/x86_64-linux-gnu/" \
     PATH="/usr/local/cargo/bin:$PATH" \
-    LIBCLANG_PATH="/usr/lib/llvm-10/lib"
+    LIBCLANG_PATH="/usr/lib/llvm-10/lib" \
+    CARGO_TARGET_X86_64_APPLE_DARWIN_LINKER="x86_64-apple-darwin-clang" \
+    LIBCLANG_PATH="/usr/lib/llvm-10/lib/" \
+    CC_x86_64_apple_darwin="x86_64-apple-darwin-clang" \
+    CXX_x86_64_apple_darwin="x86_64-apple-darwin-clang++" \
+    AR_x86_64_apple_darwin="x86_64-apple-darwin-ar" \
+    BINDGEN_EXTRA_CLANG_ARGS_x86_64_apple_darwin="--sysroot=/opt/osxcross/target/SDK/MacOSX11.1.sdk/" \
+    QEMU_LD_PREFIX="/opt/osxcross/target/SDK/MacOSX11.1.sdk/"
+
 
 COPY setup/lib.sh /lib.sh
 
@@ -20,6 +28,9 @@ RUN /rustup.sh x86_64-unknown-linux-gnu $RUST_TARGET $RUSTUP_DEFAULT_TOOLCHAIN
 
 COPY setup/rubygems.sh /
 RUN /rubygems.sh
+
+COPY setup/cmake.sh /
+RUN /cmake.sh
 
 RUN bash -c "source /lib.sh && install_packages libclang-dev clang"
 

--- a/docker/Dockerfile.x86_64-linux
+++ b/docker/Dockerfile.x86_64-linux
@@ -6,7 +6,15 @@ ENV RUBY_TARGET="x86_64-linux" \
     PKG_CONFIG_ALLOW_CROSS="1" \
     RUSTUP_HOME="/usr/local/rustup" \
     CARGO_HOME="/usr/local/cargo" \
-    PATH="/usr/local/cargo/bin:$PATH"
+    PATH="/usr/local/cargo/bin:$PATH" \
+    LIBCLANG_PATH="/opt/rh/llvm-toolset-7/root/usr/lib64" \
+    CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER="ld" \
+    CC_x86_64_unknown_linux_gnu="x86_64-redhat-linux-gcc" \
+    CXX_x86_64_unknown_linux_gnu="x86_64-redhat-linux-g++" \
+    AR_x86_64_unknown_linux_gnu="ar" \
+    BINDGEN_EXTRA_CLANG_ARGS_x86_64_unknown_linux_gnu="--sysroot=/usr -I/usr/lib/gcc/x86_64-redhat-linux/4.8.2/include" \
+    QEMU_LD_PREFIX="/usr"
+
 
 COPY setup/lib.sh /lib.sh
 
@@ -16,10 +24,10 @@ RUN /rustup.sh x86_64-unknown-linux-gnu $RUST_TARGET $RUSTUP_DEFAULT_TOOLCHAIN
 COPY setup/rubygems.sh /
 RUN /rubygems.sh
 
-RUN source /lib.sh && install_packages llvm-toolset-7
+COPY setup/cmake.sh /
+RUN /cmake.sh
 
-ENV LIBCLANG_PATH="/opt/rh/llvm-toolset-7/root/usr/lib64" \
-    BINDGEN_EXTRA_CLANG_ARGS="--sysroot=/usr -I/usr/lib/gcc/x86_64-redhat-linux/4.8.2/include"
+RUN source /lib.sh && install_packages llvm-toolset-7
 
 COPY setup/rubybashrc.sh /
 RUN /rubybashrc.sh

--- a/docker/setup/cmake.sh
+++ b/docker/setup/cmake.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -x
+set -eo pipefail
+
+# shellcheck disable=SC1091
+source /lib.sh
+
+main() {
+    local version=3.23.1
+
+    install_packages curl
+
+    local td
+    td="$(mktemp -d)"
+
+    pushd "${td}"
+
+    curl --retry 3 -sSfL "https://github.com/Kitware/CMake/releases/download/v${version}/cmake-${version}-linux-x86_64.sh" -o cmake.sh
+    sh cmake.sh --skip-license --prefix=/usr/local
+
+    popd
+
+    purge_packages
+
+    rm -rf "${td}"
+    rm -rf /var/lib/apt/lists/*
+    rm "${0}"
+}
+
+main "${@}"

--- a/docker/setup/rubybashrc.sh
+++ b/docker/setup/rubybashrc.sh
@@ -6,6 +6,14 @@ set -euo pipefail
 # shellcheck disable=SC1091
 source /lib.sh
 
+set_target_env_for_key_matching() {
+  local var_name
+  var_name="$(env | grep "${1}" | cut -d '=' -f 1)"
+  local var_value
+  var_value="$(env | grep "${1}" | cut -d '=' -f2-)"
+  echo "export ${var_name}=\"${var_value}\"" >> /etc/rubybashrc
+}
+
 main() {
   # shellcheck disable=SC2129
   echo "export PATH=\"/usr/local/cargo/bin:\$PATH\"" >> /etc/rubybashrc
@@ -14,11 +22,17 @@ main() {
   echo "export RUBY_TARGET=\"$RUBY_TARGET\"" >> /etc/rubybashrc
   echo "export RUST_TARGET=\"$RUST_TARGET\"" >> /etc/rubybashrc
   echo "export RUSTUP_DEFAULT_TOOLCHAIN=\"$RUSTUP_DEFAULT_TOOLCHAIN\"" >> /etc/rubybashrc
-  echo "export BINDGEN_EXTRA_CLANG_ARGS=\"$BINDGEN_EXTRA_CLANG_ARGS\"" >> /etc/rubybashrc
   echo "export PKG_CONFIG_ALLOW_CROSS=\"$PKG_CONFIG_ALLOW_CROSS\"" >> /etc/rubybashrc
   echo "export LIBCLANG_PATH=\"$LIBCLANG_PATH\"" >> /etc/rubybashrc
   echo "export CARGO_BUILD_TARGET=\"$RUST_TARGET\"" >> /etc/rubybashrc
   echo "export CARGO=\"/usr/local/cargo/bin/cargo\"" >> /etc/rubybashrc
+  echo "export RB_SYS_CARGO_PROFILE=\"release\"" >> /etc/rubybashrc
+
+  set_target_env_for_key_matching "^BINDGEN_EXTRA_CLANG_ARGS_"
+  set_target_env_for_key_matching "^CC_"
+  set_target_env_for_key_matching "^CXX_"
+  set_target_env_for_key_matching "^AR_"
+  set_target_env_for_key_matching "^CARGO_TARGET_.*_LINKER"
 
   rm "${0}"
 }

--- a/docker/setup/rubygems.sh
+++ b/docker/setup/rubygems.sh
@@ -12,7 +12,7 @@ main() {
   builtin pushd "${td}"
 
   # Using my fork for now
-  git clone --single-branch --branch cargo-builder-target --depth 1 https://github.com/ianks/rubygems .
+  git clone --single-branch --depth 1 https://github.com/rubygems/rubygems .
   ruby setup.rb
 
   builtin popd

--- a/rakelib/docker.rake
+++ b/rakelib/docker.rake
@@ -2,7 +2,7 @@
 
 require "yaml"
 
-RCD_TAG = "1.2.1"
+RCD_TAG = "1.2.2"
 DOCKERFILES = Dir["docker/Dockerfile.*"]
 DOCKERFILE_PLATFORMS = DOCKERFILES.map { |f| File.extname(f).delete(".") }
 DOCKERFILE_PLATFORM_PAIRS = DOCKERFILES.zip(DOCKERFILE_PLATFORMS)

--- a/script/rcd
+++ b/script/rcd
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -ex
+
+PLATFORM="$1"
+export RCD_IMAGE="rbsys/rcd:$PLATFORM"
+shift
+
+docker pull "$RCD_IMAGE" --quiet
+exec rake-compiler-dock $@


### PR DESCRIPTION
Stealing a lot of stuff from [`cross-rs`](https://github.com/cross-rs/cross/tree/main/docker) here. Essentially, this PR further specifies environment variables to make cross compiled builds more reliable. The main benefit here is that by setting the Cargo linker, we avoid certain issues when Rust crates link static C libraries using the `cc` crate.