### PR TITLE
Block compress-debug-sections linker arg in `rb_sys/mkmf`

### DIFF
--- a/gem/lib/rb_sys/cargo_builder.rb
+++ b/gem/lib/rb_sys/cargo_builder.rb
@@ -1,3 +1,5 @@
+require_relative "cargo_builder/link_flag_converter"
+
 module RbSys
   # A class to build a Ruby gem Cargo. Extracted from `rubygems` gem, with some modifications.
   class CargoBuilder < Gem::Ext::Builder

--- a/gem/lib/rb_sys/cargo_builder/link_flag_converter.rb
+++ b/gem/lib/rb_sys/cargo_builder/link_flag_converter.rb
@@ -1,10 +1,22 @@
 # frozen_string_literal: true
 
+require "shellwords"
+
 module RbSys
-  class CargoBuilder
+  class CargoBuilder < Gem::Ext::Builder
     # Converts Ruby link flags into something cargo understands
     class LinkFlagConverter
-      def self.convert(arg)
+      FILTERED_PATTERNS = [
+        /compress-debug-sections/ # Not supported by all linkers, and not required for Rust
+      ]
+
+      def self.convert(args)
+        Shellwords.split(args).flat_map { |arg| convert_arg(arg) }
+      end
+
+      def self.convert_arg(arg)
+        return [] if FILTERED_PATTERNS.any? { |p| p.match?(arg) }
+
         case arg.chomp
         when /^-L\s*(.+)$/
           ["-L", "native=#{$1}"]

--- a/gem/test/test_link_flag_converter.rb
+++ b/gem/test/test_link_flag_converter.rb
@@ -1,0 +1,12 @@
+require "test_helper"
+require "rb_sys/cargo_builder"
+
+class TestLinkFlagConverter < Minitest::Test
+  def test_link_arg_detection
+    flags = "-L/opt/ruby/lib  -Wl,--compress-debug-sections=zlib -Wl,-undefined,dynamic_lookup"
+    args = Shellwords.split(flags)
+    args = args.flat_map { |arg| RbSys::CargoBuilder::LinkFlagConverter.convert(arg) }
+
+    assert_equal ["-L", "native=/opt/ruby/lib", "-C", "link_arg=-Wl,-undefined,dynamic_lookup"], args
+  end
+end

--- a/gem/test/test_rb_sys.rb
+++ b/gem/test/test_rb_sys.rb
@@ -29,6 +29,14 @@ class TestRbSys < Minitest::Test
     assert_match(/export NO_LINK_RUTIE := true/, makefile.read)
   end
 
+  def test_doesnt_contain_blocked_link_args
+    makefile = create_makefile
+    lines = makefile.read.split("\n")
+    cargo_command = lines.find { |l| l.include? "rustc" }
+
+    assert !cargo_command.include?("compress-debug-sections")
+  end
+
   def test_uses_custom_profile
     makefile = create_makefile do |b|
       b.profile = :dev


### PR DESCRIPTION
We previously blocked this flag in the cargo build phase, but we also need to block it for the gem compilation phase.