### PR TITLE
Make `pkgconfig` configuration more robust

### DIFF
--- a/docker/Dockerfile.arm-linux
+++ b/docker/Dockerfile.arm-linux
@@ -12,6 +12,7 @@ ENV RUBY_TARGET="arm-linux" \
     CXX_arm_unknown_linux_gnueabihf="arm-linux-gnueabihf-g++" \
     AR_arm_unknown_linux_gnueabihf="arm-linux-gnueabihf-ar" \
     BINDGEN_EXTRA_CLANG_ARGS_arm_unknown_linux_gnueabihf="--sysroot=/usr/arm-linux-gnueabihf" \
+    PKG_CONFIG_PATH="/usr/lib/arm-linux-gnueabihf/pkgconfig" \
     CMAKE_arm_unknown_linux_gnueabihf="/opt/cmake/bin/cmake"
 
 COPY setup/lib.sh /lib.sh

--- a/docker/Dockerfile.arm64-darwin
+++ b/docker/Dockerfile.arm64-darwin
@@ -13,6 +13,7 @@ ENV RUBY_TARGET="arm64-darwin" \
     AR_aarch64_apple_darwin="aarch64-apple-darwin-ar" \
     BINDGEN_EXTRA_CLANG_ARGS_aarch64_apple_darwin="--sysroot=/opt/osxcross/target/SDK/MacOSX11.1.sdk/" \
     CARGO_TARGET_AARCH64_APPLE_DARWIN_LINKER="aarch64-apple-darwin-clang" \
+    PKG_CONFIG="aarch64-apple-darwin-pkg-config" \
     CMAKE_aarch64_apple_darwin="/opt/cmake/bin/cmake"
 
 COPY setup/lib.sh /lib.sh

--- a/docker/Dockerfile.x64-mingw-ucrt
+++ b/docker/Dockerfile.x64-mingw-ucrt
@@ -12,6 +12,7 @@ ENV RUBY_TARGET="x64-mingw-ucrt" \
     CC_x86_64_pc_windows_gnu="x86_64-w64-mingw32-gcc" \
     CXX_x86_64_pc_windows_gnu="x86_64-w64-mingw32-g++" \
     AR_x86_64_pc_windows_gnu="x86_64-w64-mingw32-ar" \
+    PKG_CONFIG_PATH_x86_64_pc_windows_gnu="/usr/x86_64-w64-mingw32/pkgconfig" \
     CMAKE_x86_64_pc_windows_gnu="/opt/cmake/bin/cmake"
 
 COPY setup/lib.sh /lib.sh

--- a/docker/Dockerfile.x64-mingw32
+++ b/docker/Dockerfile.x64-mingw32
@@ -12,6 +12,7 @@ ENV RUBY_TARGET="x64-mingw32" \
     CC_x86_64_pc_windows_gnu="x86_64-w64-mingw32-gcc" \
     CXX_x86_64_pc_windows_gnu="x86_64-w64-mingw32-g++" \
     AR_x86_64_pc_windows_gnu="x86_64-w64-mingw32-ar" \
+    PKG_CONFIG_PATH_x86_64_pc_windows_gnu="/usr/x86_64-w64-mingw32/pkgconfig" \
     CMAKE_x86_64_pc_windows_gnu="/opt/cmake/bin/cmake"
 
 COPY setup/lib.sh /lib.sh

--- a/docker/Dockerfile.x86-mingw32
+++ b/docker/Dockerfile.x86-mingw32
@@ -12,6 +12,7 @@ ENV RUBY_TARGET="x86-mingw32" \
     CC_i686_pc_windows_gnu="i686-w64-mingw32-gcc" \
     CXX_i686_pc_windows_gnu="i686-w64-mingw32-g++" \
     AR_i686_pc_windows_gnu="i686-w64-mingw32-gcc-ar" \
+    PKG_CONFIG_PATH_i686_pc_windows_gnu="/usr/i686-w64-mingw32/pkgconfig" \
     CMAKE_i686_pc_windows_gnu="/opt/cmake/bin/cmake"
 
 COPY setup/lib.sh /lib.sh

--- a/docker/Dockerfile.x86_64-darwin
+++ b/docker/Dockerfile.x86_64-darwin
@@ -13,6 +13,7 @@ ENV RUBY_TARGET="x86_64-darwin" \
     AR_x86_64_apple_darwin="x86_64-apple-darwin-ar" \
     BINDGEN_EXTRA_CLANG_ARGS_x86_64_apple_darwin="--sysroot=/opt/osxcross/target/SDK/MacOSX11.1.sdk/" \
     CARGO_TARGET_X86_64_APPLE_DARWIN_LINKER="x86_64-apple-darwin-clang" \
+    PKG_CONFIG="x86_64-apple-darwin-pkg-config" \
     CMAKE_x86_64_apple_darwin="/opt/cmake/bin/cmake"
 
 COPY setup/lib.sh /lib.sh

--- a/gem/exe/rb-sys-dock
+++ b/gem/exe/rb-sys-dock
@@ -213,7 +213,7 @@ def log_some_useful_info(_options)
 end
 
 def set_env(options)
-  ENV["RCD_IMAGE"] ||= "rbsys/#{options[:toolchain_info]}:#{options[:version]}"
+  ENV["RCD_IMAGE"] ||= "rbsys/#{options[:toolchain_info].platform}:#{options[:version]}"
 end
 
 set_env(options)


### PR DESCRIPTION
Previously, we did not specify the target for `pkgconfig`, which could lead to installation issues.