### PR TITLE
Block libssp

### DIFF
--- a/gem/lib/rb_sys/cargo_builder/link_flag_converter.rb
+++ b/gem/lib/rb_sys/cargo_builder/link_flag_converter.rb
@@ -7,7 +7,8 @@ module RbSys
     # Converts Ruby link flags into something cargo understands
     class LinkFlagConverter
       FILTERED_PATTERNS = [
-        /compress-debug-sections/ # Not supported by all linkers, and not required for Rust
+        /compress-debug-sections/, # Not supported by all linkers, and not required for Rust
+        /libssp/
       ]
 
       def self.convert(args)


### PR DESCRIPTION
wasmtime-rb builds are failing on Windows because libssp can't be found ([example build](https://github.com/bytecodealliance/wasmtime-rb/actions/runs/3707904651/jobs/6285025179)):
> error: could not find native static library `ssp`, perhaps an -L flag is missing?


Here's the result of [`RB_SYS_DEBUG_BUILD`](https://gist.github.com/jbourassa/4943fd60164a4c64236053b65b319bec). I found that libssp is on the machine, but not in the library path:
- `/usr/lib/gcc/x86_64-w64-mingw32/9.3-win32`
- `/usr/lib/gcc/x86_64-w64-mingw32/9.3-posix`

A [recent build on yrb](https://github.com/y-crdt/yrb/actions/runs/3696220120/jobs/6259625710) linked against `ssp` just fine. The 2 builds must use slightly different containers I assume (0.9.50 vs 0.9.51), not sure what that should change.


Skipping libssp fixed the issue, so I figured I should bring this up in a PR. **I don't know if it's the right fix.**