### PR TITLE
Ensure `-Wl,-undefined,dynamic_lookup` is set on macos for gems

### DIFF
--- a/crates/rb-sys/Cargo.toml
+++ b/crates/rb-sys/Cargo.toml
@@ -13,8 +13,6 @@ links = "rb"
 repository = "https://github.com/oxidize-rb/rb-sys"
 
 [build-dependencies]
-bindgen = { version = "0.60", default-features = false, features = ["runtime"] }
-linkify = "0.9"
 rb-sys-build = { path = "../rb-sys-build", version = "0.9.32" }
 cc = { version = "1.0", optional = true }
 

--- a/crates/rb-sys/build/main.rs
+++ b/crates/rb-sys/build/main.rs
@@ -39,7 +39,8 @@ fn main() {
     if is_link_ruby_enabled() {
         link_libruby(&mut rbconfig);
     } else {
-        add_libruby_to_blocklist(&mut rbconfig)
+        add_libruby_to_blocklist(&mut rbconfig);
+        enable_dynamic_lookup(&mut rbconfig);
     }
 
     rbconfig.print_cargo_args();
@@ -169,5 +170,12 @@ fn export_cargo_cfg(rbconfig: &mut RbConfig) {
 fn rustc_cfg(rbconfig: &RbConfig, name: &str, key: &str) {
     if let Some(k) = rbconfig.get_optional(key) {
         println!("cargo:rustc-cfg={}=\"{}\"", name, k);
+    }
+}
+
+fn enable_dynamic_lookup(rbconfig: &mut RbConfig) {
+    // See https://github.com/oxidize-rb/rb-sys/issues/88
+    if cfg!(target_os = "macos") {
+        rbconfig.push_dldflags("-Wl,-undefined,dynamic_lookup");
     }
 }

--- a/examples/rust_reverse/ext/rust_reverse/Cargo.lock
+++ b/examples/rust_reverse/ext/rust_reverse/Cargo.lock
@@ -155,8 +155,6 @@ dependencies = [
 name = "rb-sys"
 version = "0.9.32"
 dependencies = [
- "bindgen",
- "linkify",
  "rb-sys-build",
 ]
 
@@ -164,6 +162,8 @@ dependencies = [
 name = "rb-sys-build"
 version = "0.9.32"
 dependencies = [
+ "bindgen",
+ "linkify",
  "regex",
  "shell-words",
 ]

--- a/gem/lib/rb_sys/cargo_builder.rb
+++ b/gem/lib/rb_sys/cargo_builder.rb
@@ -119,6 +119,10 @@ module RbSys
         # run on one that isn't the missing libraries will cause the extension
         # to fail on start.
         flags += ["-C", "link-arg=-static-libgcc"]
+      elsif darwin_target?
+        # See https://github.com/oxidize-rb/rb-sys/issues/88
+        dl_flag = "-Wl,-undefined,dynamic_lookup"
+        flags += ["-C", "link-arg=#{dl_flag}"] unless makefile_config("DLDFLAGS")&.include?(dl_flag)
       end
 
       flags


### PR DESCRIPTION
This PR ensures that `-Wl,-undefined,dynamic_lookup` is added on macos when Ruby is not being linked. This is needed since gems inherently lookup libruby symbols after a gem is required.

resolves #88 