### PR TITLE
Implement value_type.h and special_consts.h in Rust

### DIFF
--- a/crates/rb-sys-tests/src/helpers.rs
+++ b/crates/rb-sys-tests/src/helpers.rs
@@ -1,0 +1,6 @@
+#[macro_export]
+macro_rules! rstring {
+    ($s:expr) => {
+        unsafe { rb_sys::rb_str_new($s.as_ptr() as _, $s.len() as _) }
+    };
+}

--- a/crates/rb-sys-tests/src/lib.rs
+++ b/crates/rb-sys-tests/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(unused_unsafe)]
+
 extern crate rb_sys;
 
 #[cfg(not(windows_broken_vm_init_3_1))]
@@ -22,9 +24,20 @@ fn vm_init() {
     }
 }
 
+#[macro_use]
+mod helpers;
+
 #[cfg(test)]
 mod basic_smoke_test;
+
 #[cfg(test)]
 mod ruby_abi_version_test;
+
 #[cfg(all(test, unix, feature = "ruby-macros"))]
 mod ruby_macros_test;
+
+#[cfg(test)]
+mod value_type_test;
+
+#[cfg(test)]
+mod special_consts_test;

--- a/crates/rb-sys-tests/src/ruby_macros_test.rs
+++ b/crates/rb-sys-tests/src/ruby_macros_test.rs
@@ -2,37 +2,6 @@ use rb_sys::macros::*;
 use rb_sys::*;
 use std::{slice, str};
 
-macro_rules! rstring {
-    ($s:expr) => {
-        unsafe { rb_str_new($s.as_ptr() as _, $s.len() as _) }
-    };
-}
-
-#[cfg(not(windows_broken_vm_init_3_1))]
-#[test]
-fn test_symbol_p() {
-    let name = std::ffi::CString::new("foo").unwrap();
-    let ptr = name.as_ptr();
-    let symbol = unsafe { rb_intern(ptr) };
-    let sym = unsafe { ID2SYM(symbol) };
-
-    assert!(unsafe { SYMBOL_P(sym) });
-}
-
-#[test]
-fn test_integer_type_p() {
-    let int = unsafe { rb_num2fix(1) };
-
-    assert!(unsafe { RB_INTEGER_TYPE_P(int) });
-}
-
-#[test]
-fn test_rb_float_type_p() {
-    let float = unsafe { rb_float_new(1.0) };
-
-    assert!(unsafe { RB_FLOAT_TYPE_P(float) });
-}
-
 #[cfg(not(windows_broken_vm_init_3_1))]
 #[test]
 fn test_rstring_len() {

--- a/crates/rb-sys-tests/src/ruby_macros_test.rs
+++ b/crates/rb-sys-tests/src/ruby_macros_test.rs
@@ -8,16 +8,6 @@ macro_rules! rstring {
     };
 }
 
-#[test]
-fn test_nil_p() {
-    assert!(unsafe { NIL_P(Qnil as u64) });
-}
-
-#[test]
-fn test_rb_test() {
-    assert!(!unsafe { RB_TEST(Qnil as u64) });
-}
-
 #[cfg(not(windows_broken_vm_init_3_1))]
 #[test]
 fn test_symbol_p() {

--- a/crates/rb-sys-tests/src/special_consts_test.rs
+++ b/crates/rb-sys-tests/src/special_consts_test.rs
@@ -1,0 +1,37 @@
+use rb_sys::special_consts::*;
+use rb_sys::*;
+
+#[cfg(not(windows_broken_vm_init_3_1))]
+#[test]
+fn test_fixnum_p() {
+    unsafe {
+        let int = rb_num2fix(1);
+        let big = rb_int2big(isize::MAX);
+
+        assert!(FIXNUM_P(int));
+        assert!(!FIXNUM_P(big));
+    }
+}
+
+#[cfg(not(windows_broken_vm_init_3_1))]
+#[test]
+fn test_static_sym_p() {
+    unsafe {
+        let id = rb_intern_str(rstring!("foo"));
+        let sym = rb_id2sym(id);
+
+        assert!(STATIC_SYM_P(sym));
+        assert!(!STATIC_SYM_P(Qnil));
+    }
+}
+
+#[cfg(not(windows_broken_vm_init_3_1))]
+#[test]
+fn test_flonum_p() {
+    unsafe {
+        let flonum = rb_float_new(0.0);
+
+        assert!(FLONUM_P(flonum));
+        assert!(!FLONUM_P(Qnil));
+    }
+}

--- a/crates/rb-sys-tests/src/special_consts_test.rs
+++ b/crates/rb-sys-tests/src/special_consts_test.rs
@@ -6,7 +6,7 @@ use rb_sys::*;
 fn test_fixnum_p() {
     unsafe {
         let int = rb_num2fix(1);
-        let big = rb_int2big(isize::MAX);
+        let big = rb_int2big(9999999);
 
         assert!(FIXNUM_P(int));
         assert!(!FIXNUM_P(big));

--- a/crates/rb-sys-tests/src/value_type_test.rs
+++ b/crates/rb-sys-tests/src/value_type_test.rs
@@ -1,0 +1,63 @@
+use rb_sys::value_type::*;
+use rb_sys::*;
+
+#[cfg(not(windows_broken_vm_init_3_1))]
+#[test]
+fn test_builtin_type_p() {
+    unsafe {
+        let val = rstring!("foo");
+
+        assert_eq!(RB_BUILTIN_TYPE(val), RUBY_T_STRING);
+    }
+}
+
+#[cfg(not(windows_broken_vm_init_3_1))]
+#[test]
+fn test_rb_integer_type_p() {
+    unsafe {
+        let int = rb_num2fix(1);
+        let big = rb_int2big(isize::MAX);
+
+        assert!(RB_INTEGER_TYPE_P(int));
+        assert!(RB_INTEGER_TYPE_P(big));
+        assert!(!RB_INTEGER_TYPE_P(Qnil as VALUE));
+    }
+}
+
+#[cfg(not(windows_broken_vm_init_3_1))]
+#[test]
+fn test_rb_dynamic_sym_p() {
+    unsafe {
+        let id = rb_intern_str(rstring!("foo"));
+        let static_sym = rb_id2sym(id);
+        let sym = rb_to_symbol(rstring!("foobar"));
+
+        assert!(!RB_DYNAMIC_SYM_P(static_sym));
+        assert!(RB_DYNAMIC_SYM_P(sym));
+    }
+}
+
+#[cfg(not(windows_broken_vm_init_3_1))]
+#[test]
+fn test_rb_symbol_p() {
+    unsafe {
+        let id = rb_intern_str(rstring!("foo"));
+        let static_sym = rb_id2sym(id);
+        let sym = rb_to_symbol(rstring!("foobar"));
+
+        assert!(RB_SYMBOL_P(static_sym));
+        assert!(RB_SYMBOL_P(sym));
+    }
+}
+
+#[cfg(not(windows_broken_vm_init_3_1))]
+#[test]
+fn test_rb_type_p() {
+    unsafe {
+        assert_eq!(RB_TYPE_P(rstring!("foo")), RUBY_T_STRING);
+        assert_eq!(RB_TYPE_P(rb_to_symbol(rstring!("foo"))), RUBY_T_SYMBOL);
+        assert_eq!(RB_TYPE_P(Qnil), RUBY_T_NIL);
+        assert_eq!(RB_TYPE_P(Qtrue), RUBY_T_TRUE);
+        assert_eq!(RB_TYPE_P(Qfalse), RUBY_T_FALSE);
+    }
+}

--- a/crates/rb-sys-tests/src/value_type_test.rs
+++ b/crates/rb-sys-tests/src/value_type_test.rs
@@ -16,7 +16,7 @@ fn test_builtin_type_p() {
 fn test_rb_integer_type_p() {
     unsafe {
         let int = rb_num2fix(1);
-        let big = rb_int2big(isize::MAX);
+        let big = rb_int2big(9999999);
 
         assert!(RB_INTEGER_TYPE_P(int));
         assert!(RB_INTEGER_TYPE_P(big));

--- a/crates/rb-sys/build/bindings.rs
+++ b/crates/rb-sys/build/bindings.rs
@@ -69,7 +69,7 @@ fn clean_docs() {
             }
 
             // Remove anything cargo thinks is executable
-            outline = outline.replace("`", "");
+            outline = outline.replace('`', "");
 
             outfile.write_all(outline.as_bytes()).unwrap();
         }

--- a/crates/rb-sys/build/bindings.rs
+++ b/crates/rb-sys/build/bindings.rs
@@ -68,6 +68,9 @@ fn clean_docs() {
                 );
             }
 
+            // Remove anything cargo thinks is executable
+            outline = outline.replace("`", "");
+
             outfile.write_all(outline.as_bytes()).unwrap();
         }
 

--- a/crates/rb-sys/src/lib.rs
+++ b/crates/rb-sys/src/lib.rs
@@ -2,6 +2,7 @@ pub mod bindings;
 #[cfg(feature = "ruby-macros")]
 pub mod macros;
 pub mod special_consts;
+pub mod value_type;
 
 #[cfg(use_global_allocator)]
 mod allocator;
@@ -12,6 +13,7 @@ pub use allocator::*;
 pub use bindings::*;
 pub use ruby_abi_version::*;
 pub use special_consts::*;
+pub use value_type::*;
 
 pub type Value = VALUE;
 pub type RubyValue = VALUE;

--- a/crates/rb-sys/src/macros/mod.rs
+++ b/crates/rb-sys/src/macros/mod.rs
@@ -6,48 +6,9 @@
 
 use std::os::raw::{c_char, c_long};
 
-use crate::{ruby_value_type, ID, VALUE};
+use crate::{ID, VALUE};
 
 extern "C" {
-
-    /// Queries if the given object is of given type.
-    ///
-    /// @param[in]  obj    An object.
-    /// @param[in]  t      A type.
-    /// @retval     true   `obj` is of type `t`.
-    /// @retval     false  Otherwise.
-    ///
-    /// @internal
-    ///
-    /// This  function is  a super-duper  hot  path.  Optimised  targeting modern  C
-    /// compilers and x86_64 architecture.
-    #[link_name = "ruby_macros_RB_TYPE_P"]
-    pub fn RB_TYPE_P(obj: VALUE, t: ruby_value_type) -> bool;
-
-    /// Queries if the object is an instance of ::ruby_macros_cInteger.
-    ///
-    /// @param[in]  obj    Object in question.
-    /// @retval     true   It is.
-    /// @retval     false  It isn't.
-    #[link_name = "ruby_macros_RB_INTEGER_TYPE_P"]
-    pub fn RB_INTEGER_TYPE_P(obj: VALUE) -> bool;
-
-    /// Queries if the object is an instance of ::ruby_macros_cFloat.
-    ///
-    /// @param[in]  obj    Object in question.
-    /// @retval     true   It is.
-    /// @retval     false  It isn't.
-    #[link_name = "ruby_macros_RB_FLOAT_TYPE_P"]
-    pub fn RB_FLOAT_TYPE_P(obj: VALUE) -> bool;
-
-    /// Queries if the object is an instance of ::ruby_macros_cSymbol.
-    ///
-    /// @param[in]  obj    Object in question.
-    /// @retval     true   It is.
-    /// @retval     false  It isn't.
-    #[link_name = "ruby_macros_SYMBOL_P"]
-    pub fn SYMBOL_P(obj: VALUE) -> bool;
-
     /// Allocates an instance of ::rb_cSymbol that has the given id.
     ///
     /// @param[in]  id           An id.

--- a/crates/rb-sys/src/macros/mod.rs
+++ b/crates/rb-sys/src/macros/mod.rs
@@ -48,27 +48,6 @@ extern "C" {
     #[link_name = "ruby_macros_SYMBOL_P"]
     pub fn SYMBOL_P(obj: VALUE) -> bool;
 
-    /// Checks if the given object is nil.
-    ///
-    /// @param[in]  obj    An arbitrary ruby object.
-    /// @retval     true   `obj` is ::Qnil.
-    /// @retval     false  Anything else.
-    #[link_name = "ruby_macros_NIL_P"]
-    pub fn NIL_P(obj: VALUE) -> bool;
-
-    /// Emulates Ruby's "if" statement.
-    ///
-    /// @param[in]  obj    An arbitrary ruby object.
-    /// @retval     false  `obj` is either ::Qfalse or ::Qnil.
-    /// @retval     true   Anything else.
-    ///
-    /// @internal
-    ///
-    /// It HAS to be `__attribute__((const))` in  order for clang to properly deduce
-    /// `__builtin_assume()`.
-    #[link_name = "ruby_macros_RB_TEST"]
-    pub fn RB_TEST(obj: VALUE) -> bool;
-
     /// Allocates an instance of ::rb_cSymbol that has the given id.
     ///
     /// @param[in]  id           An id.

--- a/crates/rb-sys/src/macros/ruby_macros.c
+++ b/crates/rb-sys/src/macros/ruby_macros.c
@@ -5,14 +5,6 @@
 #define RB_INTEGER_TYPE_P(c) (FIXNUM_P(c) || RB_TYPE_P(c, T_BIGNUM))
 #endif
 
-#ifndef RB_NIL_P
-#define RB_NIL_P(c) NIL_P(c)
-#endif
-
-#ifndef RB_TEST
-#define RB_TEST(c) RTEST(c)
-#endif
-
 bool ruby_macros_RB_TYPE_P(VALUE obj, enum ruby_value_type t)
 {
   return RB_TYPE_P(obj, (int)t);
@@ -31,16 +23,6 @@ bool ruby_macros_SYMBOL_P(VALUE obj)
 bool ruby_macros_RB_FLOAT_TYPE_P(VALUE obj)
 {
   return RB_FLOAT_TYPE_P(obj);
-}
-
-bool ruby_macros_NIL_P(VALUE obj)
-{
-  return RB_NIL_P(obj);
-}
-
-bool ruby_macros_RB_TEST(VALUE obj)
-{
-  return RB_TEST(obj);
 }
 
 VALUE

--- a/crates/rb-sys/src/macros/ruby_macros.c
+++ b/crates/rb-sys/src/macros/ruby_macros.c
@@ -1,30 +1,6 @@
 #include "ruby.h"
 #include "stdbool.h"
 
-#ifndef RB_INTEGER_TYPE_P
-#define RB_INTEGER_TYPE_P(c) (FIXNUM_P(c) || RB_TYPE_P(c, T_BIGNUM))
-#endif
-
-bool ruby_macros_RB_TYPE_P(VALUE obj, enum ruby_value_type t)
-{
-  return RB_TYPE_P(obj, (int)t);
-};
-
-bool ruby_macros_RB_INTEGER_TYPE_P(VALUE obj)
-{
-  return RB_INTEGER_TYPE_P(obj);
-}
-
-bool ruby_macros_SYMBOL_P(VALUE obj)
-{
-  return SYMBOL_P(obj);
-}
-
-bool ruby_macros_RB_FLOAT_TYPE_P(VALUE obj)
-{
-  return RB_FLOAT_TYPE_P(obj);
-}
-
 VALUE
 ruby_macros_ID2SYM(ID obj)
 {

--- a/crates/rb-sys/src/special_consts.rs
+++ b/crates/rb-sys/src/special_consts.rs
@@ -18,6 +18,7 @@ pub const FLONUM_MASK: ruby_special_consts = ruby_special_consts::RUBY_FLONUM_MA
 pub const FLONUM_FLAG: ruby_special_consts = ruby_special_consts::RUBY_FLONUM_FLAG;
 pub const SYMBOL_FLAG: ruby_special_consts = ruby_special_consts::RUBY_SYMBOL_FLAG;
 
+#[allow(clippy::from_over_into)]
 impl Into<VALUE> for ruby_special_consts {
     fn into(self) -> VALUE {
         self as VALUE

--- a/crates/rb-sys/src/special_consts.rs
+++ b/crates/rb-sys/src/special_consts.rs
@@ -33,9 +33,9 @@ impl Into<VALUE> for ruby_special_consts {
 /// ```
 /// use rb_sys::special_consts::*;
 ///
-/// assert!(!RB_TEST(Qfalse));
-/// assert!(!RB_TEST(Qnil));
-/// assert!(RB_TEST(Qtrue));
+/// assert!(!TEST(Qfalse));
+/// assert!(!TEST(Qnil));
+/// assert!(TEST(Qtrue));
 /// ```
 #[inline(always)]
 pub fn TEST<T: Into<VALUE>>(obj: T) -> bool {
@@ -51,8 +51,8 @@ pub fn TEST<T: Into<VALUE>>(obj: T) -> bool {
 /// ```
 /// use rb_sys::special_consts::*;
 ///
-/// assert!(RB_NIL_P(Qnil));
-/// assert!(!RB_NIL_P(Qtrue));
+/// assert!(NIL_P(Qnil));
+/// assert!(!NIL_P(Qtrue));
 /// ```
 #[inline(always)]
 pub fn NIL_P<T: Into<VALUE>>(obj: T) -> bool {
@@ -81,7 +81,7 @@ pub fn FIXNUM_P<T: Into<VALUE>>(obj: T) -> bool {
 /// @note       These days  there are static  and dynamic symbols, just  like we
 ///             once had Fixnum/Bignum back in the old days.
 pub fn STATIC_SYM_P<T: Into<VALUE>>(obj: T) -> bool {
-    (obj.into() & VALUE::MAX) == SYMBOL_FLAG as VALUE
+    (obj.into() & 0xff) == SYMBOL_FLAG as VALUE
 }
 
 /// Checks if the given object is a so-called Flonum.
@@ -119,9 +119,9 @@ pub fn IMMEDIATE_P<T: Into<VALUE>>(obj: T) -> bool {
 /// ```
 /// use rb_sys::special_consts::*;
 ///
-/// assert!(RB_SPECIAL_CONST_P(Qnil));
-/// assert!(RB_SPECIAL_CONST_P(Qtrue));
-/// assert!(RB_SPECIAL_CONST_P(Qfalse));
+/// assert!(SPECIAL_CONST_P(Qnil));
+/// assert!(SPECIAL_CONST_P(Qtrue));
+/// assert!(SPECIAL_CONST_P(Qfalse));
 /// ```
 #[inline(always)]
 pub fn SPECIAL_CONST_P<T: Into<VALUE>>(obj: T) -> bool {

--- a/crates/rb-sys/src/special_consts.rs
+++ b/crates/rb-sys/src/special_consts.rs
@@ -4,8 +4,9 @@
 //! around in bindgen's output.
 
 #![allow(non_upper_case_globals)]
+#![allow(non_snake_case)]
 
-use crate::ruby_special_consts;
+use crate::{ruby_special_consts, VALUE};
 
 pub const Qfalse: ruby_special_consts = ruby_special_consts::RUBY_Qfalse;
 pub const Qtrue: ruby_special_consts = ruby_special_consts::RUBY_Qtrue;
@@ -16,3 +17,117 @@ pub const FIXNUM_FLAG: ruby_special_consts = ruby_special_consts::RUBY_FIXNUM_FL
 pub const FLONUM_MASK: ruby_special_consts = ruby_special_consts::RUBY_FLONUM_MASK;
 pub const FLONUM_FLAG: ruby_special_consts = ruby_special_consts::RUBY_FLONUM_FLAG;
 pub const SYMBOL_FLAG: ruby_special_consts = ruby_special_consts::RUBY_SYMBOL_FLAG;
+
+impl Into<VALUE> for ruby_special_consts {
+    fn into(self) -> VALUE {
+        self as VALUE
+    }
+}
+
+/// Emulates Ruby's "if" statement.
+///
+/// @param[in]  obj    An arbitrary ruby object.
+/// @retval     false  `obj` is either ::RUBY_Qfalse or ::RUBY_Qnil.
+/// @retval     true   Anything else.
+///
+/// ```
+/// use rb_sys::special_consts::*;
+///
+/// assert!(!RB_TEST(Qfalse));
+/// assert!(!RB_TEST(Qnil));
+/// assert!(RB_TEST(Qtrue));
+/// ```
+#[inline(always)]
+pub fn TEST<T: Into<VALUE>>(obj: T) -> bool {
+    (obj.into() & !(Qnil as VALUE)) != 0
+}
+
+/// Checks if the given object is nil.
+///
+/// @param[in]  obj    An arbitrary ruby object.
+/// @retval     true   `obj` is ::RUBY_Qnil.
+/// @retval     false  Anything else.
+///
+/// ```
+/// use rb_sys::special_consts::*;
+///
+/// assert!(RB_NIL_P(Qnil));
+/// assert!(!RB_NIL_P(Qtrue));
+/// ```
+#[inline(always)]
+pub fn NIL_P<T: Into<VALUE>>(obj: T) -> bool {
+    obj.into() == (Qnil as VALUE)
+}
+
+/// Checks if the given object is a so-called Fixnum.
+///
+/// @param[in]  obj    An arbitrary ruby object.
+/// @retval     true   `obj` is a Fixnum.
+/// @retval     false  Anything else.
+/// @note       Fixnum was  a thing  in the  20th century, but  it is  rather an
+///             implementation detail today.
+#[inline(always)]
+pub fn FIXNUM_P<T: Into<VALUE>>(obj: T) -> bool {
+    (obj.into() & FIXNUM_FLAG as VALUE) != 0
+}
+
+/// Checks if the given object is a static symbol.
+///
+/// @param[in]  obj    An arbitrary ruby object.
+/// @retval     true   `obj` is a static symbol
+/// @retval     false  Anything else.
+/// @see        RB_DYNAMIC_SYM_P()
+/// @see        RB_SYMBOL_P()
+/// @note       These days  there are static  and dynamic symbols, just  like we
+///             once had Fixnum/Bignum back in the old days.
+pub fn STATIC_SYM_P<T: Into<VALUE>>(obj: T) -> bool {
+    (obj.into() & VALUE::MAX) == SYMBOL_FLAG as VALUE
+}
+
+/// Checks if the given object is a so-called Flonum.
+///
+/// @param[in]  obj    An arbitrary ruby object.
+/// @retval     true   `obj` is a Flonum.
+/// @retval     false  Anything else.
+/// @see        RB_FLOAT_TYPE_P()
+/// @note       These days there are Flonums and non-Flonum floats, just like we
+///             once had Fixnum/Bignum back in the old days.
+#[inline(always)]
+pub fn FLONUM_P<T: Into<VALUE>>(obj: T) -> bool {
+    (obj.into() & (FLONUM_MASK as VALUE)) == FLONUM_FLAG as VALUE
+}
+
+/// Checks if  the given  object is  an immediate  i.e. an  object which  has no
+/// corresponding storage inside of the object space.
+///
+/// @param[in]  obj    An arbitrary ruby object.
+/// @retval     true   `obj` is a Flonum.
+/// @retval     false  Anything else.
+/// @see        RB_FLOAT_TYPE_P()
+/// @note       The concept of "immediate" is purely C specific.
+#[inline(always)]
+pub fn IMMEDIATE_P<T: Into<VALUE>>(obj: T) -> bool {
+    obj.into() & (IMMEDIATE_MASK as VALUE) != 0
+}
+
+/// Checks if the given object is of enum ::ruby_special_consts.
+///
+/// @param[in]  obj    An arbitrary ruby object.
+/// @retval     true   `obj` is a special constant.
+/// @retval     false  Anything else.
+///
+/// ```
+/// use rb_sys::special_consts::*;
+///
+/// assert!(RB_SPECIAL_CONST_P(Qnil));
+/// assert!(RB_SPECIAL_CONST_P(Qtrue));
+/// assert!(RB_SPECIAL_CONST_P(Qfalse));
+/// ```
+#[inline(always)]
+pub fn SPECIAL_CONST_P<T: Into<VALUE>>(obj: T) -> bool {
+    let value: VALUE = obj.into();
+    let is_immediate = value & (IMMEDIATE_MASK as VALUE) != 0;
+    let test = (value & !(Qnil as VALUE)) != 0;
+
+    is_immediate || !test
+}

--- a/crates/rb-sys/src/value_type.rs
+++ b/crates/rb-sys/src/value_type.rs
@@ -1,0 +1,118 @@
+//! Definitions for Ruby's special constants.
+//!
+//! Makes it easier to reference important Ruby constants, without havign to dig
+//! around in bindgen's output.
+
+#![allow(non_upper_case_globals)]
+#![allow(non_snake_case)]
+
+use std::convert::TryInto;
+
+use crate::{
+    ruby_value_type::{self, RUBY_T_MASK},
+    Qfalse, Qnil, Qtrue, Qundef, RBasic, FIXNUM_P, FLONUM_P, SPECIAL_CONST_P, STATIC_SYM_P, VALUE,
+};
+
+pub use ruby_value_type::*;
+
+/// Queries the type of the object.
+///
+/// @param[in]  obj  Object in question.
+/// @pre        `obj` must not be a special constant.
+/// @return     The type of `obj`.
+#[inline(always)]
+pub unsafe fn RB_BUILTIN_TYPE(obj: VALUE) -> ruby_value_type {
+    debug_assert!(!SPECIAL_CONST_P(obj));
+
+    let rbasic = obj as *const RBasic;
+
+    let ret = (*rbasic).flags & RUBY_T_MASK as VALUE;
+    let ret: u32 = ret.try_into().unwrap();
+
+    std::mem::transmute::<_, ruby_value_type>(ret)
+}
+
+/// Queries if the object is an instance of ::rb_cInteger.
+///
+/// @param[in]  obj    Object in question.
+/// @retval     true   It is.
+/// @retval     false  It isn't.
+#[inline(always)]
+pub unsafe fn RB_INTEGER_TYPE_P(obj: VALUE) -> bool {
+    if FIXNUM_P(obj) {
+        true
+    } else if SPECIAL_CONST_P(obj) {
+        false
+    } else {
+        RB_BUILTIN_TYPE(obj) == RUBY_T_BIGNUM
+    }
+}
+
+/// Queries if the object is a dynamic symbol.
+///
+/// @param[in]  obj    Object in question.
+/// @retval     true   It is.
+/// @retval     false  It isn't.
+#[inline(always)]
+pub unsafe fn RB_DYNAMIC_SYM_P(obj: VALUE) -> bool {
+    if SPECIAL_CONST_P(obj) {
+        false
+    } else {
+        RB_BUILTIN_TYPE(obj) == RUBY_T_SYMBOL
+    }
+}
+
+/// Queries if the object is an instance of ::rb_cSymbol.
+///
+/// @param[in]  obj    Object in question.
+/// @retval     true   It is.
+/// @retval     false  It isn't.
+#[inline(always)]
+pub unsafe fn RB_SYMBOL_P(obj: VALUE) -> bool {
+    return STATIC_SYM_P(obj) || RB_DYNAMIC_SYM_P(obj);
+}
+
+/// Identical to RB_BUILTIN_TYPE(), except it can also accept special constants.
+///
+/// @param[in]  obj  Object in question.
+/// @return     The type of `obj`.
+#[inline(always)]
+pub unsafe fn RB_TYPE_P<T: Into<VALUE>>(value: T) -> ruby_value_type {
+    let obj = value.into();
+
+    if !SPECIAL_CONST_P(obj) {
+        return RB_BUILTIN_TYPE(obj);
+    } else if obj == Qfalse as VALUE {
+        return RUBY_T_FALSE;
+    } else if obj == Qnil as VALUE {
+        return RUBY_T_NIL;
+    } else if obj == Qtrue as VALUE {
+        return RUBY_T_TRUE;
+    } else if obj == Qundef as VALUE {
+        return RUBY_T_UNDEF;
+    } else if FIXNUM_P(obj) {
+        return RUBY_T_FIXNUM;
+    } else if STATIC_SYM_P(obj) {
+        return RUBY_T_SYMBOL;
+    } else {
+        debug_assert!(FLONUM_P(obj));
+        return RUBY_T_FLOAT;
+    }
+}
+
+/**
+ * Queries if the object is an instance of ::rb_cFloat.
+ *
+ * @param[in]  obj    Object in question.
+ * @retval     true   It is.
+ * @retval     false  It isn't.
+ */
+pub unsafe fn RB_FLOAT_TYPE_P(obj: VALUE) -> bool {
+    if FLONUM_P(obj) {
+        return true;
+    } else if SPECIAL_CONST_P(obj) {
+        return false;
+    } else {
+        return RB_BUILTIN_TYPE(obj) == RUBY_T_FLOAT;
+    }
+}

--- a/crates/rb-sys/src/value_type.rs
+++ b/crates/rb-sys/src/value_type.rs
@@ -20,6 +20,10 @@ pub use ruby_value_type::*;
 /// @param[in]  obj  Object in question.
 /// @pre        `obj` must not be a special constant.
 /// @return     The type of `obj`.
+///
+/// # Safety
+/// This function is unsafe because it could dereference a raw pointer when
+/// attemping to access the underlying [`RBasic`] struct.
 #[inline(always)]
 pub unsafe fn RB_BUILTIN_TYPE(obj: VALUE) -> ruby_value_type {
     debug_assert!(!SPECIAL_CONST_P(obj));
@@ -37,6 +41,10 @@ pub unsafe fn RB_BUILTIN_TYPE(obj: VALUE) -> ruby_value_type {
 /// @param[in]  obj    Object in question.
 /// @retval     true   It is.
 /// @retval     false  It isn't.
+///
+/// # Safety
+/// This function is unsafe because it could dereference a raw pointer when
+/// attemping to access the underlying [`RBasic`] struct.
 #[inline(always)]
 pub unsafe fn RB_INTEGER_TYPE_P(obj: VALUE) -> bool {
     if FIXNUM_P(obj) {
@@ -53,6 +61,10 @@ pub unsafe fn RB_INTEGER_TYPE_P(obj: VALUE) -> bool {
 /// @param[in]  obj    Object in question.
 /// @retval     true   It is.
 /// @retval     false  It isn't.
+///
+/// # Safety
+/// This function is unsafe because it could dereference a raw pointer when
+/// attemping to access the underlying [`RBasic`] struct.
 #[inline(always)]
 pub unsafe fn RB_DYNAMIC_SYM_P(obj: VALUE) -> bool {
     if SPECIAL_CONST_P(obj) {
@@ -67,52 +79,62 @@ pub unsafe fn RB_DYNAMIC_SYM_P(obj: VALUE) -> bool {
 /// @param[in]  obj    Object in question.
 /// @retval     true   It is.
 /// @retval     false  It isn't.
+///
+/// # Safety
+/// This function is unsafe because it could dereference a raw pointer when
+/// attemping to access the underlying [`RBasic`] struct.
 #[inline(always)]
 pub unsafe fn RB_SYMBOL_P(obj: VALUE) -> bool {
-    return STATIC_SYM_P(obj) || RB_DYNAMIC_SYM_P(obj);
+    STATIC_SYM_P(obj) || RB_DYNAMIC_SYM_P(obj)
 }
 
 /// Identical to RB_BUILTIN_TYPE(), except it can also accept special constants.
 ///
 /// @param[in]  obj  Object in question.
 /// @return     The type of `obj`.
+///
+/// # Safety
+/// This function is unsafe because it could dereference a raw pointer when
+/// attemping to access the underlying [`RBasic`] struct.
 #[inline(always)]
 pub unsafe fn RB_TYPE_P<T: Into<VALUE>>(value: T) -> ruby_value_type {
     let obj = value.into();
 
     if !SPECIAL_CONST_P(obj) {
-        return RB_BUILTIN_TYPE(obj);
+        RB_BUILTIN_TYPE(obj)
     } else if obj == Qfalse as VALUE {
-        return RUBY_T_FALSE;
+        RUBY_T_FALSE
     } else if obj == Qnil as VALUE {
-        return RUBY_T_NIL;
+        RUBY_T_NIL
     } else if obj == Qtrue as VALUE {
-        return RUBY_T_TRUE;
+        RUBY_T_TRUE
     } else if obj == Qundef as VALUE {
-        return RUBY_T_UNDEF;
+        RUBY_T_UNDEF
     } else if FIXNUM_P(obj) {
-        return RUBY_T_FIXNUM;
+        RUBY_T_FIXNUM
     } else if STATIC_SYM_P(obj) {
-        return RUBY_T_SYMBOL;
+        RUBY_T_SYMBOL
     } else {
         debug_assert!(FLONUM_P(obj));
-        return RUBY_T_FLOAT;
+        RUBY_T_FLOAT
     }
 }
 
-/**
- * Queries if the object is an instance of ::rb_cFloat.
- *
- * @param[in]  obj    Object in question.
- * @retval     true   It is.
- * @retval     false  It isn't.
- */
+/// Queries if the object is an instance of ::rb_cFloat.
+///
+/// @param[in]  obj    Object in question.
+/// @retval     true   It is.
+/// @retval     false  It isn't.
+///
+/// # Safety
+/// This function is unsafe because it could dereference a raw pointer when
+/// attemping to access the underlying [`RBasic`] struct.
 pub unsafe fn RB_FLOAT_TYPE_P(obj: VALUE) -> bool {
     if FLONUM_P(obj) {
-        return true;
+        true
     } else if SPECIAL_CONST_P(obj) {
-        return false;
+        false
     } else {
-        return RB_BUILTIN_TYPE(obj) == RUBY_T_FLOAT;
+        RB_BUILTIN_TYPE(obj) == RUBY_T_FLOAT
     }
 }


### PR DESCRIPTION
In order to benefit from Rust compiler optimizations, this PR adds Rust functions to reimplement the equivalent `static inline` functions from `value_type.h` and `special_consts.h`.