### PR TITLE
Infer gem feature in mkmf

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -47,7 +47,7 @@ runs:
           ~/.cargo/git/db/
           target/
           examples/rust_reverse/tmp/
-        key: ${{ inputs.os }}-${{ inputs.ruby_version }}-${{ inputs.rust_toolchain }}-cargo-v4-${{ hashFiles('**/Cargo.lock', '**/extconf.rb') }}
+        key: ${{ inputs.os }}-${{ inputs.ruby_version }}-${{ inputs.rust_toolchain }}-cargo-v5-${{ hashFiles('**/Cargo.lock', '**/extconf.rb') }}
 
     - uses: actions-rs/toolchain@v1
       with:

--- a/crates/rb-sys/Cargo.toml
+++ b/crates/rb-sys/Cargo.toml
@@ -18,12 +18,10 @@ cc = { version = "1.0", optional = true }
 
 [features]
 default = []
-gem = ["ruby-abi-version"]
 link-ruby = []
 no-link-ruby = []
 ruby-macros = ["cc"]
 ruby-static = []
-ruby-abi-version = []
 global-allocator = []
 bindgen-rbimpls = ["rb-sys-build/bindgen-rbimpls"]
 bindgen-deprecated-types = ["rb-sys-build/bindgen-deprecated-types"]

--- a/crates/rb-sys/build/features.rs
+++ b/crates/rb-sys/build/features.rs
@@ -18,10 +18,6 @@ pub fn is_global_allocator_enabled(rb_config: &RbConfig) -> bool {
     }
 }
 
-pub fn is_ruby_abi_version_enabled() -> bool {
-    is_env_variable_defined("CARGO_FEATURE_RUBY_ABI_VERSION")
-}
-
 pub fn is_ruby_macros_enabled() -> bool {
     if cfg!(windows) {
         return false;
@@ -31,7 +27,7 @@ pub fn is_ruby_macros_enabled() -> bool {
 }
 
 pub fn is_gem_enabled() -> bool {
-    is_env_variable_defined("CARGO_FEATURE_GEM")
+    cfg!(rb_sys_gem)
 }
 
 pub fn is_no_link_ruby_enabled() -> bool {
@@ -81,7 +77,7 @@ pub fn is_link_ruby_enabled() -> bool {
                 to your `Cargo.toml`:
                 
                 [dependencies.rb-sys] 
-                features = [\"link-ruby\", \"ruby-abi-version\"] # Living dangerously! 
+                features = [\"link-ruby\"] # Living dangerously! 
             "
             .split('\n')
             .map(|line| line.trim())

--- a/crates/rb-sys/build/main.rs
+++ b/crates/rb-sys/build/main.rs
@@ -96,16 +96,16 @@ fn export_cargo_cfg(rbconfig: &mut RbConfig) {
     rustc_cfg(rbconfig, "ruby_patchlevel", "PATCHLEVEL");
     rustc_cfg(rbconfig, "ruby_api_version", "RUBY_API_VERSION");
 
-    if rbconfig.has_ruby_dln_check_abi() {
-        println!("cargo:rustc-cfg=has_ruby_abi_version");
-    }
-
     if is_global_allocator_enabled(rbconfig) {
         println!("cargo:rustc-cfg=use_global_allocator");
     }
 
-    if is_ruby_abi_version_enabled() {
+    if is_gem_enabled() {
         println!("cargo:rustc-cfg=use_ruby_abi_version");
+    }
+
+    if rbconfig.has_ruby_dln_check_abi() {
+        println!("cargo:rustc-cfg=has_ruby_abi_version");
     }
 
     let version = Version::current(rbconfig);

--- a/crates/rb-sys/readme.md
+++ b/crates/rb-sys/readme.md
@@ -20,7 +20,7 @@ Ruby gems require a bit of boilerplate to be defined to be usable from Ruby. `rb
 doing the work for you, by simply enabling the `gem` feature.
 
 ```toml
-rb-sys = { version = "0.9",  features = ["gem"] }
+rb-sys = "0.9"
 ```
 
 Under the hood this ensures we do not link libruby (unless on Windows), and defines a `ruby_abi_version` function for
@@ -63,8 +63,6 @@ rb-sys = { version = "0.9",  features = ["ruby-macros"] }
 
 ### Other features
 
-- `gem`: Setup boilerplate for a Ruby gem.
-- `ruby-abi-version`: Set the Ruby ABI version.
 - `ruby-macros`: Generate Rust functions for Ruby macros like `RSTRING_PTR`.
 - `global-allocator`: Report Rust memory allocations to the Ruby GC (_recommended_).
 - `ruby-static`: Link the static version of libruby.

--- a/crates/rb-sys/src/ruby_abi_version.rs
+++ b/crates/rb-sys/src/ruby_abi_version.rs
@@ -2,8 +2,8 @@
 //!
 //! Since Ruby 3.2, gems are required to define a `ruby_abi_version` function.
 //! For C extensions, this is done transparently by including `ruby.h`, but for
-//! Rust we have to define it ourselves. This is enabled automatically by the
-//! `ruby-abi-versions` Cargo feature flag.
+//! Rust we have to define it ourselves. This is enabled automatically by when
+//! compiling a gem.
 
 #[doc(hidden)]
 #[cfg(not(has_ruby_abi_version))]

--- a/examples/rust_reverse/Rakefile
+++ b/examples/rust_reverse/Rakefile
@@ -32,7 +32,7 @@ task :build do
   FileUtils.cp("rust_reverse.gemspec", "pkg/rust_reverse")
 
   cargo_toml_path = "pkg/rust_reverse/ext/rust_reverse/Cargo.toml"
-  new_contents = File.read(cargo_toml_path).gsub(' path = "./../../../../crates/rb-sys",', "git = \"https://github.com/oxidize-rb/rb-sys\", rev = #{ENV['GITHUB_REF'].inspect},")
+  new_contents = File.read(cargo_toml_path).gsub(' path = "./../../../../crates/rb-sys",', "git = \"https://github.com/oxidize-rb/rb-sys\", rev = #{ENV["GITHUB_REF"].inspect},")
   FileUtils.rm(cargo_toml_path)
   File.write(cargo_toml_path, new_contents)
 

--- a/examples/rust_reverse/Rakefile
+++ b/examples/rust_reverse/Rakefile
@@ -31,15 +31,11 @@ task :build do
 
   FileUtils.cp("rust_reverse.gemspec", "pkg/rust_reverse")
 
+  full_path = File.expand_path("./../../../crates/rb-sys", __FILE__)
   cargo_toml_path = "pkg/rust_reverse/ext/rust_reverse/Cargo.toml"
-  new_contents = File.read(cargo_toml_path).gsub(' path = "./../../../../crates/rb-sys",', "git = \"https://github.com/oxidize-rb/rb-sys\", rev = #{ENV["GITHUB_SHA"].inspect},")
-  new_contents << "[workspace]"
+  new_contents = File.read(cargo_toml_path).gsub('./../../../../crates/rb-sys', full_path)
   FileUtils.rm(cargo_toml_path)
   File.write(cargo_toml_path, new_contents)
-
-  Dir.chdir(File.dirname(cargo_toml_path)) do
-    sh "cargo update -p rb-sys"
-  end
 
   Dir.chdir("pkg/rust_reverse") do
     sh "gem build rust_reverse.gemspec --output=../rust_reverse.gem"

--- a/examples/rust_reverse/Rakefile
+++ b/examples/rust_reverse/Rakefile
@@ -32,7 +32,7 @@ task :build do
   FileUtils.cp("rust_reverse.gemspec", "pkg/rust_reverse")
 
   cargo_toml_path = "pkg/rust_reverse/ext/rust_reverse/Cargo.toml"
-  new_contents = File.read(cargo_toml_path).gsub(' path = "./../../../../crates/rb-sys",', "git = \"https://github.com/oxidize-rb/rb-sys\", rev = #{ENV["GITHUB_REF"].inspect},")
+  new_contents = File.read(cargo_toml_path).gsub(' path = "./../../../../crates/rb-sys",', "git = \"https://github.com/oxidize-rb/rb-sys\", rev = #{ENV["GITHUB_SHA"].inspect},")
   FileUtils.rm(cargo_toml_path)
   File.write(cargo_toml_path, new_contents)
 

--- a/examples/rust_reverse/Rakefile
+++ b/examples/rust_reverse/Rakefile
@@ -32,7 +32,7 @@ task :build do
   FileUtils.cp("rust_reverse.gemspec", "pkg/rust_reverse")
 
   cargo_toml_path = "pkg/rust_reverse/ext/rust_reverse/Cargo.toml"
-  new_contents = File.read(cargo_toml_path).gsub(' path = "./../../../../crates/rb-sys",', "")
+  new_contents = File.read(cargo_toml_path).gsub(' path = "./../../../../crates/rb-sys",', "git = \"https://github.com/oxidize-rb/rb-sys\", rev = #{ENV['GITHUB_REF'].inspect},")
   FileUtils.rm(cargo_toml_path)
   File.write(cargo_toml_path, new_contents)
 

--- a/examples/rust_reverse/Rakefile
+++ b/examples/rust_reverse/Rakefile
@@ -33,6 +33,7 @@ task :build do
 
   cargo_toml_path = "pkg/rust_reverse/ext/rust_reverse/Cargo.toml"
   new_contents = File.read(cargo_toml_path).gsub(' path = "./../../../../crates/rb-sys",', "git = \"https://github.com/oxidize-rb/rb-sys\", rev = #{ENV["GITHUB_SHA"].inspect},")
+  new_contents << "[workspace]"
   FileUtils.rm(cargo_toml_path)
   File.write(cargo_toml_path, new_contents)
 

--- a/examples/rust_reverse/Rakefile
+++ b/examples/rust_reverse/Rakefile
@@ -36,6 +36,10 @@ task :build do
   FileUtils.rm(cargo_toml_path)
   File.write(cargo_toml_path, new_contents)
 
+  Dir.chdir(File.dirname(cargo_toml_path)) do
+    sh "cargo update -p rb-sys"
+  end
+
   Dir.chdir("pkg/rust_reverse") do
     sh "gem build rust_reverse.gemspec --output=../rust_reverse.gem"
   end

--- a/examples/rust_reverse/Rakefile
+++ b/examples/rust_reverse/Rakefile
@@ -33,7 +33,7 @@ task :build do
 
   full_path = File.expand_path("./../../../crates/rb-sys", __FILE__)
   cargo_toml_path = "pkg/rust_reverse/ext/rust_reverse/Cargo.toml"
-  new_contents = File.read(cargo_toml_path).gsub('./../../../../crates/rb-sys', full_path)
+  new_contents = File.read(cargo_toml_path).gsub("./../../../../crates/rb-sys", full_path)
   FileUtils.rm(cargo_toml_path)
   File.write(cargo_toml_path, new_contents)
 

--- a/examples/rust_reverse/ext/rust_reverse/Cargo.toml
+++ b/examples/rust_reverse/ext/rust_reverse/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "rust-reverse"
 version = "0.9.36"
-autotests = false # set true if you want to use "cargo test"
+autotests = true # set true if you want to use "cargo test"
 edition = "2018"
 
 [dependencies]
-rb-sys = { version = "0.9.36", path = "./../../../../crates/rb-sys", features = ["gem", "global-allocator"] }
+rb-sys = { version = "0.9.36", path = "./../../../../crates/rb-sys", features = ["global-allocator"] }
 
 [lib]
 crate-type = ["cdylib"]

--- a/gem/lib/rb_sys/mkmf.rb
+++ b/gem/lib/rb_sys/mkmf.rb
@@ -10,8 +10,7 @@ require_relative "mkmf/config"
 module RbSys
   # Helper class for creating Rust Makefiles
   module Mkmf
-    # GLOBAL_RUSTFLAGS = ["--cfg=rb_sys_gem"]
-    GLOBAL_RUSTFLAGS = []
+    GLOBAL_RUSTFLAGS = ["--cfg=rb_sys_gem"]
 
     # Helper for building Rust extensions by creating a Ruby compatible makefile
     # for Rust. By using this class, your rust extension will be 100% compatible

--- a/gem/lib/rb_sys/mkmf.rb
+++ b/gem/lib/rb_sys/mkmf.rb
@@ -10,6 +10,9 @@ require_relative "mkmf/config"
 module RbSys
   # Helper class for creating Rust Makefiles
   module Mkmf
+    # GLOBAL_RUSTFLAGS = ["--cfg=rb_sys_gem"]
+    GLOBAL_RUSTFLAGS = []
+
     # Helper for building Rust extensions by creating a Ruby compatible makefile
     # for Rust. By using this class, your rust extension will be 100% compatible
     # with the rake-compiler gem, which allows for easy cross compilation.
@@ -62,6 +65,7 @@ module RbSys
 
         #{conditional_assign("RB_SYS_CARGO_PROFILE", builder.profile)}
         #{conditional_assign("RB_SYS_CARGO_FEATURES", builder.features.join(","))}
+        #{conditional_assign("RB_SYS_GLOBAL_RUSTFLAGS", GLOBAL_RUSTFLAGS.join(" "))}
         #{conditional_assign("RB_SYS_EXTRA_RUSTFLAGS", builder.extra_rustflags.join(" "))}
 
         # Set dirname for the profile, since the profiles do not directly map to target dir (i.e. dev -> debug)
@@ -105,7 +109,7 @@ module RbSys
         #{endif_stmt}
 
         #{env_vars(builder)}
-        #{export_env("RUSTFLAGS", "$(RUSTFLAGS) $(RB_SYS_EXTRA_RUSTFLAGS)")}
+        #{export_env("RUSTFLAGS", "$(RB_SYS_GLOBAL_RUSTFLAGS) $(RB_SYS_EXTRA_RUSTFLAGS) $(RUSTFLAGS)")}
 
         FORCE: ;
 

--- a/gem/test/test_rb_sys.rb
+++ b/gem/test/test_rb_sys.rb
@@ -64,7 +64,7 @@ class TestRbSys < Minitest::Test
 
     content = makefile.read
 
-    assert content.include?("export RUSTFLAGS := $(RUSTFLAGS) $(RB_SYS_EXTRA_RUSTFLAGS)")
+    assert content.include?("export RUSTFLAGS := $(RB_SYS_GLOBAL_RUSTFLAGS) $(RB_SYS_EXTRA_RUSTFLAGS) $(RUSTFLAGS)")
     assert content.include?("RB_SYS_EXTRA_RUSTFLAGS ?= --cfg=foo")
   end
 


### PR DESCRIPTION
This PR removes the `gem` and `ruby-abi-version` features in favor of a global `--cfg=rb_sys_gem` config value. This allows `rb-sys` to automagically configure itself for usage in a gem, without requiring the dependee to specify the feature.

Under the hood, `create_rust_makefile` will now set this flag so gems are compiled correctly.