### PR TITLE
Codify the minimum supported ruby and rust versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,20 @@ env:
   DEBUG_OUTPUT_DIR: /tmp/debug
 
 jobs:
+  fetch_ci_data:
+    name: 📥 Fetch CI data
+    runs-on: ubuntu-latest
+    outputs:
+      minimum-supported-ruby-version: ${{ steps.data.outputs.minimum-supported-ruby-version }}
+      minimum-supported-rust-version: ${{ steps.data.outputs.minimum-supported-rust-version }}
+    steps:
+      - id: data
+        run: |
+          curl -s https://raw.githubusercontent.com/oxidize-rb/rb-sys/$GITHUB_SHA/data/toolchains.json > toolchains.json
+          echo "minimum-supported-rust-version=$(jq -r '.policy["minimum-supported-rust-version"]' toolchains.json)" >> $GITHUB_OUTPUT
   build_and_test:
     name: 🧪 Test
+    needs: fetch_ci_data
     strategy:
       fail-fast: false
       matrix:
@@ -21,7 +33,7 @@ jobs:
         ruby_version: ["2.4", "2.5", "2.6", "2.7", "3.0", "3.1", "head"]
         sys:
           - os: ubuntu-latest
-            rust_toolchain: "1.51"
+            rust_toolchain: ${{ needs.fetch_ci_data.outputs.minimum-supported-rust-version }}
           - os: ubuntu-latest
             rust_toolchain: stable
           - os: macos-latest

--- a/data/toolchains.json
+++ b/data/toolchains.json
@@ -1,4 +1,8 @@
 {
+  "policy": {
+    "minimum-supported-ruby-version": "2.4",
+    "minimum-supported-rust-version": "1.51"
+  },
   "toolchains": [
     {
       "ruby-platform": "arm-linux",

--- a/rakelib/readme.rake
+++ b/rakelib/readme.rake
@@ -1,0 +1,19 @@
+namespace :readme do
+  task :toolchains do
+    contents = File.read("readme.md")
+    toolchains = JSON.parse(File.read("data/toolchains.json"))
+
+    new_contents = contents.gsub(/<!--toolchains ([^>]+) --><!--\/toolchains -->/) do
+      path = $1
+      parts = path.split(".").compact.reject(&:empty?)
+      value = toolchains.dig(*parts) || raise("No value for path: #{parts}")
+
+      "<!--toolchains #{path} -->#{value}<!--/toolchains-->"
+    end
+
+    File.write("readme.md", new_contents)
+  end
+end
+
+desc "Compile the README"
+task readme: ["readme:toolchains"]

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -1,15 +1,16 @@
 namespace :release do
   desc "Bump the gem version"
-  task bump: ["data:derive"] do
+  task bump: ["readme", "data:derive"] do
     require_relative "./../gem/lib/rb_sys/version"
     old_version = RbSys::VERSION
 
     printf "What is the new version (current: #{old_version})?: "
     new_version = $stdin.gets.chomp
 
-    sh "fastmod", "--extensions=md", old_version.to_s, new_version.to_s
-    sh "fastmod", "--extensions=toml", "version = \"#{old_version}\"", "version = #{new_version.inspect}"
-    sh "fastmod", "--extensions=rb", "^  VERSION = \"#{old_version}\"", "  VERSION = #{new_version.inspect}"
+    sh "fastmod", "--extensions=md", "--accept-all", old_version.to_s, new_version.to_s
+    sh "fastmod", "--extensions=toml", "--accept-all", "^version = \"#{old_version}\"", "version = #{new_version.inspect}"
+    sh "fastmod", "--extensions=toml", "--accept-all", "rb-sys = { version = \"#{old_version}\"", "rb-sys = { version = #{new_version.inspect}"
+    sh "fastmod", "--extensions=rb", "--accept-all", "^  VERSION = \"#{old_version}\"", "  VERSION = #{new_version.inspect}"
     sh "cargo check"
     Dir.chdir("examples/rust_reverse") { sh("cargo", "check") }
     sh "bundle"

--- a/readme.md
+++ b/readme.md
@@ -37,6 +37,13 @@ building your own gem.
 - This [PR for the `yrb` gem][yrb] shows how to integrate `rb-sys` and [`magnus`][magnus] into an existing gem.
 - A [guide for setting debug breakpoints in VSCode][debugging-guide] is available.
 
+## Supported Toolchains
+
+- Ruby: <!--toolchains .policy.minimum-supported-ruby-version -->2.4<!--/toolchains-->+ (for full compatibility with
+  Rubygems)
+- Rust: <!--toolchains .policy.minimum-supported-rust-version -->1.51<!--/toolchains-->+ (for old versions of rust
+  toolchains ubuntu)
+
 ## Supported Platforms
 
 We support cross compilation to the following platforms (this information is also available in the [`./data`](./data)


### PR DESCRIPTION
We have had an informal rust and ruby support policy for awhile, this PR just codifies it.