### PR TITLE
Implement `RARRAY_LEN` and `RARRAY_PTR` in Rust

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -41,6 +41,7 @@ runs:
     - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ inputs.rust_toolchain }}
+        components: clippy, rustfmt
     - name: Fix clang dep for rust-bindgen (see https://github.com/rubygems/rubygems/pull/5175#discussion_r794873977)
       if: ${{ contains(inputs.os, 'windows') }}
       shell: bash

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -38,10 +38,9 @@ runs:
           target/
           examples/rust_reverse/tmp/
         key: ${{ inputs.os }}-${{ inputs.ruby_version }}-${{ inputs.rust_toolchain }}-cargo-v4-${{ hashFiles('**/Cargo.lock', '**/extconf.rb') }}
-    - uses: actions-rs/toolchain@v1
+    - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ inputs.rust_toolchain }}
-        default: true
     - name: Fix clang dep for rust-bindgen (see https://github.com/rubygems/rubygems/pull/5175#discussion_r794873977)
       if: ${{ contains(inputs.os, 'windows') }}
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,15 +18,10 @@ jobs:
           rust_toolchain: stable
           ruby_version: "3.1"
           os: ubuntu-latest
-      - uses: actions-rs/cargo@v1
-        name: ✂️ Run clippy
-        with:
-          command: clippy
-      - uses: actions-rs/cargo@v1
-        name: 📃 Run cargo fmt
-        with:
-          command: fmt
-          args: --check
+      - name: ✂️ Run clippy
+        run: cargo clippy || true
+      - name: 📃 Run cargo fmt
+        run: cargo fmt --check
       - name: 🚓 Run Standard.rb
         run: bundle exec standardrb --format github
 

--- a/crates/rb-sys-tests/src/lib.rs
+++ b/crates/rb-sys-tests/src/lib.rs
@@ -41,3 +41,6 @@ mod value_type_test;
 
 #[cfg(test)]
 mod special_consts_test;
+
+#[cfg(test)]
+mod rarray_test;

--- a/crates/rb-sys-tests/src/rarray_test.rs
+++ b/crates/rb-sys-tests/src/rarray_test.rs
@@ -1,0 +1,24 @@
+use rb_sys::*;
+
+#[cfg(not(windows_broken_vm_init_3_1))]
+#[test]
+fn test_rarray_len_small() {
+    let rstr: VALUE = rstring!("foo");
+    let rarray = unsafe { rb_ary_new() };
+    unsafe { rb_ary_push(rarray, rstr) };
+
+    assert_eq!(unsafe { RARRAY_LEN(rarray) }, 1);
+}
+
+#[cfg(not(windows_broken_vm_init_3_1))]
+#[test]
+fn test_rarray_len_large() {
+    let rarray = unsafe { rb_ary_new() };
+
+    for _ in (0..100).into_iter() {
+        let rstr: VALUE = rstring!("foo");
+        unsafe { rb_ary_push(rarray, rstr) };
+    }
+
+    assert_eq!(unsafe { RARRAY_LEN(rarray) }, 100);
+}

--- a/crates/rb-sys-tests/src/ruby_macros_test.rs
+++ b/crates/rb-sys-tests/src/ruby_macros_test.rs
@@ -12,16 +12,6 @@ fn test_rstring_len() {
 
 #[cfg(not(windows_broken_vm_init_3_1))]
 #[test]
-fn test_rarray_len() {
-    let rstr: VALUE = rstring!("foo");
-    let rarray = unsafe { rb_ary_new() };
-    unsafe { rb_ary_push(rarray, rstr) };
-
-    assert_eq!(unsafe { RARRAY_LEN(rarray) }, 1);
-}
-
-#[cfg(not(windows_broken_vm_init_3_1))]
-#[test]
 fn test_rstring_ptr() {
     let rstr = rstring!("foo");
 

--- a/crates/rb-sys/build/bindings.rs
+++ b/crates/rb-sys/build/bindings.rs
@@ -32,9 +32,7 @@ pub fn generate(rbconfig: &RbConfig) {
     let bindings = if cfg!(feature = "bindgen-deprecated-types") {
         bindings
     } else {
-        bindings
-            .blocklist_item("^ruby_fl_type.*")
-            .blocklist_item("^_bindgen_ty_9.*")
+        bindings.blocklist_item("^_bindgen_ty_9.*")
     };
 
     write_bindings(bindings, "bindings-raw.rs");

--- a/crates/rb-sys/build/main.rs
+++ b/crates/rb-sys/build/main.rs
@@ -125,36 +125,86 @@ fn export_cargo_cfg(rbconfig: &mut RbConfig) {
         if &version < v {
             println!(r#"cargo:rustc-cfg=ruby_lt_{}_{}"#, v.major(), v.minor());
             println!(r#"cargo:version_lt_{}_{}=true"#, v.major(), v.minor());
+            println!(
+                "cargo:rustc-cfg=version_lt_{}_{}=\"true\"",
+                v.major(),
+                v.minor()
+            );
         } else {
             println!(r#"cargo:version_lt_{}_{}=false"#, v.major(), v.minor());
+            println!(
+                "cargo:rustc-cfg=version_lt_{}_{}=\"false\"",
+                v.major(),
+                v.minor()
+            );
         }
 
         if &version <= v {
             println!(r#"cargo:rustc-cfg=ruby_lte_{}_{}"#, v.major(), v.minor());
             println!(r#"cargo:version_lte_{}_{}=true"#, v.major(), v.minor());
+            println!(
+                "cargo:rustc-cfg=version_lte_{}_{}=\"true\"",
+                v.major(),
+                v.minor()
+            );
         } else {
             println!(r#"cargo:version_lte_{}_{}=false"#, v.major(), v.minor());
+            println!(
+                "cargo:rustc-cfg=version_lte_{}_{}=\"false\"",
+                v.major(),
+                v.minor()
+            );
         }
 
         if &version == v {
             println!(r#"cargo:rustc-cfg=ruby_eq_{}_{}"#, v.major(), v.minor());
             println!(r#"cargo:version_eq_{}_{}=true"#, v.major(), v.minor());
+            println!(
+                "cargo:rustc-cfg=version_eq_{}_{}=\"true\"",
+                v.major(),
+                v.minor()
+            );
         } else {
             println!(r#"cargo:version_eq_{}_{}=false"#, v.major(), v.minor());
+            println!(
+                "cargo:rustc-cfg=version_eq_{}_{}=\"false\"",
+                v.major(),
+                v.minor()
+            );
         }
 
         if &version >= v {
             println!(r#"cargo:rustc-cfg=ruby_gte_{}_{}"#, v.major(), v.minor());
             println!(r#"cargo:version_gte_{}_{}=true"#, v.major(), v.minor());
+            println!(
+                "cargo:rustc-cfg=version_gte_{}_{}=\"true\"",
+                v.major(),
+                v.minor()
+            );
         } else {
             println!(r#"cargo:version_gte_{}_{}=false"#, v.major(), v.minor());
+            println!(
+                "cargo:rustc-cfg=version_gte_{}_{}=\"false\"",
+                v.major(),
+                v.minor()
+            );
         }
 
         if &version > v {
             println!(r#"cargo:rustc-cfg=ruby_gt_{}_{}"#, v.major(), v.minor());
             println!(r#"cargo:version_gt_{}_{}=true"#, v.major(), v.minor());
+            println!(
+                "cargo:rustc-cfg=version_gt_{}_{}=\"true\"",
+                v.major(),
+                v.minor()
+            );
         } else {
             println!(r#"cargo:version_gt_{}_{}=false"#, v.major(), v.minor());
+            println!(
+                "cargo:rustc-cfg=version_gt_{}_{}=\"false\"",
+                v.major(),
+                v.minor()
+            );
         }
     }
 

--- a/crates/rb-sys/src/assert.rs
+++ b/crates/rb-sys/src/assert.rs
@@ -1,0 +1,19 @@
+/// A macro which asserts the object is a given Ruby type.
+#[macro_export]
+macro_rules! debug_assert_ruby_type {
+    ($obj:expr, $type:expr) => {
+        debug_assert!($crate::RB_BUILTIN_TYPE($obj) == $type);
+    };
+}
+
+/// A macro to assert a Ruby flag is set
+#[macro_export]
+macro_rules! refute_flag {
+    ($flags:expr, $flag:expr) => {
+        assert!(
+            $flags & ($flag as $crate::VALUE) == 0,
+            "{:?} flag was unexpectedly set",
+            stringify!($flag)
+        );
+    };
+}

--- a/crates/rb-sys/src/lib.rs
+++ b/crates/rb-sys/src/lib.rs
@@ -7,6 +7,7 @@ pub mod value_type;
 
 #[cfg(use_global_allocator)]
 mod allocator;
+mod assert;
 mod ruby_abi_version;
 
 #[cfg(use_global_allocator)]

--- a/crates/rb-sys/src/lib.rs
+++ b/crates/rb-sys/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod bindings;
 #[cfg(feature = "ruby-macros")]
 pub mod macros;
+pub mod rarray;
 pub mod special_consts;
 pub mod value_type;
 
@@ -11,6 +12,7 @@ mod ruby_abi_version;
 #[cfg(use_global_allocator)]
 pub use allocator::*;
 pub use bindings::*;
+pub use rarray::*;
 pub use ruby_abi_version::*;
 pub use special_consts::*;
 pub use value_type::*;

--- a/crates/rb-sys/src/macros/mod.rs
+++ b/crates/rb-sys/src/macros/mod.rs
@@ -41,14 +41,6 @@ extern "C" {
     #[link_name = "ruby_macros_RSTRING_LEN"]
     pub fn RSTRING_LEN(obj: VALUE) -> c_long;
 
-    /// Queries the length of the array.
-    ///
-    /// @param[in]  a  Array in question.
-    /// @return     Its number of elements.
-    /// @pre        `a` must be an instance of ::RArray.
-    #[link_name = "ruby_macros_RARRAY_LEN"]
-    pub fn RARRAY_LEN(a: VALUE) -> c_long;
-
     /// Wild  use of  a  C  pointer.  This  function  accesses  the backend  storage
     /// directly.   This is  slower  than  #RARRAY_PTR_USE_TRANSIENT.  It  exercises
     /// extra manoeuvres  to protect our generational  GC.  Use of this  function is

--- a/crates/rb-sys/src/macros/mod.rs
+++ b/crates/rb-sys/src/macros/mod.rs
@@ -41,18 +41,4 @@ extern "C" {
     #[link_name = "ruby_macros_RSTRING_LEN"]
     pub fn RSTRING_LEN(obj: VALUE) -> c_long;
 
-    /// Wild  use of  a  C  pointer.  This  function  accesses  the backend  storage
-    /// directly.   This is  slower  than  #RARRAY_PTR_USE_TRANSIENT.  It  exercises
-    /// extra manoeuvres  to protect our generational  GC.  Use of this  function is
-    /// considered archaic.  Use a modern way instead.
-
-    /// @param[in]  ary  An object of ::RArray.
-    /// @return     The backend C array.
-
-    /// @internal
-
-    /// That said...  there are  extension libraries  in the wild  who uses  it.  We
-    /// cannot but continue supporting.
-    #[link_name = "ruby_macros_RARRAY_PTR"]
-    pub fn RARRAY_PTR(a: VALUE) -> *const VALUE;
 }

--- a/crates/rb-sys/src/macros/ruby_macros.c
+++ b/crates/rb-sys/src/macros/ruby_macros.c
@@ -22,9 +22,3 @@ long ruby_macros_RSTRING_LEN(VALUE obj)
 {
   return RSTRING_LEN(obj);
 }
-
-const VALUE *
-ruby_macros_RARRAY_PTR(VALUE ary)
-{
-  return RARRAY_PTR(ary);
-}

--- a/crates/rb-sys/src/macros/ruby_macros.c
+++ b/crates/rb-sys/src/macros/ruby_macros.c
@@ -23,11 +23,6 @@ long ruby_macros_RSTRING_LEN(VALUE obj)
   return RSTRING_LEN(obj);
 }
 
-long ruby_macros_RARRAY_LEN(VALUE obj)
-{
-  return RARRAY_LEN(obj);
-}
-
 const VALUE *
 ruby_macros_RARRAY_PTR(VALUE ary)
 {

--- a/crates/rb-sys/src/rarray.rs
+++ b/crates/rb-sys/src/rarray.rs
@@ -6,14 +6,21 @@
 #![allow(non_snake_case)]
 
 #[cfg(version_gte_3_0 = "true")]
-use crate::ruby_rarray_consts::RARRAY_EMBED_LEN_SHIFT;
+use crate::ruby_rarray_consts::{RARRAY_EMBED_LEN_SHIFT, RARRAY_TRANSIENT_FLAG};
 #[cfg(version_gte_3_0 = "false")]
-use crate::ruby_rarray_flags::RARRAY_EMBED_LEN_SHIFT;
+use crate::ruby_rarray_flags::{RARRAY_EMBED_LEN_SHIFT, RARRAY_TRANSIENT_FLAG};
 use crate::{
+    debug_assert_ruby_type, rb_gc_writebarrier_unprotect, refute_flag,
+    ruby_fl_type::{RUBY_FL_USER12, RUBY_FL_USER14},
     ruby_rarray_flags::{RARRAY_EMBED_FLAG, RARRAY_EMBED_LEN_MASK},
-    RArray, RBasic, RB_BUILTIN_TYPE, RUBY_T_ARRAY, VALUE,
+    ruby_xmalloc2, RArray, RBasic, RGENGC_WB_PROTECTED_ARRAY, RUBY_T_ARRAY, USE_TRANSIENT_HEAP,
+    VALUE,
 };
-use std::{convert::TryInto, os::raw::c_long};
+use std::{convert::TryInto, mem::size_of, os::raw::c_long, ptr::copy_nonoverlapping};
+
+pub const RARRAY_SHARED_ROOT_FLAG: u32 = RUBY_FL_USER12 as _;
+pub const RARRAY_PTR_IN_USE_FLAG: u32 = RUBY_FL_USER14 as _;
+pub const RARRAY_SHARED_FLAG: u32 = crate::ruby_fl_type::RUBY_ELTS_SHARED as _;
 
 /// Queries the length of the array.
 ///
@@ -26,7 +33,7 @@ use std::{convert::TryInto, os::raw::c_long};
 /// underlying [`RArray`] struct.
 #[inline(always)]
 pub unsafe fn RARRAY_LEN(obj: VALUE) -> c_long {
-    debug_assert!(RB_BUILTIN_TYPE(obj) == RUBY_T_ARRAY);
+    debug_assert_ruby_type!(obj, RUBY_T_ARRAY);
 
     let rarray = obj as *const RArray;
     let rbasic = obj as *const RBasic;
@@ -38,5 +45,57 @@ pub unsafe fn RARRAY_LEN(obj: VALUE) -> c_long {
         shifted.try_into().unwrap()
     } else {
         (*rarray).as_.heap.len
+    }
+}
+
+/// Wild  use of  a  C  pointer.  This  function  accesses  the backend  storage
+/// directly.   This is  slower  than  #RARRAY_PTR_USE_TRANSIENT.  It  exercises
+/// extra manoeuvres  to protect our generational  GC.  Use of this  function is
+/// considered archaic.  Use a modern way instead.
+///
+/// @param[in]  ary  An object of ::RArray.
+/// @return     The backend C array.
+///
+/// @internal
+///
+/// That said...  there are  extension libraries  in the wild  who uses  it.  We
+/// cannot but continue supporting.
+///
+/// # Safety
+/// This function is unsafe because it dereferences a raw pointer to access the
+/// underlying [`RArray`] struct.
+#[inline(always)]
+pub unsafe fn RARRAY_PTR(obj: VALUE) -> *const VALUE {
+    debug_assert_ruby_type!(obj, RUBY_T_ARRAY);
+
+    if RGENGC_WB_PROTECTED_ARRAY == 1 {
+        rb_gc_writebarrier_unprotect(obj);
+    }
+
+    let rarray = obj as *mut RArray;
+    let rbasic = obj as *mut RBasic;
+    let fl = (*rbasic).flags;
+
+    // Implements https://github.com/ruby/ruby/blob/cfb9624460a295e4e1723301486d89058c228e07/array.c#L456
+    if USE_TRANSIENT_HEAP == 1 && (fl & RARRAY_TRANSIENT_FLAG as VALUE) != 0 {
+        refute_flag!(fl, RARRAY_SHARED_ROOT_FLAG);
+
+        let old_ptr = (*rarray).as_.heap.ptr as *const VALUE;
+        let capa = (*rarray).as_.heap.aux.capa;
+
+        refute_flag!(fl, RARRAY_SHARED_FLAG as VALUE | RARRAY_EMBED_FLAG as VALUE);
+        refute_flag!(fl, RARRAY_PTR_IN_USE_FLAG);
+
+        let new_ptr = ruby_xmalloc2(capa.try_into().unwrap(), size_of::<VALUE>() as _);
+
+        (*rbasic).flags &= !(RARRAY_TRANSIENT_FLAG as VALUE);
+        copy_nonoverlapping(old_ptr, new_ptr as _, capa.try_into().unwrap());
+        (*rarray).as_.heap.ptr = new_ptr as _;
+    }
+
+    if (fl & RARRAY_EMBED_FLAG as VALUE) != 0 {
+        &(*rarray).as_.ary as *const VALUE
+    } else {
+        (*rarray).as_.heap.ptr as *const VALUE
     }
 }

--- a/crates/rb-sys/src/rarray.rs
+++ b/crates/rb-sys/src/rarray.rs
@@ -1,0 +1,42 @@
+//! Helpers for Ruby's rarray.h
+//!
+//! Makes it easier to reference to use the rarray.h API.
+
+#![allow(non_upper_case_globals)]
+#![allow(non_snake_case)]
+
+#[cfg(version_gte_3_0 = "true")]
+use crate::ruby_rarray_consts::RARRAY_EMBED_LEN_SHIFT;
+#[cfg(version_gte_3_0 = "false")]
+use crate::ruby_rarray_flags::RARRAY_EMBED_LEN_SHIFT;
+use crate::{
+    ruby_rarray_flags::{RARRAY_EMBED_FLAG, RARRAY_EMBED_LEN_MASK},
+    RArray, RBasic, RB_BUILTIN_TYPE, RUBY_T_ARRAY, VALUE,
+};
+use std::{convert::TryInto, os::raw::c_long};
+
+/// Queries the length of the array.
+///
+/// @param[in]  a  Array in question.
+/// @return     Its number of elements.
+/// @pre        `a` must be an instance of ::RArray.
+///
+/// # Safety
+/// This function is unsafe because it dereferences a raw pointer to access the
+/// underlying [`RArray`] struct.
+#[inline(always)]
+pub unsafe fn RARRAY_LEN(obj: VALUE) -> c_long {
+    debug_assert!(RB_BUILTIN_TYPE(obj) == RUBY_T_ARRAY);
+
+    let rarray = obj as *const RArray;
+    let rbasic = obj as *const RBasic;
+    let flags = (*rbasic).flags;
+
+    if flags & RARRAY_EMBED_FLAG as VALUE != 0 {
+        let masked = flags & RARRAY_EMBED_LEN_MASK as VALUE;
+        let shifted = masked >> RARRAY_EMBED_LEN_SHIFT as VALUE;
+        shifted.try_into().unwrap()
+    } else {
+        (*rarray).as_.heap.len
+    }
+}

--- a/crates/rb-sys/src/rarray.rs
+++ b/crates/rb-sys/src/rarray.rs
@@ -6,13 +6,13 @@
 #![allow(non_snake_case)]
 
 #[cfg(version_gte_3_0 = "true")]
-use crate::ruby_rarray_consts::{RARRAY_EMBED_LEN_SHIFT, RARRAY_TRANSIENT_FLAG};
+use crate::ruby_rarray_consts::RARRAY_EMBED_LEN_SHIFT;
 #[cfg(version_gte_3_0 = "false")]
 use crate::ruby_rarray_flags::{RARRAY_EMBED_LEN_SHIFT, RARRAY_TRANSIENT_FLAG};
 use crate::{
     debug_assert_ruby_type, rb_gc_writebarrier_unprotect, refute_flag,
     ruby_fl_type::{RUBY_FL_USER12, RUBY_FL_USER14},
-    ruby_rarray_flags::{RARRAY_EMBED_FLAG, RARRAY_EMBED_LEN_MASK},
+    ruby_rarray_flags::{RARRAY_EMBED_FLAG, RARRAY_EMBED_LEN_MASK, RARRAY_TRANSIENT_FLAG},
     ruby_xmalloc2, RArray, RBasic, RGENGC_WB_PROTECTED_ARRAY, RUBY_T_ARRAY, USE_TRANSIENT_HEAP,
     VALUE,
 };


### PR DESCRIPTION
This PR implements CRuby's `RARRAY_LEN` and `RARRAY_PTR` in Rust, in favor of using the compiled+linked C code from before. This allows `rustc` to inline things much more effectively.

This PR takes care to faithfully re-implement the C code exactly (i.e. proper assertions, handling, transient array pointers, etc).