### PR TITLE
Fix build on Ruby 3.2

### DIFF
--- a/crates/rb-sys-build/src/rb_config.rs
+++ b/crates/rb-sys-build/src/rb_config.rs
@@ -315,8 +315,11 @@ impl RbConfig {
     pub fn has_ruby_dln_check_abi(&self) -> bool {
         let major = self.get("MAJOR").parse::<i32>().unwrap();
         let minor = self.get("MINOR").parse::<i32>().unwrap();
+        let patchlevel = self.get("PATCHLEVEL").parse::<i32>().unwrap();
 
-        major >= 3 && minor >= 2 && !cfg!(target_family = "windows")
+        // Ruby has ABI version on verion 3.2 and later only on development
+        // versions
+        major >= 3 && minor >= 2 && patchlevel == -1 && !cfg!(target_family = "windows")
     }
 
     // Examines the string from shell variables and expands them with values in the value_map

--- a/crates/rb-sys-tests/src/ruby_abi_version_test.rs
+++ b/crates/rb-sys-tests/src/ruby_abi_version_test.rs
@@ -1,6 +1,6 @@
 rb_sys::ruby_abi_version!();
 
-#[cfg(all(ruby_gte_3_2, unix))]
+#[cfg(all(ruby_has_ruby_abi_version, unix))]
 #[test]
 fn test_ruby_abi_version() {
     assert!(ruby_abi_version() >= 1)


### PR DESCRIPTION
After ruby/ruby@cd1a0b3, only development versions of Ruby have RUBY_ABI_VERSION defined. This means that rb-sys fails to compile on released version of 3.2.0.