### PR TITLE
Use proper bindgen include paths for LLVM on mswin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
         run: "bundle exec rake bindings:generate"
 
       - uses: actions/upload-artifact@v3
-        if: failure()
+        if: always()
         with:
           name: ci-debug-artifacts-${{ matrix.sys.os }}-${{ matrix.ruby_version }}
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,9 @@ jobs:
       - name: Set LIBCLANG_PATH
         if: matrix.ruby_version == 'mswin'
         shell: pwsh
-        run: echo "LIBCLANG_PATH=$((gcm clang).source -replace "clang.exe")" >> $env:GITHUB_ENV
+        run: |
+          echo "LIBCLANG_PATH=$((gcm clang).source -replace "clang.exe")" >> $env:GITHUB_ENV
+          echo "BINDGEN_EXTRA_CLANG_ARGS=-IC:\Program Files\LLVM\include" >> $env:GITHUB_ENV
 
       - uses: oxidize-rb/actions/setup-ruby-and-rust@main
         if: matrix.ruby_version != 'skip'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,15 @@ jobs:
               rust_toolchain: stable-x86_64-pc-windows-msvc
     runs-on: ${{ matrix.sys.os }}
     steps:
+      - name: Setup debug info
+        run: |
+          mkdir -p /tmp/debug
+
+          if [ "$ACTIONS_STEP_DEBUG" = "true" ]; then
+            echo "RUST_BACKTRACE=1" >> $GITHUB_ENV
+            echo "RUST_LOG=debug" >> $GITHUB_ENV
+          fi
+
       - uses: actions/checkout@v3
 
       - uses: oxidize-rb/actions/setup-ruby-and-rust@main
@@ -41,26 +50,15 @@ jobs:
           bundler-cache: true
           cargo-cache: true
 
-      # - name: Debug makefile
-      #   env:
-      #     BUNDLE_GEM__TEST: "rpec"
-      #     BUNDLE_GEM__CI: "github"
-      #     BUNDLE_GEM__MIT: "true"
-      #     BUNDLE_GEM__COC: "true"
-      #     BUNDLE_GEM__CHANGELOG: "true"
-      #     BUNDLE_GEM__LINTER: "standard"
-      #   run: |
-      #     mkdir tmp/
-      #     cd tmp/
-      #     bundle gem --ext testing
-      #     cd testing/ext/testing
-      #     ruby extconf.rb
-      #     cat Makefile
-
       - name: Bundle install
         if: matrix.ruby_version == 'skip'
         shell: bash
         run: bundle install -j3
+
+      - name: Debug makefile
+        if: env.ACTIONS_STEP_DEBUG == 'true'
+        shell: bash
+        run: bundle exec rake debug:mkmf > /tmp/debug/Makefile
 
       - name: 📍 Examples test
         env:
@@ -149,7 +147,9 @@ jobs:
         run: "bundle exec rake bindings:generate"
 
       - uses: actions/upload-artifact@v3
+        if: failure()
         with:
-          name: generated-bindings
-          path: /tmp/bindings/**/*
-          if-no-files-found: error
+          name: ci-debug-artifacts-${{ matrix.sys.os }}-${{ matrix.ruby_version }}
+          path: |
+            /tmp/bindings/**/*
+            /tmp/debug/**/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,11 @@ jobs:
 
       - uses: actions/checkout@v3
 
+      - name: Set LIBCLANG_PATH
+        if: matrix.ruby_version == 'mswin'
+        shell: pwsh
+        run: echo "LIBCLANG_PATH=$((gcm clang).source -replace "clang.exe")" >> $env:GITHUB_ENV
+
       - uses: oxidize-rb/actions/setup-ruby-and-rust@main
         if: matrix.ruby_version != 'skip'
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
       - main
   pull_request: {}
 
+env:
+  DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+  DEBUG_OUTPUT_DIR: /tmp/debug
+
 jobs:
   build_and_test:
     name: 🧪 Test
@@ -31,17 +35,11 @@ jobs:
               rust_toolchain: stable-x86_64-pc-windows-msvc
     runs-on: ${{ matrix.sys.os }}
     steps:
+      - uses: actions/checkout@v3
+
       - name: Setup debug info
         shell: bash
-        run: |
-          mkdir -p /tmp/debug
-
-          if [ "$ACTIONS_STEP_DEBUG" = "true" ]; then
-            echo "RUST_BACKTRACE=1" >> $GITHUB_ENV
-            echo "RUST_LOG=debug" >> $GITHUB_ENV
-          fi
-
-      - uses: actions/checkout@v3
+        run: script/ci/set-debug-env.sh
 
       - name: Set LIBCLANG_PATH
         if: matrix.ruby_version == 'mswin'
@@ -62,14 +60,29 @@ jobs:
         run: bundle install -j3
 
       - name: Debug makefile
-        if: env.ACTIONS_STEP_DEBUG == 'true'
+        if: secrets.ACTIONS_STEP_DEBUG == 'true'
         shell: bash
-        run: bundle exec rake debug:mkmf > /tmp/debug/Makefile
+        run: |
+          bundle exec rake debug:mkmf > $DEBUG_OUTPUT_DIR/Makefile
+          echo "::group::Print mkmf generated Makefile"
+          cat $DEBUG_OUTPUT_DIR/Makefile
+          echo "::endgroup::"
 
       - name: 📍 Examples test
         env:
           RB_SYS_CARGO_PROFILE: "release"
-        run: bundle exec rake test:examples
+        run: |
+          if ! bundle exec rake test:examples; then
+            echo "🎉 Examples test passed"
+          else
+            echo "❌ Examples test failed"
+
+            if [ "$DEBUG" = "true" ]; then
+              cp -R examples/ $DEBUG_OUTPUT_DIR/examples
+            fi
+
+            exit 1
+          fi
 
       - name: 🧪 Cargo test
         run: bundle exec rake test:cargo
@@ -82,7 +95,7 @@ jobs:
         run: |
           set -ex
           gem update --system > /dev/null
-          export RUBYOPT="-I$PWD/gem/lib"
+          export RUBYOPT="$RUBYOPT -I$PWD/gem/lib"
           pushd examples/rust_reverse
           bundle exec rake build
           gem install pkg/*.gem --verbose
@@ -102,15 +115,16 @@ jobs:
 
       - name: "🧱 Generate bindings"
         if: env.ACTIONS_STEP_DEBUG == 'true'
-        run: "bundle exec rake bindings:generate"
+        run: bundle exec rake bindings:generate
 
       - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: ci-debug-artifacts-${{ matrix.sys.os }}-${{ matrix.ruby_version }}
+          retention-days: 1
           path: |
             /tmp/bindings/**/*
-            /tmp/debug/**/*
+            ${{ env.DEBUG_OUTPUT_DIR }}/**/*
 
   build_and_test_static:
     name: 🔘 Static

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
         run: bundle install -j3
 
       - name: Debug makefile
-        if: secrets.ACTIONS_STEP_DEBUG == 'true'
+        if: env.ACTIONS_STEP_DEBUG == 'true'
         shell: bash
         run: |
           bundle exec rake debug:mkmf > $DEBUG_OUTPUT_DIR/Makefile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,6 @@ jobs:
         if: matrix.ruby_version == 'mswin'
         shell: pwsh
         run: |
-          echo "LIBCLANG_PATH=$((gcm clang).source -replace "clang.exe")" >> $env:GITHUB_ENV
           echo "BINDGEN_EXTRA_CLANG_ARGS=-IC:\Program Files\LLVM\include" >> $env:GITHUB_ENV
 
       - uses: oxidize-rb/actions/setup-ruby-and-rust@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,21 +71,11 @@ jobs:
       - name: 📍 Examples test
         env:
           RB_SYS_CARGO_PROFILE: "release"
-        run: |
-          if ! bundle exec rake test:examples; then
-            echo "🎉 Examples test passed"
-          else
-            echo "❌ Examples test failed"
-
-            if [ "$DEBUG" = "true" ]; then
-              cp -R examples/ $DEBUG_OUTPUT_DIR/examples
-            fi
-
-            exit 1
-          fi
+        run: script/ci/upload-on-failure.sh "bundle exec rake test:examples" "examples-test" "./examples"
 
       - name: 🧪 Cargo test
-        run: bundle exec rake test:cargo
+        shell: bash
+        run: script/ci/upload-on-failure.sh "bundle exec rake test:cargo" "cargo-test" "./target"
 
       - name: 💎 Gem test
         run: bundle exec rake test:gem
@@ -99,6 +89,7 @@ jobs:
           pushd examples/rust_reverse
           bundle exec rake build
           gem install pkg/*.gem --verbose
+          script/ci/upload-on-failure.sh "gem install pkg/*.gem --verbose" "smoke-test" "./pkg"
           ruby -rrust_reverse -e "puts RustReverse.reverse('olleh')" | grep hello
           popd
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
         run: |
           set -ex
           gem update --system > /dev/null
-          export RUBYOPT="$RUBYOPT -I$PWD/gem/lib"
+          export RUBYOPT="-I$PWD/gem/lib"
           pushd examples/rust_reverse
           bundle exec rake build
           gem install pkg/*.gem --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,18 @@ jobs:
         if: matrix.ruby_version == '3.1'
         run: bundle exec standardrb --format github
 
+      - name: "🧱 Generate bindings"
+        if: env.ACTIONS_STEP_DEBUG == 'true'
+        run: "bundle exec rake bindings:generate"
+
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: ci-debug-artifacts-${{ matrix.sys.os }}-${{ matrix.ruby_version }}
+          path: |
+            /tmp/bindings/**/*
+            /tmp/debug/**/*
+
   build_and_test_static:
     name: 🔘 Static
     strategy:
@@ -147,14 +159,3 @@ jobs:
 
       - name: 🧪 Run tests
         run: bundle exec rake test
-
-      - name: "🧱 Generate bindings"
-        run: "bundle exec rake bindings:generate"
-
-      - uses: actions/upload-artifact@v3
-        if: failure()
-        with:
-          name: ci-debug-artifacts-${{ matrix.sys.os }}-${{ matrix.ruby_version }}
-          path: |
-            /tmp/bindings/**/*
-            /tmp/debug/**/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,8 @@ jobs:
       - uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: ci-debug-artifacts-${{ matrix.sys.os }}-${{ matrix.ruby_version }}
+          name: rb-sys-ci-debug-artifacts-${{ matrix.sys.os }}-${{ matrix.ruby_version }}
+          if-no-files-found: ignore
           retention-days: 1
           path: |
             /tmp/bindings/**/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       - name: 📍 Examples test
         env:
           RB_SYS_CARGO_PROFILE: "release"
-        run: script/ci/upload-on-failure.sh "bundle exec rake test:examples" "examples-test" "./examples"
+        run: ../../script/ci/upload-on-failure.sh "bundle exec rake test:examples" "examples-test" "./examples"
 
       - name: 🧪 Cargo test
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       - name: 📍 Examples test
         env:
           RB_SYS_CARGO_PROFILE: "release"
-        run: ../../script/ci/upload-on-failure.sh "bundle exec rake test:examples" "examples-test" "./examples"
+        run: script/ci/upload-on-failure.sh "bundle exec rake test:examples" "examples-test" "./examples"
 
       - name: 🧪 Cargo test
         shell: bash
@@ -89,7 +89,7 @@ jobs:
           pushd examples/rust_reverse
           bundle exec rake build
           gem install pkg/*.gem --verbose
-          script/ci/upload-on-failure.sh "gem install pkg/*.gem --verbose" "smoke-test" "./pkg"
+          ../../script/ci/upload-on-failure.sh "gem install pkg/*.gem --verbose" "smoke-test" "./pkg"
           ruby -rrust_reverse -e "puts RustReverse.reverse('olleh')" | grep hello
           popd
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,12 +41,6 @@ jobs:
         shell: bash
         run: script/ci/set-debug-env.sh
 
-      - name: Set LIBCLANG_PATH
-        if: matrix.ruby_version == 'mswin'
-        shell: pwsh
-        run: |
-          echo "BINDGEN_EXTRA_CLANG_ARGS=-IC:\Program Files\LLVM\include" >> $env:GITHUB_ENV
-
       - uses: oxidize-rb/actions/setup-ruby-and-rust@main
         if: matrix.ruby_version != 'skip'
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
     runs-on: ${{ matrix.sys.os }}
     steps:
       - name: Setup debug info
+        shell: bash
         run: |
           mkdir -p /tmp/debug
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
           echo "::endgroup::"
 
       - name: 📍 Examples test
+        shell: bash
         env:
           RB_SYS_CARGO_PROFILE: "release"
         run: script/ci/upload-on-failure.sh "bundle exec rake test:examples" "examples-test" "./examples"

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,10 @@
 EXAMPLES = Dir["examples/*"]
 
+CLEAN = Rake::FileList.new.tap do |list|
+  list.include("**/target")
+  list.include("**/tmp")
+end
+
 def extra_args
   seperator_index = ARGV.index("--")
   seperator_index && ARGV[(seperator_index + 1)..-1]
@@ -159,4 +164,9 @@ namespace :debug do
 
     rm_rf(tmpdir)
   end
+end
+
+desc "Clean up"
+task :clean do
+  CLEAN.each { |f| rm_rf(f) }
 end

--- a/Rakefile
+++ b/Rakefile
@@ -144,3 +144,19 @@ namespace :bindings do
     FileUtils.cp(bindings_file, out_dir)
   end
 end
+
+namespace :debug do
+  task :mkmf do
+    require "tmpdir"
+    tmpdir = Dir.mktmpdir
+
+    chdir(tmpdir) do
+      touch "testing.c"
+      touch "testing.h"
+      sh "ruby", "-rmkmf", "-e", "create_makefile('testing')"
+      puts File.read("Makefile")
+    end
+
+    rm_rf(tmpdir)
+  end
+end

--- a/script/ci/set-debug-env.sh
+++ b/script/ci/set-debug-env.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -e
+
+is_debug_info_enabled() {
+  if [[ "${DEBUG:-false}" == "true" ]]; then
+    true
+  elif [[ "${CI:-false}" == "true" ]]; then
+    false
+  else
+    true
+  fi
+}
+
+set_env_var() {
+  if [[ -n "$GITHUB_ENV" ]]; then
+    echo "${1}=${2}" >> "$GITHUB_ENV"
+  else
+    echo "export ${1}=${2}"
+  fi
+}
+
+main() {
+  mkdir -p "${DEBUG_OUTPUT_DIR:-/tmp/debug}"
+
+  if is_debug_info_enabled; then
+    set_env_var "RUST_BACKTRACE" "1"
+    set_env_var "RUST_LOG" "debug"
+    set_env_var "RB_SYS_VERBOSE" "true"
+    set_env_var "CARGO_TERM_VERBOSE" "true"
+    set_env_var "RUBYOPT" "-w"
+    set_env_var "V" "1"
+  fi
+}
+
+main

--- a/script/ci/upload-on-failure.sh
+++ b/script/ci/upload-on-failure.sh
@@ -5,7 +5,7 @@
 # Example:
 #   $ run-and-upload-on-failure.sh "cargo test --all-features" "cargo-test" "target/debug"
 main() {
-  if "$1"; then
+  if eval "$1"; then
     if [[ "${DEBUG:-false}" == "true" ]]; then
       upload_dir "$2" "$3"
     fi

--- a/script/ci/upload-on-failure.sh
+++ b/script/ci/upload-on-failure.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Exec given command and copy debug info to a file if it fails
+#
+# Example:
+#   $ run-and-upload-on-failure.sh "cargo test --all-features" "cargo-test" "target/debug"
+main() {
+  if "$1"; then
+    exit 0
+  else
+    exit_code=$?
+    output_dir="${DEBUG_OUTPUT_DIR:-/tmp/debug}/$2"
+    output_file="${output_dir}.tar"
+
+    mkdir -p "$output_dir"
+    tar -cf "$output_file" -C "$3" .
+    echo "[ERROR] Command failed, debug output saved to $output_file" >&2
+    exit $exit_code
+  fi
+}
+
+main "$@"

--- a/script/ci/upload-on-failure.sh
+++ b/script/ci/upload-on-failure.sh
@@ -6,17 +6,26 @@
 #   $ run-and-upload-on-failure.sh "cargo test --all-features" "cargo-test" "target/debug"
 main() {
   if "$1"; then
+    if [[ "${DEBUG:-false}" == "true" ]]; then
+      upload_dir "$2" "$3"
+    fi
+
     exit 0
   else
     exit_code=$?
-    output_dir="${DEBUG_OUTPUT_DIR:-/tmp/debug}/$2"
-    output_file="${output_dir}.tar"
-
-    mkdir -p "$output_dir"
-    tar -cf "$output_file" -C "$3" .
-    echo "[ERROR] Command failed, debug output saved to $output_file" >&2
+    upload_dir "$2" "$3"
     exit $exit_code
   fi
+}
+
+
+upload_dir() {
+  output_dir="${DEBUG_OUTPUT_DIR:-/tmp/debug}/$1"
+  output_file="${output_dir}.tar"
+
+  mkdir -p "$output_dir"
+  tar -cf "$output_file" -C "$2" .
+  echo "[INFO] Debug output saved to $output_file" >&2
 }
 
 main "$@"


### PR DESCRIPTION
Somewhere along the way, bindgen started including the wrong path for clang when generating bindings. This PR adds some debugging helpers, but ultimate relies on https://github.com/oxidize-rb/actions/commit/27945b582cd8f0e17392e8d0690012979923777e for the bindgen fix.