### PR TITLE
Add `rb-sys-env` to ease integration pains

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,12 +176,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rb-sys-env"
+version = "0.1.0"
+
+[[package]]
 name = "rb-sys-tests"
 version = "0.9.38"
 dependencies = [
  "ctor",
  "rb-sys",
- "rb-sys-build",
+ "rb-sys-env",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,5 +3,6 @@ members = [
     "crates/rb-sys",
     "crates/rb-sys-tests",
     "crates/rb-sys-build",
+    "crates/rb-sys-env",
 ]
 exclude = ["examples/rust_reverse/ext/rust_reverse"]

--- a/crates/rb-sys-build/src/bindings.rs
+++ b/crates/rb-sys-build/src/bindings.rs
@@ -9,11 +9,14 @@ use std::path::PathBuf;
 
 /// Generate bindings for the Ruby using bindgen.
 pub fn generate(rbconfig: &RbConfig, static_ruby: bool) {
-    let clang_args = vec![
+    let mut clang_args = vec![
         format!("-I{}", rbconfig.get("rubyhdrdir")),
         format!("-I{}", rbconfig.get("rubyarchhdrdir")),
         "-fms-extensions".to_string(),
     ];
+
+    clang_args.extend(rbconfig.cflags.clone());
+    clang_args.extend(rbconfig.cppflags());
 
     eprintln!("Using bindgen with clang args: {:?}", clang_args);
 

--- a/crates/rb-sys-build/src/bindings.rs
+++ b/crates/rb-sys-build/src/bindings.rs
@@ -161,7 +161,7 @@ fn push_cargo_cfg_from_bindings() -> Result<(), Box<dyn std::error::Error>> {
                 let name = val.name().to_lowercase();
                 let val = val.as_bool();
                 println!("cargo:rustc-cfg=ruby_{}=\"{}\"", name, val);
-                println!("cargo:defines_{}=\"{}\"", name, val);
+                println!("cargo:defines_{}={}", name, val);
             }
         }
 

--- a/crates/rb-sys-build/src/rb_config.rs
+++ b/crates/rb-sys-build/src/rb_config.rs
@@ -237,9 +237,16 @@ impl RbConfig {
 
     /// Print to rb_config output for cargo
     pub fn print_cargo_args(&self) {
-        for arg in self.cargo_args() {
+        let cargo_args = self.cargo_args();
+
+        for arg in &cargo_args {
             println!("{}", arg);
         }
+
+        let encoded_cargo_args = cargo_args.join("\x1E");
+        let encoded_cargo_args = encoded_cargo_args.replace('\n', "\x1F");
+
+        println!("cargo:encoded_cargo_args={}", encoded_cargo_args);
     }
 
     /// Adds items to the rb_config based on a string from LDFLAGS/DLDFLAGS

--- a/crates/rb-sys-build/src/rb_config.rs
+++ b/crates/rb-sys-build/src/rb_config.rs
@@ -155,6 +155,16 @@ impl RbConfig {
         self.get("ruby_version")
     }
 
+    /// Get the CPPFLAGS from the RbConfig, making sure to subsitute variables.
+    pub fn cppflags(&self) -> Vec<String> {
+        if let Some(cppflags) = self.get_optional("CPPFLAGS") {
+            let flags = self.subst_shell_variables(&cppflags);
+            shellsplit(&flags)
+        } else {
+            vec![]
+        }
+    }
+
     /// Returns the value of the given key from the either the matching
     /// `RBCONFIG_{key}` environment variable or `RbConfig::CONFIG[{key}]` hash.
     pub fn get(&self, key: &str) -> String {

--- a/crates/rb-sys-build/src/rb_config.rs
+++ b/crates/rb-sys-build/src/rb_config.rs
@@ -13,7 +13,7 @@ use library::*;
 use search_path::*;
 use std::ffi::OsString;
 
-use crate::utils::{is_msvc, shellsplit};
+use crate::utils::{is_msvc, is_mswin_or_mingw, shellsplit};
 
 use self::flags::Flags;
 
@@ -395,7 +395,7 @@ fn capture_name(regex: &Regex, arg: &str) -> Option<String> {
 // Needed because Rust 1.51 does not support link-arg, and thus rpath
 // See <https://doc.rust-lang.org/cargo/reference/environment-variables.html#dynamic-library-paths
 fn append_ld_library_path(search_paths: Vec<&str>) {
-    let env_var_name = if cfg!(windows) {
+    let env_var_name = if is_mswin_or_mingw() {
         "PATH"
     } else if cfg!(target_os = "macos") {
         "DYLD_FALLBACK_LIBRARY_PATH"

--- a/crates/rb-sys-build/src/utils.rs
+++ b/crates/rb-sys-build/src/utils.rs
@@ -7,6 +7,15 @@ pub fn is_msvc() -> bool {
     }
 }
 
+/// Check if current platform is mswin or mingw.
+pub fn is_mswin_or_mingw() -> bool {
+    if let Ok(target) = std::env::var("TARGET") {
+        target.contains("msvc") || target.contains("pc-windows-gnu")
+    } else {
+        false
+    }
+}
+
 /// Splits shell words.
 pub fn shellsplit(s: &str) -> Vec<String> {
     match shell_words::split(s) {

--- a/crates/rb-sys-env/Cargo.toml
+++ b/crates/rb-sys-env/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "rb-sys-env"
+version = "0.1.0"
+edition = "2018"
+description = "Integrates rb-sys into high level frameworks"
+homepage = "https://github.com/oxidize-rb/rb-sys"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/oxidize-rb/rb-sys"
+readme = "readme.md"
+
+[lib]
+bench = false
+doctest = false

--- a/crates/rb-sys-env/readme.md
+++ b/crates/rb-sys-env/readme.md
@@ -1,0 +1,119 @@
+# `rb-sys-env`
+
+Helpers to integrate `rb-sys` into your high-level Ruby bindings library.
+
+## Features
+
+- Provides the neccesary Cargo configuration to ensure that Rust crates compile properly across all platforms
+- Sets useful rustc-cfg flags that you can use from your crate
+- Exposes all `RbConfig::CONFIG` values from rb-sys
+
+## Usage
+
+Add this to your `Cargo.toml`:
+
+```toml
+[dependencies]
+rb-sys-env = "0.1"
+```
+
+Then, in your crate's `build.rs`:
+
+```rust
+pub fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let _rb_env = rb_sys_env::activate()?;
+
+    Ok(())
+}
+```
+
+### Available `rustc-cfg`
+
+Here is an example of the `rustc-cfg` flags that are set by this crate:
+
+- `#[cfg(ruby_have_ruby_re_h)]`
+- `#[cfg(ruby_use_rgengc)]`
+- `#[cfg(ruby_use_symbol_as_method_name)]`
+- `#[cfg(ruby_have_ruby_util_h)]`
+- `#[cfg(ruby_have_ruby_oniguruma_h)]`
+- `#[cfg(ruby_have_ruby_defines_h)]`
+- `#[cfg(ruby_use_flonum)]`
+- `#[cfg(ruby_have_ruby_onigmo_h)]`
+- `#[cfg(ruby_use_unaligned_member_access)]`
+- `#[cfg(ruby_use_transient_heap)]`
+- `#[cfg(ruby_have_ruby_atomic_h)]`
+- `#[cfg(ruby_have_rb_scan_args_optional_hash)]`
+- `#[cfg(ruby_have_rb_data_type_t_parent)]`
+- `#[cfg(ruby_have_ruby_debug_h)]`
+- `#[cfg(ruby_have_ruby_encoding_h)]`
+- `#[cfg(ruby_have_ruby_ruby_h)]`
+- `#[cfg(ruby_have_ruby_intern_h)]`
+- `#[cfg(ruby_use_mjit)]`
+- `#[cfg(ruby_have_rb_data_type_t_function)]`
+- `#[cfg(ruby_have_rb_fd_init)]`
+- `#[cfg(ruby_have_rb_reg_new_str)]`
+- `#[cfg(ruby_have_rb_io_t)]`
+- `#[cfg(ruby_have_ruby_memory_view_h)]`
+- `#[cfg(ruby_have_ruby_version_h)]`
+- `#[cfg(ruby_have_ruby_st_h)]`
+- `#[cfg(ruby_have_ruby_thread_native_h)]`
+- `#[cfg(ruby_have_ruby_random_h)]`
+- `#[cfg(ruby_have_ruby_regex_h)]`
+- `#[cfg(ruby_have_rb_define_alloc_func)]`
+- `#[cfg(ruby_have_ruby_fiber_scheduler_h)]`
+- `#[cfg(ruby_have_ruby_missing_h)]`
+- `#[cfg(ruby_have_rb_ext_ractor_safe)]`
+- `#[cfg(ruby_have_ruby_thread_h)]`
+- `#[cfg(ruby_have_ruby_vm_h)]`
+- `#[cfg(ruby_use_rincgc)]`
+- `#[cfg(ruby_have_ruby_ractor_h)]`
+- `#[cfg(ruby_have_ruby_io_h)]`
+- `#[cfg(ruby_3)]`
+- `#[cfg(ruby_3_1)]`
+- `#[cfg(ruby_3_1_2)]`
+- `#[cfg(ruby_gte_2_2)]`
+- `#[cfg(ruby_gt_2_2)]`
+- `#[cfg(ruby_gte_2_3)]`
+- `#[cfg(ruby_gt_2_3)]`
+- `#[cfg(ruby_gte_2_4)]`
+- `#[cfg(ruby_gt_2_4)]`
+- `#[cfg(ruby_gte_2_5)]`
+- `#[cfg(ruby_gt_2_5)]`
+- `#[cfg(ruby_gte_2_6)]`
+- `#[cfg(ruby_gt_2_6)]`
+- `#[cfg(ruby_gte_2_7)]`
+- `#[cfg(ruby_gt_2_7)]`
+- `#[cfg(ruby_gte_3_0)]`
+- `#[cfg(ruby_gt_3_0)]`
+- `#[cfg(ruby_lte_3_1)]`
+- `#[cfg(ruby_3_1)]`
+- `#[cfg(ruby_eq_3_1)]`
+- `#[cfg(ruby_gte_3_1)]`
+- `#[cfg(ruby_lt_3_2)]`
+- `#[cfg(ruby_lte_3_2)]`
+- `#[cfg(ruby_lt_3_3)]`
+- `#[cfg(ruby_lte_3_3)]`
+- `#[cfg(ruby_gte_1)]`
+- `#[cfg(ruby_gt_1)]`
+- `#[cfg(ruby_gte_2)]`
+- `#[cfg(ruby_gt_2)]`
+- `#[cfg(ruby_lte_3)]`
+- `#[cfg(ruby_3)]`
+- `#[cfg(ruby_eq_3)]`
+- `#[cfg(ruby_gte_3)]`
+- `#[cfg(ruby_lt_4)]`
+- `#[cfg(ruby_lte_4)]`
+
+## License
+
+Licensed under either of
+
+- Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as
+defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.

--- a/crates/rb-sys-env/readme.md
+++ b/crates/rb-sys-env/readme.md
@@ -27,7 +27,7 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-### Available `rustc-cfg`
+## Available `rustc-cfg`
 
 Here is an example of the `rustc-cfg` flags that are set by this crate:
 

--- a/crates/rb-sys-env/readme.md
+++ b/crates/rb-sys-env/readme.md
@@ -13,7 +13,7 @@ Helpers to integrate `rb-sys` into your high-level Ruby bindings library.
 Add this to your `Cargo.toml`:
 
 ```toml
-[dependencies]
+[build-dependencies]
 rb-sys-env = "0.1"
 ```
 

--- a/crates/rb-sys-env/src/defines.rs
+++ b/crates/rb-sys-env/src/defines.rs
@@ -1,0 +1,37 @@
+use std::{collections::HashMap, rc::Rc};
+
+/// The DEFINES variables from libruby.
+#[derive(Debug, Clone)]
+pub struct Defines {
+    raw_environment: Rc<HashMap<String, String>>,
+}
+
+impl Defines {
+    pub(crate) fn from_raw_environment(raw_environment: Rc<HashMap<String, String>>) -> Self {
+        Self { raw_environment }
+    }
+
+    /// Determines the given key is true.
+    pub fn is_value_true(&self, key: &str) -> bool {
+        self.raw_environment
+            .get(format!("DEFINES_{}", key).as_str())
+            .map(|v| v == "1" || v == "true")
+            .unwrap_or(false)
+    }
+
+    /// Fetches the raw value for the given key.
+    pub fn get_raw_value(&self, key: &str) -> Option<&str> {
+        self.raw_environment
+            .get(format!("DEFINES_{}", key).as_str())
+            .map(|v| v.as_str())
+    }
+
+    pub(crate) fn print_cargo_rustc_cfg(&self) {
+        for (key, val) in self.raw_environment.iter() {
+            if key.starts_with("DEFINES_") && val == "true" {
+                let key = key.trim_start_matches("DEFINES_");
+                rustc_cfg!("ruby_{}", key.to_lowercase());
+            }
+        }
+    }
+}

--- a/crates/rb-sys-env/src/lib.rs
+++ b/crates/rb-sys-env/src/lib.rs
@@ -1,0 +1,77 @@
+#![doc = include_str!("../readme.md")]
+
+#[macro_use]
+mod utils;
+mod defines;
+mod rb_env;
+mod ruby_version;
+
+use std::error::Error;
+
+pub use defines::Defines;
+pub use rb_env::RbEnv;
+pub use ruby_version::RubyVersion;
+
+/// Configures Cargo linking based on the `DEP_RB_*` environment variables. This
+/// is needed to ensure that Cargo properly links to libruby on Windows..
+///
+/// ```should_panic
+/// // In your crate's build.rs
+///
+/// pub fn main() -> Result<(), Box<dyn std::error::Error>> {
+///     let rb_env = rb_sys_env::activate()?;
+///
+///     if rb_env.ruby_major_minor() < (2, 7) {
+///         panic!("Your Ruby version is EOL!");
+///     }
+///
+///     Ok(())
+/// }
+///
+/// // In your crate's lib.rs
+/// pub fn is_ruby_flonum_activated() -> bool {
+///     cfg!(ruby_use_flonum)
+/// }
+/// ```
+pub fn activate() -> Result<RbEnv, Box<dyn Error>> {
+    let env = RbEnv::default();
+
+    env.print_cargo_rerun_if_changed();
+    env.print_cargo_rustc_cfg();
+    env.print_encoded_cargo_args();
+
+    if std::env::var_os("RB_SYS_ENV_DEBUG").is_some() {
+        eprintln!("=======================");
+        eprintln!("The \"RB_SYS_ENV_DEBUG\" env var was detecting, aborted build.");
+        std::process::exit(1);
+    }
+
+    Ok(env)
+}
+
+/// Loads the `DEP_RB_*` environment variables, without setting Cargo configuration.
+///
+/// *Note*: This will not activate the `rb-sys` crate's features to ensure Ruby is properly linked.
+///
+/// ```
+/// // In your crate's build.rs
+///
+/// pub fn main() -> Result<(), Box<dyn std::error::Error>> {
+///     let rb_env = rb_sys_env::load()?;
+///
+///     rb_env.print_cargo_rerun_if_changed();
+///     rb_env.print_cargo_rustc_cfg();
+///     rb_env.print_encoded_cargo_args();
+///
+///     if rb_env.ruby_major_minor() < (2, 7) {
+///         panic!("Your Ruby version is EOL!");
+///     }
+///
+///     Ok(())
+/// }
+/// ```
+pub fn load() -> Result<RbEnv, Box<dyn Error>> {
+    let env = RbEnv::default();
+
+    Ok(env)
+}

--- a/crates/rb-sys-env/src/lib.rs
+++ b/crates/rb-sys-env/src/lib.rs
@@ -1,4 +1,108 @@
-#![doc = include_str!("../readme.md")]
+//! # `rb-sys-env`
+//!
+//! Helpers to integrate `rb-sys` into your high-level Ruby bindings library.
+//!
+//! ## Features
+//!
+//! - Provides the neccesary Cargo configuration to ensure that Rust crates compile properly across all platforms
+//! - Sets useful rustc-cfg flags that you can use from your crate
+//! - Exposes all `RbConfig::CONFIG` values from rb-sys
+//!
+//! ## Usage
+//!
+//! Add this to your `Cargo.toml`:
+//!
+//! ```toml
+//! [build-dependencies]
+//! rb-sys-env = "0.1"
+//! ```
+//!
+//! Then, in your crate's `build.rs`:
+//!
+//! ```rust
+//! pub fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!     let _rb_env = rb_sys_env::activate()?;
+//!
+//!     Ok(())
+//! }
+//! ```
+//!
+//! ## Available `rustc-cfg`
+//!
+//! Here is an example of the `rustc-cfg` flags that are set by this crate:
+//!
+//! - `#[cfg(ruby_have_ruby_re_h)]`
+//! - `#[cfg(ruby_use_rgengc)]`
+//! - `#[cfg(ruby_use_symbol_as_method_name)]`
+//! - `#[cfg(ruby_have_ruby_util_h)]`
+//! - `#[cfg(ruby_have_ruby_oniguruma_h)]`
+//! - `#[cfg(ruby_have_ruby_defines_h)]`
+//! - `#[cfg(ruby_use_flonum)]`
+//! - `#[cfg(ruby_have_ruby_onigmo_h)]`
+//! - `#[cfg(ruby_use_unaligned_member_access)]`
+//! - `#[cfg(ruby_use_transient_heap)]`
+//! - `#[cfg(ruby_have_ruby_atomic_h)]`
+//! - `#[cfg(ruby_have_rb_scan_args_optional_hash)]`
+//! - `#[cfg(ruby_have_rb_data_type_t_parent)]`
+//! - `#[cfg(ruby_have_ruby_debug_h)]`
+//! - `#[cfg(ruby_have_ruby_encoding_h)]`
+//! - `#[cfg(ruby_have_ruby_ruby_h)]`
+//! - `#[cfg(ruby_have_ruby_intern_h)]`
+//! - `#[cfg(ruby_use_mjit)]`
+//! - `#[cfg(ruby_have_rb_data_type_t_function)]`
+//! - `#[cfg(ruby_have_rb_fd_init)]`
+//! - `#[cfg(ruby_have_rb_reg_new_str)]`
+//! - `#[cfg(ruby_have_rb_io_t)]`
+//! - `#[cfg(ruby_have_ruby_memory_view_h)]`
+//! - `#[cfg(ruby_have_ruby_version_h)]`
+//! - `#[cfg(ruby_have_ruby_st_h)]`
+//! - `#[cfg(ruby_have_ruby_thread_native_h)]`
+//! - `#[cfg(ruby_have_ruby_random_h)]`
+//! - `#[cfg(ruby_have_ruby_regex_h)]`
+//! - `#[cfg(ruby_have_rb_define_alloc_func)]`
+//! - `#[cfg(ruby_have_ruby_fiber_scheduler_h)]`
+//! - `#[cfg(ruby_have_ruby_missing_h)]`
+//! - `#[cfg(ruby_have_rb_ext_ractor_safe)]`
+//! - `#[cfg(ruby_have_ruby_thread_h)]`
+//! - `#[cfg(ruby_have_ruby_vm_h)]`
+//! - `#[cfg(ruby_use_rincgc)]`
+//! - `#[cfg(ruby_have_ruby_ractor_h)]`
+//! - `#[cfg(ruby_have_ruby_io_h)]`
+//! - `#[cfg(ruby_3)]`
+//! - `#[cfg(ruby_3_1)]`
+//! - `#[cfg(ruby_3_1_2)]`
+//! - `#[cfg(ruby_gte_2_2)]`
+//! - `#[cfg(ruby_gt_2_2)]`
+//! - `#[cfg(ruby_gte_2_3)]`
+//! - `#[cfg(ruby_gt_2_3)]`
+//! - `#[cfg(ruby_gte_2_4)]`
+//! - `#[cfg(ruby_gt_2_4)]`
+//! - `#[cfg(ruby_gte_2_5)]`
+//! - `#[cfg(ruby_gt_2_5)]`
+//! - `#[cfg(ruby_gte_2_6)]`
+//! - `#[cfg(ruby_gt_2_6)]`
+//! - `#[cfg(ruby_gte_2_7)]`
+//! - `#[cfg(ruby_gt_2_7)]`
+//! - `#[cfg(ruby_gte_3_0)]`
+//! - `#[cfg(ruby_gt_3_0)]`
+//! - `#[cfg(ruby_lte_3_1)]`
+//! - `#[cfg(ruby_3_1)]`
+//! - `#[cfg(ruby_eq_3_1)]`
+//! - `#[cfg(ruby_gte_3_1)]`
+//! - `#[cfg(ruby_lt_3_2)]`
+//! - `#[cfg(ruby_lte_3_2)]`
+//! - `#[cfg(ruby_lt_3_3)]`
+//! - `#[cfg(ruby_lte_3_3)]`
+//! - `#[cfg(ruby_gte_1)]`
+//! - `#[cfg(ruby_gt_1)]`
+//! - `#[cfg(ruby_gte_2)]`
+//! - `#[cfg(ruby_gt_2)]`
+//! - `#[cfg(ruby_lte_3)]`
+//! - `#[cfg(ruby_3)]`
+//! - `#[cfg(ruby_eq_3)]`
+//! - `#[cfg(ruby_gte_3)]`
+//! - `#[cfg(ruby_lt_4)]`
+//! - `#[cfg(ruby_lte_4)]`
 
 #[macro_use]
 mod utils;

--- a/crates/rb-sys-env/src/rb_env.rs
+++ b/crates/rb-sys-env/src/rb_env.rs
@@ -91,6 +91,7 @@ impl RbEnv {
         println!("cargo:rerun-if-changed=build.rs");
         println!("cargo:rerun-if-env-changed=RB_SYS_ENV_DEBUG");
         println!("cargo:rerun-if-env-changed=RUBY");
+        println!("cargo:rerun-if-env-changed=RUBY_ROOT");
         println!("cargo:rerun-if-env-changed=RUBY_VERSION");
     }
 }

--- a/crates/rb-sys-env/src/rb_env.rs
+++ b/crates/rb-sys-env/src/rb_env.rs
@@ -1,0 +1,107 @@
+use crate::{Defines, RubyVersion};
+use std::{collections::HashMap, rc::Rc};
+
+const ENV_PREFIX: &str = "DEP_RB_";
+const RBCONFIG_PREFIX: &str = "RBCONFIG_";
+const CARGO_FEATURE_PREFIX: &str = "CARGO_FEATURE_";
+
+/// Information about the rb-sys environment.
+#[derive(Debug, Clone)]
+pub struct RbEnv {
+    defines: Defines,
+    vars: Rc<HashMap<String, String>>,
+}
+
+impl RbEnv {
+    /// The current Ruby version.
+    pub fn ruby_version(&self) -> RubyVersion {
+        RubyVersion::from_raw_environment(&self.vars)
+    }
+
+    /// The (major, minor) tuple of the current Ruby version.
+    pub fn ruby_major_minor(&self) -> (u8, u8) {
+        self.ruby_version().major_minor()
+    }
+
+    /// Get a value from the current Ruby's `RbConfig::CONFIG`.
+    pub fn get_rbconfig_value(&self, key: &str) -> Option<&str> {
+        self.vars
+            .get(&format!("{}{}", RBCONFIG_PREFIX, key))
+            .map(|v| v.as_str())
+    }
+
+    /// List the Cargo features of rb-sys
+    pub fn cargo_features(&self) -> Vec<String> {
+        let keys = self.vars.keys();
+        let keys = keys.filter(|k| k.starts_with(CARGO_FEATURE_PREFIX));
+        let keys = keys.map(|k| k.trim_start_matches(CARGO_FEATURE_PREFIX));
+
+        keys.map(|k| k.replace('_', "-").to_lowercase()).collect()
+    }
+
+    /// Tell Cargo to link to libruby.
+    pub fn link_ruby(self) -> Self {
+        let libdir = self.vars.get("LIBDIR").expect("DEP_RB_LIBDIR is not set");
+        let lib = self.vars.get("LIB").expect("DEP_RB_LIB is not set");
+
+        println!("cargo:rustc-link-search=native={}", libdir);
+        println!("cargo:rustc-link-lib={}", lib);
+
+        self
+    }
+
+    // Decodes the cargo args from `DEP_RB_ENCODED_CARGO_ARGS` environment variable.
+    pub fn encoded_cargo_args(&self) -> Vec<String> {
+        if let Some(raw_args) = self.vars.get("ENCODED_CARGO_ARGS") {
+            let lines = raw_args.split('\x1E');
+            let unescaped = lines.map(|line| line.replace('\x1F', "\n"));
+            unescaped.collect()
+        } else {
+            vec![]
+        }
+    }
+
+    /// Indicates if we are using libruby-static.
+    pub fn is_ruby_static(&self) -> bool {
+        self.vars
+            .get("RUBY_STATIC")
+            .map(|v| v == "true")
+            .unwrap_or(false)
+    }
+
+    /// Prints args for rustc (i.e. `cargo:rustc-cfg=...`).
+    pub fn print_cargo_rustc_cfg(&self) {
+        self.defines.print_cargo_rustc_cfg();
+        self.ruby_version().print_cargo_rustc_cfg();
+    }
+
+    /// Prints directives for rustc (i.e. `cargo:rustc-link-lib=...`).
+    pub fn print_encoded_cargo_args(&self) {
+        for line in self.encoded_cargo_args() {
+            println!("{}", line);
+        }
+    }
+
+    /// Prints directives for re-runs (i.e. `cargo:rerun-if-env-changed=...`)
+    pub fn print_cargo_rerun_if_changed(&self) {
+        for key in self.vars.keys() {
+            println!("cargo:rerun-if-env-changed={}{}", ENV_PREFIX, key);
+        }
+
+        println!("cargo:rerun-if-env-changed=RUBY");
+        println!("cargo:rerun-if-env-changed=RUBY_VERSION");
+    }
+}
+
+impl Default for RbEnv {
+    fn default() -> Self {
+        let vars = std::env::vars();
+        let vars = vars.filter(|(key, _)| key.starts_with(ENV_PREFIX));
+        let vars = vars.map(|(key, value)| (key.trim_start_matches(ENV_PREFIX).to_string(), value));
+        let vars: HashMap<String, String> = vars.collect();
+        let vars = Rc::new(vars);
+        let defines = Defines::from_raw_environment(vars.clone());
+
+        Self { defines, vars }
+    }
+}

--- a/crates/rb-sys-env/src/rb_env.rs
+++ b/crates/rb-sys-env/src/rb_env.rs
@@ -39,8 +39,8 @@ impl RbEnv {
         keys.map(|k| k.replace('_', "-").to_lowercase()).collect()
     }
 
-    /// Tell Cargo to link to libruby.
-    pub fn link_ruby(self) -> Self {
+    /// Tell Cargo to link to libruby, even if `rb-sys` decided not to.
+    pub fn force_link_ruby(self) -> Self {
         let libdir = self.vars.get("LIBDIR").expect("DEP_RB_LIBDIR is not set");
         let lib = self.vars.get("LIB").expect("DEP_RB_LIB is not set");
 
@@ -88,6 +88,7 @@ impl RbEnv {
             println!("cargo:rerun-if-env-changed={}{}", ENV_PREFIX, key);
         }
 
+        println!("cargo:rerun-if-env-changed=RB_SYS_ENV_DEBUG");
         println!("cargo:rerun-if-env-changed=RUBY");
         println!("cargo:rerun-if-env-changed=RUBY_VERSION");
     }

--- a/crates/rb-sys-env/src/rb_env.rs
+++ b/crates/rb-sys-env/src/rb_env.rs
@@ -88,6 +88,7 @@ impl RbEnv {
             println!("cargo:rerun-if-env-changed={}{}", ENV_PREFIX, key);
         }
 
+        println!("cargo:rerun-if-changed=build.rs");
         println!("cargo:rerun-if-env-changed=RB_SYS_ENV_DEBUG");
         println!("cargo:rerun-if-env-changed=RUBY");
         println!("cargo:rerun-if-env-changed=RUBY_VERSION");

--- a/crates/rb-sys-env/src/ruby_version.rs
+++ b/crates/rb-sys-env/src/ruby_version.rs
@@ -54,40 +54,40 @@ impl RubyVersion {
         rustc_cfg!("ruby_{}_{}", self.major, self.minor);
         rustc_cfg!("ruby_{}_{}_{}", self.major, self.minor, self.teeny);
 
-        for v in COMPARABLE_RUBY_MINORS {
-            if self.major_minor() < v {
+        for v in &COMPARABLE_RUBY_MINORS {
+            if self.major_minor() < *v {
                 rustc_cfg!(r#"ruby_lt_{}_{}"#, v.0, v.1);
             }
-            if self.major_minor() <= v {
+            if self.major_minor() <= *v {
                 rustc_cfg!(r#"ruby_lte_{}_{}"#, v.0, v.1);
             }
-            if self.major_minor() == v {
+            if self.major_minor() == *v {
                 rustc_cfg!(r#"ruby_{}_{}"#, v.0, v.1);
                 rustc_cfg!(r#"ruby_eq_{}_{}"#, v.0, v.1);
             }
-            if self.major_minor() >= v {
+            if self.major_minor() >= *v {
                 rustc_cfg!(r#"ruby_gte_{}_{}"#, v.0, v.1);
             }
-            if self.major_minor() > v {
+            if self.major_minor() > *v {
                 rustc_cfg!(r#"ruby_gt_{}_{}"#, v.0, v.1);
             }
         }
 
-        for v in COMPARABLE_RUBY_MAJORS {
-            if self.major() < v {
+        for v in &COMPARABLE_RUBY_MAJORS {
+            if self.major() < *v {
                 rustc_cfg!(r#"ruby_lt_{}"#, v);
             }
-            if self.major() <= v {
+            if self.major() <= *v {
                 rustc_cfg!(r#"ruby_lte_{}"#, v);
             }
-            if self.major() == v {
+            if self.major() == *v {
                 rustc_cfg!(r#"ruby_{}"#, v);
                 rustc_cfg!(r#"ruby_eq_{}"#, v);
             }
-            if self.major() >= v {
+            if self.major() >= *v {
                 rustc_cfg!(r#"ruby_gte_{}"#, v);
             }
-            if self.major() > v {
+            if self.major() > *v {
                 rustc_cfg!(r#"ruby_gt_{}"#, v);
             }
         }

--- a/crates/rb-sys-env/src/ruby_version.rs
+++ b/crates/rb-sys-env/src/ruby_version.rs
@@ -1,0 +1,163 @@
+use std::collections::HashMap;
+
+const COMPARABLE_RUBY_MAJORS: [u8; 4] = [1, 2, 3, 4];
+
+const COMPARABLE_RUBY_MINORS: [(u8, u8); 10] = [
+    (2, 2),
+    (2, 3),
+    (2, 4),
+    (2, 5),
+    (2, 6),
+    (2, 7),
+    (3, 0),
+    (3, 1),
+    (3, 2),
+    (3, 3),
+];
+
+/// The current Ruby version.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct RubyVersion {
+    major: u8,
+    minor: u8,
+    teeny: u8,
+}
+
+impl RubyVersion {
+    /// The Ruby major version.
+    pub fn major(&self) -> u8 {
+        self.major
+    }
+
+    /// The Ruby minor version.
+    pub fn minor(&self) -> u8 {
+        self.minor
+    }
+
+    /// The Ruby teeny version.
+    pub fn teeny(&self) -> u8 {
+        self.teeny
+    }
+
+    /// The Ruby version as a u8 triple.
+    pub fn major_minor_teeny(&self) -> (u8, u8, u8) {
+        (self.major, self.minor, self.teeny)
+    }
+
+    /// The Ruby version as a u8 pair.
+    pub fn major_minor(&self) -> (u8, u8) {
+        (self.major, self.minor)
+    }
+
+    pub fn print_cargo_rustc_cfg(&self) {
+        rustc_cfg!("ruby_{}", self.major);
+        rustc_cfg!("ruby_{}_{}", self.major, self.minor);
+        rustc_cfg!("ruby_{}_{}_{}", self.major, self.minor, self.teeny);
+
+        for v in COMPARABLE_RUBY_MINORS {
+            if self.major_minor() < v {
+                rustc_cfg!(r#"ruby_lt_{}_{}"#, v.0, v.1);
+            }
+            if self.major_minor() <= v {
+                rustc_cfg!(r#"ruby_lte_{}_{}"#, v.0, v.1);
+            }
+            if self.major_minor() == v {
+                rustc_cfg!(r#"ruby_{}_{}"#, v.0, v.1);
+                rustc_cfg!(r#"ruby_eq_{}_{}"#, v.0, v.1);
+            }
+            if self.major_minor() >= v {
+                rustc_cfg!(r#"ruby_gte_{}_{}"#, v.0, v.1);
+            }
+            if self.major_minor() > v {
+                rustc_cfg!(r#"ruby_gt_{}_{}"#, v.0, v.1);
+            }
+        }
+
+        for v in COMPARABLE_RUBY_MAJORS {
+            if self.major() < v {
+                rustc_cfg!(r#"ruby_lt_{}"#, v);
+            }
+            if self.major() <= v {
+                rustc_cfg!(r#"ruby_lte_{}"#, v);
+            }
+            if self.major() == v {
+                rustc_cfg!(r#"ruby_{}"#, v);
+                rustc_cfg!(r#"ruby_eq_{}"#, v);
+            }
+            if self.major() >= v {
+                rustc_cfg!(r#"ruby_gte_{}"#, v);
+            }
+            if self.major() > v {
+                rustc_cfg!(r#"ruby_gt_{}"#, v);
+            }
+        }
+    }
+}
+
+impl From<u8> for RubyVersion {
+    fn from(major: u8) -> Self {
+        Self {
+            major: major as u8,
+            minor: 0,
+            teeny: 0,
+        }
+    }
+}
+
+impl From<(u8, u8)> for RubyVersion {
+    fn from((major, minor): (u8, u8)) -> Self {
+        Self {
+            major: major as u8,
+            minor: minor as u8,
+            teeny: 0,
+        }
+    }
+}
+
+impl From<(u8, u8, u8)> for RubyVersion {
+    fn from((major, minor, teeny): (u8, u8, u8)) -> Self {
+        Self {
+            major: major as u8,
+            minor: minor as u8,
+            teeny: teeny as u8,
+        }
+    }
+}
+
+fn verpart(env: &HashMap<String, String>, key: &str) -> u8 {
+    env.get(key).unwrap().parse().unwrap()
+}
+
+impl RubyVersion {
+    pub(crate) fn from_raw_environment(env: &HashMap<String, String>) -> Self {
+        Self {
+            major: verpart(env, "MAJOR"),
+            minor: verpart(env, "MINOR"),
+            teeny: verpart(env, "TEENY"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_equality_from_tuple() {
+        assert_eq!(RubyVersion::from((3, 0, 0)), RubyVersion::from((3, 0)));
+        assert_ne!(RubyVersion::from((3, 0, 1)), RubyVersion::from((3, 0)));
+    }
+
+    #[test]
+    fn test_from_hashmap() {
+        let mut env = HashMap::new();
+        env.insert("MAJOR".to_string(), "3".to_string());
+        env.insert("MINOR".to_string(), "0".to_string());
+        env.insert("TEENY".to_string(), "0".to_string());
+
+        assert_eq!(
+            RubyVersion::from_raw_environment(&env),
+            RubyVersion::from((3, 0, 0))
+        );
+    }
+}

--- a/crates/rb-sys-env/src/utils.rs
+++ b/crates/rb-sys-env/src/utils.rs
@@ -1,0 +1,6 @@
+#[macro_export]
+macro_rules! rustc_cfg {
+    ($var:literal, $($cfg:tt)*) => {
+        println!(concat!("cargo:rustc-cfg=", $var), $($cfg)*);
+    };
+}

--- a/crates/rb-sys-tests/Cargo.toml
+++ b/crates/rb-sys-tests/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [lib]
 bench = false
-doctest = false  
+doctest = false
 doc = false
 
 [features]
@@ -19,4 +19,4 @@ rb-sys = { path = "../rb-sys", features = ["link-ruby"] }
 ctor = "0.1"
 
 [build-dependencies]
-rb-sys-build = { path = "../rb-sys-build" }
+rb-sys-env = { path = "../rb-sys-env" }

--- a/crates/rb-sys-tests/build.rs
+++ b/crates/rb-sys-tests/build.rs
@@ -1,5 +1,5 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rb_env = rb_sys_env::activate()?.link_ruby();
+    let rb_env = rb_sys_env::activate()?;
 
     if rb_env.ruby_major_minor() >= (3, 1) && cfg!(windows) {
         println!("cargo:rustc-cfg=windows_broken_vm_init_3_1");

--- a/crates/rb-sys-tests/build.rs
+++ b/crates/rb-sys-tests/build.rs
@@ -1,29 +1,9 @@
-use rb_sys_build::rb_config;
-use std::env;
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let rb_env = rb_sys_env::activate()?.link_ruby();
 
-fn main() {
-    export_cargo_cfg();
-    let mut rbconfig = rb_config();
-    let is_static = rbconfig.get("ENABLE_SHARED") == "no";
-    rbconfig.link_ruby(is_static).print_cargo_args()
-}
-
-fn export_cargo_cfg() {
-    rustc_cfg("version");
-    rustc_cfg("major");
-    rustc_cfg("minor");
-    rustc_cfg("teeny");
-    rustc_cfg("patchlevel");
-    rustc_cfg("version_gte_3_2");
-    rustc_cfg("version_gte_3_1");
-
-    if env::var("DEP_RB_VERSION_GTE_3_1") == Ok("true".to_string()) && cfg!(windows) {
+    if rb_env.ruby_major_minor() >= (3, 1) && cfg!(windows) {
         println!("cargo:rustc-cfg=windows_broken_vm_init_3_1");
     }
-}
 
-fn rustc_cfg(name: &str) {
-    let val = env::var(format!("DEP_RB_{}", &name.to_uppercase()))
-        .unwrap_or_else(|_| panic!("{} not found", name));
-    println!("cargo:rustc-cfg=ruby_{}=\"{}\"", name, val);
+    Ok(())
 }

--- a/crates/rb-sys-tests/src/ruby_abi_version_test.rs
+++ b/crates/rb-sys-tests/src/ruby_abi_version_test.rs
@@ -1,14 +1,12 @@
 rb_sys::ruby_abi_version!();
 
-#[cfg(unix)]
-#[cfg(ruby_gte_3_2)]
+#[cfg(all(ruby_gte_3_2, unix))]
 #[test]
 fn test_ruby_abi_version() {
     assert!(ruby_abi_version() >= 1)
 }
 
-#[cfg(unix)]
-#[cfg(ruby_gte_3_2)]
+#[cfg(all(ruby_lt_3_2, unix))]
 #[test]
 fn test_ruby_abi_version() {
     assert_eq!(ruby_abi_version(), 0)

--- a/crates/rb-sys-tests/src/ruby_abi_version_test.rs
+++ b/crates/rb-sys-tests/src/ruby_abi_version_test.rs
@@ -1,14 +1,14 @@
 rb_sys::ruby_abi_version!();
 
 #[cfg(unix)]
-#[cfg(ruby_version_gte_3_2 = "true")]
+#[cfg(ruby_gte_3_2)]
 #[test]
 fn test_ruby_abi_version() {
     assert!(ruby_abi_version() >= 1)
 }
 
 #[cfg(unix)]
-#[cfg(ruby_version_gte_3_2 = "false")]
+#[cfg(ruby_gte_3_2)]
 #[test]
 fn test_ruby_abi_version() {
     assert_eq!(ruby_abi_version(), 0)

--- a/crates/rb-sys-tests/src/special_consts_test.rs
+++ b/crates/rb-sys-tests/src/special_consts_test.rs
@@ -33,7 +33,11 @@ fn test_flonum_p() {
     unsafe {
         let flonum = rb_float_new(0.0);
 
+        #[cfg(ruby_use_flonum)]
         assert!(FLONUM_P(flonum));
+        #[cfg(not(ruby_use_flonum))]
+        assert!(!FLONUM_P(flonum));
+
         assert!(!FLONUM_P(Qnil));
     }
 }

--- a/crates/rb-sys/Cargo.toml
+++ b/crates/rb-sys/Cargo.toml
@@ -25,7 +25,6 @@ ruby-static = []
 global-allocator = []
 bindgen-rbimpls = ["rb-sys-build/bindgen-rbimpls"]
 bindgen-deprecated-types = ["rb-sys-build/bindgen-deprecated-types"]
-debug-build = []
 
 [lib]
 doctest = false

--- a/crates/rb-sys/build/features.rs
+++ b/crates/rb-sys/build/features.rs
@@ -1,4 +1,4 @@
-use rb_sys_build::RbConfig;
+use rb_sys_build::{utils::is_mswin_or_mingw, RbConfig};
 
 use crate::version::Version;
 
@@ -19,7 +19,7 @@ pub fn is_global_allocator_enabled(rb_config: &RbConfig) -> bool {
 }
 
 pub fn is_ruby_macros_enabled() -> bool {
-    if cfg!(windows) {
+    if is_mswin_or_mingw() {
         return false;
     }
 
@@ -63,7 +63,7 @@ pub fn is_link_ruby_enabled() -> bool {
 
     if is_no_link_ruby_enabled() {
         false
-    } else if cfg!(windows) {
+    } else if is_mswin_or_mingw() {
         true
     } else if is_gem_enabled() {
         if is_env_variable_defined("CARGO_FEATURE_LINK_RUBY") {

--- a/crates/rb-sys/build/features.rs
+++ b/crates/rb-sys/build/features.rs
@@ -41,8 +41,7 @@ pub fn is_debug_build_enabled() -> bool {
 
     println!("cargo:rerun-if-env-changed=RB_SYS_DEBUG_BUILD");
 
-    is_env_variable_defined("CARGO_FEATURE_DEBUG_BUILD")
-        || is_env_variable_defined("RB_SYS_DEBUG_BUILD")
+    is_env_variable_defined("RB_SYS_DEBUG_BUILD")
 }
 
 pub fn is_ruby_static_enabled(rbconfig: &RbConfig) -> bool {
@@ -71,13 +70,13 @@ pub fn is_link_ruby_enabled() -> bool {
             let msg = "
                 The `gem` and `link-ruby` features are mutually exclusive on this
                 platform, since the libruby symbols will be available at runtime.
-                
+
                 If you for some reason want to dangerously link libruby for your gem
                 (*not recommended*), you can remove the `gem` feature and add this
                 to your `Cargo.toml`:
-                
-                [dependencies.rb-sys] 
-                features = [\"link-ruby\"] # Living dangerously! 
+
+                [dependencies.rb-sys]
+                features = [\"link-ruby\"] # Living dangerously!
             "
             .split('\n')
             .map(|line| line.trim())

--- a/crates/rb-sys/build/main.rs
+++ b/crates/rb-sys/build/main.rs
@@ -43,6 +43,7 @@ fn main() {
         enable_dynamic_lookup(&mut rbconfig);
     }
 
+    expose_cargo_features();
     rbconfig.print_cargo_args();
 
     if is_debug_build_enabled() {
@@ -64,7 +65,7 @@ fn debug_and_exit(rbconfig: &mut RbConfig) {
     dbg!(env);
 
     eprintln!("==========\n");
-    eprintln!("The \"debug-build\" feature for rb-sys is enabled, aborting.");
+    eprintln!("The \"RB_SYS_DEBUG_BUILD\" env var was set, aborting.");
     std::process::exit(1);
 }
 
@@ -149,6 +150,7 @@ fn export_cargo_cfg(rbconfig: &mut RbConfig) {
 
     if is_ruby_static_enabled(rbconfig) {
         println!("cargo:lib={}", rbconfig.libruby_static_name());
+        println!("cargo:ruby_static=true");
     } else {
         println!("cargo:lib={}", rbconfig.libruby_so_name());
     }
@@ -166,5 +168,15 @@ fn enable_dynamic_lookup(rbconfig: &mut RbConfig) {
     // See https://github.com/oxidize-rb/rb-sys/issues/88
     if cfg!(target_os = "macos") {
         rbconfig.push_dldflags("-Wl,-undefined,dynamic_lookup");
+    }
+}
+
+fn expose_cargo_features() {
+    for (key, val) in std::env::vars() {
+        if !key.starts_with("CARGO_FEATURE_") {
+            continue;
+        }
+
+        println!("cargo:{}={}", key.to_lowercase(), val);
     }
 }

--- a/crates/rb-sys/build/main.rs
+++ b/crates/rb-sys/build/main.rs
@@ -21,6 +21,7 @@ const SUPPORTED_RUBY_VERSIONS: [Version; 8] = [
 fn main() {
     let mut rbconfig = RbConfig::current();
 
+    println!("cargo:rerun-if-env-changed=RUBY_ROOT");
     println!("cargo:rerun-if-env-changed=RUBY_VERSION");
     println!("cargo:rerun-if-env-changed=RUBY");
     println!("cargo:rerun-if-changed=wrapper.h");

--- a/crates/rb-sys/build/ruby_macros.rs
+++ b/crates/rb-sys/build/ruby_macros.rs
@@ -6,7 +6,6 @@ pub fn compile(rbconfig: &mut RbConfig) {
 
     use rb_sys_build::utils::shellsplit;
 
-    println!("cargo:rerun-if-changed=src/macros/ruby_macros.h");
     println!("cargo:rerun-if-changed=src/macros/ruby_macros.c");
 
     let mut build = cc::Build::new();


### PR DESCRIPTION
# Why

So after working to make `rb-sys` seamless with [`magnus`](https://github.com/matsadler/magnus), there are a number of integration pain points I've stumbled across:

1. Cargo link directives do not propagate transitively 

This means that means the link-args set by rb-sys do not automatically propagated to magnus. This can cause unexpected breakage ([especially on windows](https://github.com/bytecodealliance/wasmtime-rb/actions/runs/3441425110/jobs/5740960512))

More info: (https://github.com/rust-lang/cargo/issues/9554)

2. There is some baseline information that's needed at compile time

This like the `ruby_gte_3_0`, and `ruby_use_flonum` are examples of this. Exposing this information in an easy way would alleviate a lot of headaches.

# How

This PR adds a lightweight, dependency-free `rb-sys-env` crate to glue high level bindings crates together properly. **IMPORTANT**: This crate is only needed if you are wrapping rb-sys to make a high-level bindings crate (i.e. this is not needed if you are a gem author)!

At it's core, all it does is properly set cargo configuration based on the `DEP_RB_*` environment variables which are already set by `rb-sys`. This means this crate does not have to depend on `rb-sys` directly, and as such builds quickly.

# Usage

In your high-level Ruby library that wraps rb-sys

1. Add this to your `Cargo.toml`:

    ```toml
    [build-dependencies]
    rb-sys-env = "0.1"
    ```

2. Then, just add this your `build.rs`:

    ```rust
    pub fn main() -> Result<(), Box<dyn std::error::Error>> {
      let _rb_env = rb_sys_env::activate()?;

      Ok(())
    }
    ```

# What it configures

Anytime you want to see what is being set by `rb-sys-env`, you can run `RB_SYS_ENV_DEBUG=1 cargo test`...

<details>
<summary>👉 Click here to see an example output</summary>

```
  cargo:rustc-cfg=ruby_use_unaligned_member_access
  cargo:rustc-cfg=ruby_have_rb_ext_ractor_safe
  cargo:rustc-cfg=ruby_have_ruby_missing_h
  cargo:rustc-cfg=ruby_have_ruby_re_h
  cargo:rustc-cfg=ruby_have_ruby_debug_h
  cargo:rustc-cfg=ruby_have_ruby_oniguruma_h
  cargo:rustc-cfg=ruby_have_rb_io_t
  cargo:rustc-cfg=ruby_use_rincgc
  cargo:rustc-cfg=ruby_have_rb_data_type_t_function
  cargo:rustc-cfg=ruby_have_rb_data_type_t_parent
  cargo:rustc-cfg=ruby_have_ruby_intern_h
  cargo:rustc-cfg=ruby_have_ruby_defines_h
  cargo:rustc-cfg=ruby_have_ruby_thread_native_h
  cargo:rustc-cfg=ruby_have_rb_scan_args_optional_hash
  cargo:rustc-cfg=ruby_have_ruby_ruby_h
  cargo:rustc-cfg=ruby_have_ruby_io_h
  cargo:rustc-cfg=ruby_have_ruby_fiber_scheduler_h
  cargo:rustc-cfg=ruby_have_ruby_version_h
  cargo:rustc-cfg=ruby_have_rb_define_alloc_func
  cargo:rustc-cfg=ruby_use_transient_heap
  cargo:rustc-cfg=ruby_have_ruby_encoding_h
  cargo:rustc-cfg=ruby_have_ruby_random_h
  cargo:rustc-cfg=ruby_have_ruby_vm_h
  cargo:rustc-cfg=ruby_have_ruby_st_h
  cargo:rustc-cfg=ruby_have_ruby_ractor_h
  cargo:rustc-cfg=ruby_have_ruby_thread_h
  cargo:rustc-cfg=ruby_have_ruby_onigmo_h
  cargo:rustc-cfg=ruby_use_symbol_as_method_name
  cargo:rustc-cfg=ruby_have_rb_fd_init
  cargo:rustc-cfg=ruby_have_ruby_util_h
  cargo:rustc-cfg=ruby_have_ruby_regex_h
  cargo:rustc-cfg=ruby_have_rb_reg_new_str
  cargo:rustc-cfg=ruby_use_mjit
  cargo:rustc-cfg=ruby_use_flonum
  cargo:rustc-cfg=ruby_use_rgengc
  cargo:rustc-cfg=ruby_have_ruby_atomic_h
  cargo:rustc-cfg=ruby_have_ruby_memory_view_h
  cargo:rustc-cfg=ruby_3
  cargo:rustc-cfg=ruby_3_1
  cargo:rustc-cfg=ruby_3_1_2
  cargo:rustc-cfg=ruby_gte_2_2
  cargo:rustc-cfg=ruby_gt_2_2
  cargo:rustc-cfg=ruby_gte_2_3
  cargo:rustc-cfg=ruby_gt_2_3
  cargo:rustc-cfg=ruby_gte_2_4
  cargo:rustc-cfg=ruby_gt_2_4
  cargo:rustc-cfg=ruby_gte_2_5
  cargo:rustc-cfg=ruby_gt_2_5
  cargo:rustc-cfg=ruby_gte_2_6
  cargo:rustc-cfg=ruby_gt_2_6
  cargo:rustc-cfg=ruby_gte_2_7
  cargo:rustc-cfg=ruby_gt_2_7
  cargo:rustc-cfg=ruby_gte_3_0
  cargo:rustc-cfg=ruby_gt_3_0
  cargo:rustc-cfg=ruby_lte_3_1
  cargo:rustc-cfg=ruby_3_1
  cargo:rustc-cfg=ruby_eq_3_1
  cargo:rustc-cfg=ruby_gte_3_1
  cargo:rustc-cfg=ruby_lt_3_2
  cargo:rustc-cfg=ruby_lte_3_2
  cargo:rustc-cfg=ruby_lt_3_3
  cargo:rustc-cfg=ruby_lte_3_3
  cargo:rustc-cfg=ruby_gte_1
  cargo:rustc-cfg=ruby_gt_1
  cargo:rustc-cfg=ruby_gte_2
  cargo:rustc-cfg=ruby_gt_2
  cargo:rustc-cfg=ruby_lte_3
  cargo:rustc-cfg=ruby_3
  cargo:rustc-cfg=ruby_eq_3
  cargo:rustc-cfg=ruby_gte_3
  cargo:rustc-cfg=ruby_lt_4
  cargo:rustc-cfg=ruby_lte_4
  cargo:rustc-link-search=native=/Users/ianks/.rubies/3.1.2/lib
  cargo:rustc-link-lib=ruby.3.1
  cargo:rustc-link-arg=-Wl,-rpath,ruby.3.1
  cargo:rustc-link-arg=-Wl,-multiply_defined,suppress
```
</details>

