### PR TITLE
Stop rewriting static libs

### DIFF
--- a/gem/lib/rb_sys/cargo_builder/link_flag_converter.rb
+++ b/gem/lib/rb_sys/cargo_builder/link_flag_converter.rb
@@ -22,14 +22,12 @@ module RbSys
           ["-L", "native=#{$1}"]
         when /^--library=(\w+\S+)$/, /^-l\s*(\w+\S+)$/
           ["-l", $1]
-        when /^-l\s*:lib(\S+).a$/
-          ["-l", "static=#{$1}"]
         when /^-l\s*:lib(\S+).(so|dylib|dll)$/
           ["-l", "dylib=#{$1}"]
         when /^-F\s*(.*)$/
           ["-l", "framework=#{$1}"]
         else
-          ["-C", "link_arg=#{arg}"]
+          ["-C", "link-arg=#{arg}"]
         end
       end
     end

--- a/gem/test/test_link_flag_converter.rb
+++ b/gem/test/test_link_flag_converter.rb
@@ -7,6 +7,14 @@ class TestLinkFlagConverter < Minitest::Test
     args = Shellwords.split(flags)
     args = args.flat_map { |arg| RbSys::CargoBuilder::LinkFlagConverter.convert(arg) }
 
-    assert_equal ["-L", "native=/opt/ruby/lib", "-C", "link_arg=-Wl,-undefined,dynamic_lookup"], args
+    assert_equal ["-L", "native=/opt/ruby/lib", "-C", "link-arg=-Wl,-undefined,dynamic_lookup"], args
+  end
+
+  def test_not_converting_static_libs
+    flags = "-lshlwapi -l:libssp.a"
+    args = Shellwords.split(flags)
+    args = args.flat_map { |arg| RbSys::CargoBuilder::LinkFlagConverter.convert(arg) }
+
+    assert_equal ["-l", "shlwapi", "-C", "link-arg=-l:libssp.a"], args
   end
 end


### PR DESCRIPTION
As per Ian's [suggestion here](https://github.com/oxidize-rb/rb-sys/pull/123#issuecomment-1355635048), this PR makes it so `-l:lib.+\.a$` are not rewritten, and instead passed as link-arg.

That seems to work in wasmtime-rb as per my `rb-sys-dock` experiments. I haven't tried the full rb-sys in CI yet with the crate changes.