### PR TITLE
Fix issues with cargo memory consumption in qemu environments

### DIFF
--- a/docker/setup/rustup.sh
+++ b/docker/setup/rustup.sh
@@ -22,6 +22,9 @@ main() {
   rustup target add "$RUST_TARGET"
   chmod -R a+w "$RUSTUP_HOME" "$CARGO_HOME"
 
+  # Use git CLI to fetch crates (avoid memory issues in QEMU environments)
+  printf "[net]\ngit-fetch-with-cli = true" >> "$CARGO_HOME/config.toml"
+
   # Pre-fetch the registry index
   cargo init --name tmp .
   cargo fetch


### PR DESCRIPTION
On my M1 (using Docker for Mac) builds were intermittently failing due to containers running out of memory. It seems to always happen at the exact same step (fetching crates). Here is a similar issue documented in the cargo project https://github.com/rust-lang/cargo/issues/10583.