### PR TITLE
Block `compress-debug-sections` link arg

### DIFF
--- a/crates/rb-sys-build/src/rb_config.rs
+++ b/crates/rb-sys-build/src/rb_config.rs
@@ -26,6 +26,7 @@ pub struct RbConfig {
     pub link_args: Vec<String>,
     pub cflags: Vec<String>,
     pub blocklist_lib: Vec<String>,
+    pub blocklist_link_arg: Vec<String>,
     use_rpath: bool,
     value_map: HashMap<String, String>,
 }
@@ -41,6 +42,7 @@ impl RbConfig {
     pub fn new() -> RbConfig {
         RbConfig {
             blocklist_lib: vec![],
+            blocklist_link_arg: vec![],
             search_paths: Vec::new(),
             libs: Vec::new(),
             link_args: Vec::new(),
@@ -145,6 +147,12 @@ impl RbConfig {
     /// Filter the libs, removing the ones that are not needed.
     pub fn blocklist_lib(&mut self, name: &str) -> &mut RbConfig {
         self.blocklist_lib.push(name.to_string());
+        self
+    }
+
+    /// Blocklist a link argument.
+    pub fn blocklist_link_arg(&mut self, name: &str) -> &mut RbConfig {
+        self.blocklist_link_arg.push(name.to_string());
         self
     }
 
@@ -291,7 +299,7 @@ impl RbConfig {
                 self.push_search_path((SearchPathKind::Framework, name));
             } else if let Some(name) = capture_name(&framework_regex_long, &arg) {
                 self.push_library((LibraryKind::Framework, name));
-            } else {
+            } else if !self.blocklist_link_arg.iter().any(|b| arg.contains(b)) {
                 self.push_link_arg(arg);
             }
         }

--- a/crates/rb-sys/build/main.rs
+++ b/crates/rb-sys/build/main.rs
@@ -45,11 +45,16 @@ fn main() {
     }
 
     expose_cargo_features();
+    add_unsupported_link_args_to_blocklist(&mut rbconfig);
     rbconfig.print_cargo_args();
 
     if is_debug_build_enabled() {
         debug_and_exit(&mut rbconfig);
     }
+}
+
+fn add_unsupported_link_args_to_blocklist(rbconfig: &mut RbConfig) {
+    rbconfig.blocklist_link_arg("compress-debug-sections");
 }
 
 fn add_libruby_to_blocklist(rbconfig: &mut RbConfig) {


### PR DESCRIPTION
Started seeing this pop up recently, [like here](https://github.com/bytecodealliance/wasmtime-rb/actions/runs/3661541694/jobs/6189849318).

I'm assuming this is happening because Ruby is adding this flag because it detects that `ld` supports it. However, in `rake-compiler-dock` we use a different `ld` for cross compilation which does not support the flag.

The benefits of it in Rust extensions are not clear, and it's better to let cargo choose anyway.

For reference, [there's a discussion on Ruby issue tracker about the flag](https://bugs.ruby-lang.org/issues/12934) and how it can negatively impact there performance of debugging tools, as well.