### PR TITLE
Add option to cleanup dirs for rubygems

### DIFF
--- a/gem/lib/rb_sys/mkmf.rb
+++ b/gem/lib/rb_sys/mkmf.rb
@@ -103,6 +103,7 @@ module RbSys
         CLEANOBJS = $(RUSTLIBDIR) $(RB_SYS_BUILD_DIR)
         DEFFILE = $(RB_SYS_CARGO_TARGET_DIR)/$(TARGET)-$(arch).def
         CLEANLIBS = $(DLLIB) $(RUSTLIB) $(DEFFILE)
+        RUBYGEMS_CLEAN_DIRS = $(CLEANOBJS) $(CLEANFILES) #{builder.rubygems_clean_dirs.join(" ")}
 
         #{base_makefile(srcdir)}
 
@@ -134,7 +135,8 @@ module RbSys
         \t$(INSTALL_PROG) $(DLLIB) $(RUBYARCHDIR)
 
         gemclean:
-        \t-$(Q)$(RM_RF) $(CLEANOBJS) $(CLEANFILES) 2> /dev/null || true
+        \t$(ECHO) Cleaning gem artifacts
+        \t-$(Q)$(RM_RF) $(RUBYGEMS_CLEAN_DIRS) 2> /dev/null || true
 
         install: #{builder.clean_after_install ? "install-so gemclean" : "install-so"}
 

--- a/gem/lib/rb_sys/mkmf/config.rb
+++ b/gem/lib/rb_sys/mkmf/config.rb
@@ -4,13 +4,14 @@ module RbSys
   module Mkmf
     # Config that delegates to CargoBuilder if needded
     class Config
-      attr_accessor :force_install_rust_toolchain, :clean_after_install, :target_dir, :auto_install_rust_toolchain
+      attr_accessor :force_install_rust_toolchain, :clean_after_install, :target_dir, :auto_install_rust_toolchain, :rubygems_clean_dirs
 
       def initialize(builder)
         @builder = builder
         @force_install_rust_toolchain = false
         @auto_install_rust_toolchain = true
         @clean_after_install = rubygems_invoked?
+        @rubygems_clean_dirs = ["./cargo-vendor"]
       end
 
       def cross_compiling?


### PR DESCRIPTION
This makes it so you can use `cargo vendor` more easily.