### PR TITLE
Misc fixes and improvements to `rb_sys/mkmf`

### DIFF
--- a/gem/lib/rb_sys/cargo_builder.rb
+++ b/gem/lib/rb_sys/cargo_builder.rb
@@ -1,7 +1,8 @@
 module RbSys
   # A class to build a Ruby gem Cargo. Extracted from `rubygems` gem, with some modifications.
   class CargoBuilder < Gem::Ext::Builder
-    attr_accessor :spec, :runner, :profile, :env, :features, :target, :extra_rustc_args, :dry_run, :ext_dir, :extra_rustflags
+    attr_accessor :spec, :runner, :env, :features, :target, :extra_rustc_args, :dry_run, :ext_dir, :extra_rustflags
+    attr_writer :profile
 
     def initialize(spec)
       require "rubygems/command"
@@ -17,6 +18,12 @@ module RbSys
       @dry_run = true
       @ext_dir = nil
       @extra_rustflags = []
+    end
+
+    def profile
+      return :release if rubygems_invoked?
+
+      @profile
     end
 
     def build(_extension, dest_path, results, args = [], lib_dir = nil, cargo_dir = Dir.pwd)
@@ -322,6 +329,10 @@ module RbSys
       when :dev then "debug"
       else raise "unknown target directory for profile: #{profile}"
       end
+    end
+
+    def rubygems_invoked?
+      ENV.key?("SOURCE_DATE_EPOCH")
     end
 
     # Error raised when no cdylib artifact was created

--- a/gem/lib/rb_sys/mkmf.rb
+++ b/gem/lib/rb_sys/mkmf.rb
@@ -64,7 +64,7 @@ module RbSys
         #{conditional_assign("SOEXT_PREFIX", "lib", indent: 1)}
         #{endif_stmt}
 
-        #{conditional_assign("RB_SYS_CARGO_PROFILE", builder.profile)}
+        #{set_cargo_profile(builder)}
         #{conditional_assign("RB_SYS_CARGO_FEATURES", builder.features.join(","))}
         #{conditional_assign("RB_SYS_GLOBAL_RUSTFLAGS", GLOBAL_RUSTFLAGS.join(" "))}
         #{conditional_assign("RB_SYS_EXTRA_RUSTFLAGS", builder.extra_rustflags.join(" "))}
@@ -316,6 +316,12 @@ module RbSys
       else
         "export #{k} := #{v}"
       end
+    end
+
+    def set_cargo_profile(builder)
+      return assign_stmt("RB_SYS_CARGO_PROFILE", "release") if builder.rubygems_invoked?
+
+      conditional_assign("RB_SYS_CARGO_PROFILE", builder.profile)
     end
   end
 end

--- a/gem/lib/rb_sys/mkmf.rb
+++ b/gem/lib/rb_sys/mkmf.rb
@@ -84,20 +84,20 @@ module RbSys
         #{endif_stmt}
 
         # Account for sub-directories when using `--target` argument with Cargo
+        #{conditional_assign("RB_SYS_CARGO_TARGET_DIR", "target")}
         #{if_neq_stmt("$(CARGO_BUILD_TARGET)", "")}
-        #{assign_stmt("RB_SYS_CARGO_BUILD_TARGET_DIR", "target/$(CARGO_BUILD_TARGET)", indent: 1)}
+        #{assign_stmt("RB_SYS_FULL_TARGET_DIR", "$(RB_SYS_CARGO_TARGET_DIR)/$(CARGO_BUILD_TARGET)", indent: 1)}
         #{else_stmt}
-        #{assign_stmt("RB_SYS_CARGO_BUILD_TARGET_DIR", "target", indent: 1)}
+        #{assign_stmt("RB_SYS_FULL_TARGET_DIR", "$(RB_SYS_CARGO_TARGET_DIR)", indent: 1)}
         #{endif_stmt}
 
         target_prefix = #{target_prefix}
         TARGET_NAME = #{target[/\A\w+/]}
         TARGET_ENTRY = #{RbConfig::CONFIG["EXPORT_PREFIX"]}Init_$(TARGET_NAME)
-        RUBYARCHDIR   = $(sitearchdir)$(target_prefix)
+        RUBYARCHDIR = $(sitearchdir)$(target_prefix)
         TARGET = #{target}
         DLLIB = $(TARGET).#{RbConfig::CONFIG["DLEXT"]}
-        #{conditional_assign("TARGET_DIR", "$(RB_SYS_CARGO_BUILD_TARGET_DIR)")}
-        RUSTLIBDIR = $(TARGET_DIR)/$(RB_SYS_CARGO_PROFILE_DIR)
+        RUSTLIBDIR = $(RB_SYS_FULL_TARGET_DIR)/$(RB_SYS_CARGO_PROFILE_DIR)
         RUSTLIB = $(RUSTLIBDIR)/$(SOEXT_PREFIX)$(TARGET_NAME).$(SOEXT)
 
         CLEANOBJS = $(RUSTLIBDIR) $(RB_SYS_BUILD_DIR)
@@ -189,7 +189,7 @@ module RbSys
       cargo_command.gsub!(/--profile \w+/, "$(RB_SYS_CARGO_PROFILE_FLAG)")
       cargo_command.gsub!(%r{--features \S+}, "--features $(RB_SYS_CARGO_FEATURES)")
       cargo_command.gsub!(%r{--target \S+}, "--target $(CARGO_BUILD_TARGET)")
-      cargo_command.gsub!(/--target-dir (?:(?!--).)+/, "--target-dir $(TARGET_DIR) ")
+      cargo_command.gsub!(/--target-dir (?:(?!--).)+/, "--target-dir $(RB_SYS_CARGO_TARGET_DIR) ")
       cargo_command
     end
 

--- a/gem/lib/rb_sys/mkmf.rb
+++ b/gem/lib/rb_sys/mkmf.rb
@@ -243,9 +243,10 @@ module RbSys
 
         $(CARGO):
         \t$(Q) $(MAKEDIRS) $(CARGO_HOME) $(RUSTUP_HOME)
-        \tcurl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --no-modify-path --profile $(RB_SYS_RUSTUP_PROFILE) --default-toolchain none -y
-        \trustup toolchain install $(RB_SYS_DEFAULT_TOOLCHAIN) --profile $(RB_SYS_RUSTUP_PROFILE)
-        \trustup default $(RB_SYS_DEFAULT_TOOLCHAIN)
+        \t$(Q) curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --no-modify-path --profile $(RB_SYS_RUSTUP_PROFILE) --default-toolchain none -y
+        \t$(Q) rustup toolchain install $(RB_SYS_DEFAULT_TOOLCHAIN) --profile $(RB_SYS_RUSTUP_PROFILE)
+        \t$(Q) rustup default $(RB_SYS_DEFAULT_TOOLCHAIN)
+        \t$(Q) rustup component add rustfmt
 
         $(RUSTLIB): $(CARGO)
         #{endif_stmt}

--- a/gem/lib/rb_sys/mkmf.rb
+++ b/gem/lib/rb_sys/mkmf.rb
@@ -100,11 +100,13 @@ module RbSys
         RUSTLIBDIR = $(TARGET_DIR)/$(RB_SYS_CARGO_PROFILE_DIR)
         RUSTLIB = $(RUSTLIBDIR)/$(SOEXT_PREFIX)$(TARGET_NAME).$(SOEXT)
 
-        CLEANOBJS = $(RUSTLIBDIR)/.fingerprint $(RUSTLIBDIR)/incremental $(RUSTLIBDIR)/examples $(RUSTLIBDIR)/deps $(RUSTLIBDIR)/build $(RUSTLIBDIR)/.cargo-lock $(RUSTLIBDIR)/*.d $(RUSTLIBDIR)/*.rlib $(RB_SYS_BUILD_DIR)
+        CLEANOBJS = $(RUSTLIBDIR) $(RB_SYS_BUILD_DIR)
         DEFFILE = $(RUSTLIBDIR)/$(TARGET)-$(arch).def
         CLEANLIBS = $(DLLIB) $(RUSTLIB) $(DEFFILE)
 
         #{base_makefile(srcdir)}
+
+        .PHONY: gemclean
 
         #{if_neq_stmt("$(RB_SYS_VERBOSE)", "")}
         #{assign_stmt("Q", "$(0=@)", indent: 1)}
@@ -135,7 +137,10 @@ module RbSys
         \t$(Q) $(MAKEDIRS) $(RUBYARCHDIR)
         \t$(INSTALL_PROG) $(DLLIB) $(RUBYARCHDIR)
 
-        install: #{builder.clean_after_install ? "install-so realclean" : "install-so"}
+        gemclean:
+        \t-$(Q)$(RM_RF) $(CLEANOBJS) $(CLEANFILES) 2> /dev/null || true
+
+        install: #{builder.clean_after_install ? "install-so gemclean" : "install-so"}
 
         all: #{$extout ? "install" : "$(DLLIB)"}
       MAKE


### PR DESCRIPTION
- [Clean up install files more liberally in rubygems](https://github.com/oxidize-rb/rb-sys/commit/207cd9ac3265f128a82ba38a39c62d60a07f1031)
- [Ensure rustfmt installed](https://github.com/oxidize-rb/rb-sys/commit/056f74e5e3689d67bd25499411dc87ac1cda07ed) when force installing toolchain, so bindings always generate
- [Make it impossible to compile debug builds on rubygems](https://github.com/oxidize-rb/rb-sys/commit/0877b2bf91d71e855b2729a232c2979ba4674b25), this is here as a guard
- [Qualify the target dir more precisely](https://github.com/oxidize-rb/rb-sys/commit/24f081ed783646a064fd6c66db390130e181908e)