### PR TITLE
Improvements to `mkmf`

### DIFF
--- a/gem/README.md
+++ b/gem/README.md
@@ -38,6 +38,9 @@ create_rust_makefile("rust_reverse") do |r|
 
   # Clean up the target/ dir after `gem install` to reduce bloat (optional)
   r.clean_after_install = false # default: true if invoked by rubygems
+
+  # Auto-install Rust toolchain if not present on "gem install" (optional)
+  r.auto_install_rust_toolchain = false # default: true if invoked by rubygems
 end
 ```
 

--- a/gem/lib/rb_sys/cargo_builder.rb
+++ b/gem/lib/rb_sys/cargo_builder.rb
@@ -1,4 +1,5 @@
 module RbSys
+  # A class to build a Ruby gem Cargo. Extracted from `rubygems` gem, with some modifications.
   class CargoBuilder < Gem::Ext::Builder
     attr_accessor :spec, :runner, :profile, :env, :features, :target, :extra_rustc_args, :dry_run, :ext_dir, :extra_rustflags
 

--- a/gem/lib/rb_sys/mkmf.rb
+++ b/gem/lib/rb_sys/mkmf.rb
@@ -248,9 +248,9 @@ module RbSys
 
     def force_install_rust_toolchain?(builder)
       return builder.force_install_rust_toolchain if builder.force_install_rust_toolchain
-      return false unless builder.rubygems_invoked?
+      return false unless builder.rubygems_invoked? && builder.auto_install_rust_toolchain
 
-      find_executable("xxcargo").nil?
+      find_executable("cargo").nil?
     end
 
     def if_eq_stmt(a, b)

--- a/gem/lib/rb_sys/mkmf/config.rb
+++ b/gem/lib/rb_sys/mkmf/config.rb
@@ -12,6 +12,10 @@ module RbSys
         @clean_after_install = rubygems_invoked?
       end
 
+      def cross_compiling?
+        RbConfig::CONFIG["CROSS_COMPILING"] == "yes"
+      end
+
       def method_missing(name, *args, &blk)
         @builder.send(name, *args, &blk)
       end
@@ -19,8 +23,6 @@ module RbSys
       def respond_to_missing?(name, include_private = false)
         @builder.respond_to?(name) || super
       end
-
-      private
 
       # Seems to be the only way to reliably know if we were invoked by Rubygems.
       # We want to know this so we can cleanup the target directory after an

--- a/gem/lib/rb_sys/mkmf/config.rb
+++ b/gem/lib/rb_sys/mkmf/config.rb
@@ -9,6 +9,7 @@ module RbSys
       def initialize(builder)
         @builder = builder
         @force_install_rust_toolchain = false
+        @auto_install_rust_toolchain = true
         @clean_after_install = rubygems_invoked?
       end
 

--- a/gem/lib/rb_sys/mkmf/config.rb
+++ b/gem/lib/rb_sys/mkmf/config.rb
@@ -4,7 +4,7 @@ module RbSys
   module Mkmf
     # Config that delegates to CargoBuilder if needded
     class Config
-      attr_accessor :force_install_rust_toolchain, :clean_after_install
+      attr_accessor :force_install_rust_toolchain, :clean_after_install, :target_dir
 
       def initialize(builder)
         @builder = builder

--- a/gem/lib/rb_sys/toolchain_info.rb
+++ b/gem/lib/rb_sys/toolchain_info.rb
@@ -3,6 +3,13 @@
 require_relative "toolchain_info/data"
 
 module RbSys
+  # A class to get information about the Rust toolchains, and how they map to
+  # Ruby platforms.
+  #
+  # @example
+  #   RbSys::ToolchainInfo.new("x86_64-unknown-linux-gnu").ruby_platform # => "x86_64-linux"
+  #   RbSys::ToolchainInfo.new("x86_64-unknown-linux-gnu").supported? # => true
+  #   RbSys::ToolchainInfo.new("x86_64-unknown-linux-gnu")
   class ToolchainInfo
     attr_reader :platform, :gem_platform, :rust_target, :rake_compiler_dock_cc, :supported, :rake_compiler_dock_image, :docker_platform
 


### PR DESCRIPTION
# Auto-install rust toolchain when none is found on `gem install`

If a gem user does not have Rust installed, it's better to not make them install it manually. It's better for us to do it since we can `rm -rf` the dir to keep Docker images thin, and ensure we install the correct `rustc` version.

However, if we do detect `cargo` is already installed, we'll use the provided toolchain.

# Allow for `TARGET_DIR` to be specified so for cargo (for better caching in CI, etc)

This will allow for the `./target` dir to be shared, which is useful for keeping CI caches reasonably small.