### PR TITLE
Add support for Ruby 3.2

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,8 +32,8 @@ jobs:
       # Test the container
       - uses: actions/checkout@v3
         with:
-          repository: "oxidize-rb/cross-gem-action"
-          path: "tmp/cross-gem-action"
+          repository: "oxidize-rb/oxi-test"
+          path: "tmp/oxi-test"
 
       - name: Print env info
         run: |
@@ -77,10 +77,10 @@ jobs:
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
-      # - uses: "oxidize-rb/cross-gem-action@main"
-      #   with:
-      #     platform: ${{ matrix.platform.ruby_target }}
-      #     directory: tmp/cross-gem-action/__tests__/fixtures/test-gem
+      - uses: "oxidize-rb/cross-gem-action@main"
+        with:
+          platform: ${{ matrix.platform.ruby_target }}
+          directory: tmp/oxi-test
 
       - name: Push images
         if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -77,10 +77,14 @@ jobs:
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.1"
+
       - name: Run tests
         run: |
-          gem install rb_sys
           cd tmp/oxi-test
+          bundle install
           rb-sys-dock --platform ${{ matrix.platform.ruby_target }} --latest -- \
             "bash -c 'bundle install && bundle exec rake native:${{ matrix.platform.ruby_target }} gem'"
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -85,6 +85,7 @@ jobs:
         run: |
           sudo chown -R $USER:$USER tmp/oxi-test
           cd tmp/oxi-test
+          gem install rb_sys
           rb-sys-dock --platform ${{ matrix.platform.ruby_target }} --latest -- \
             "bash -c 'bundle install && bundle exec rake native:${{ matrix.platform.ruby_target }} gem'"
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Run tests
         run: |
-          sudo chown -R $USER:$USER tmp/oxi-test
+          sudo chmod 777 tmp/oxi-test
           cd tmp/oxi-test
           gem install rb_sys
           rb-sys-dock --platform ${{ matrix.platform.ruby_target }} --latest -- \

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -77,10 +77,12 @@ jobs:
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
-      - uses: "oxidize-rb/cross-gem-action@main"
-        with:
-          platform: ${{ matrix.platform.ruby_target }}
-          directory: tmp/oxi-test
+      - name: Run tests
+        run: |
+          gem install rb_sys
+          cd tmp/oxi-test
+          rb-sys-dock --platform ${{ matrix.platform.ruby_target }} --latest -- \
+            "bash -c 'bundle install && bundle exec rake native:${{ matrix.platform.ruby_target }} gem'"
 
       - name: Push images
         if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -83,8 +83,8 @@ jobs:
 
       - name: Run tests
         run: |
+          sudo chown -R $USER:$USER tmp/oxi-test
           cd tmp/oxi-test
-          bundle install
           rb-sys-dock --platform ${{ matrix.platform.ruby_target }} --latest -- \
             "bash -c 'bundle install && bundle exec rake native:${{ matrix.platform.ruby_target }} gem'"
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -86,6 +86,10 @@ jobs:
           sudo chmod 777 tmp/oxi-test
           cd tmp/oxi-test
           gem install rb_sys
+
+          export RB_SYS_DOCK_UID=$(id -u)
+          export RB_SYS_DOCK_GID=$(id -g)
+
           rb-sys-dock --platform ${{ matrix.platform.ruby_target }} --latest -- \
             "bash -c 'bundle install && bundle exec rake native:${{ matrix.platform.ruby_target }} gem'"
 

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,8 @@
+[target.x86_64-unknown-linux-gnu]
+image = "ghcr.io/oxidize-rb/x86_64-linux:3.2-ubuntu"
+
+[target.aarch64-unknown-linux-gnu]
+image = "ghcr.io/oxidize-rb/aarch64-linux:3.2-ubuntu"
+
+[target.aarch64-unknown-linux-musl]
+image = "ghcr.io/oxidize-rb/aarch64-linux-musl:3.2-ubuntu"

--- a/docker/Dockerfile.aarch64-linux
+++ b/docker/Dockerfile.aarch64-linux
@@ -1,4 +1,4 @@
-FROM larskanis/rake-compiler-dock-mri-aarch64-linux:1.2.2
+FROM ghcr.io/rake-compiler/rake-compiler-dock-snapshot:aarch64-linux
 
 ENV RUBY_TARGET="aarch64-linux" \
     RUST_TARGET="aarch64-unknown-linux-gnu" \

--- a/docker/Dockerfile.arm-linux
+++ b/docker/Dockerfile.arm-linux
@@ -1,4 +1,4 @@
-FROM larskanis/rake-compiler-dock-mri-arm-linux:1.2.2
+FROM ghcr.io/rake-compiler/rake-compiler-dock-snapshot:arm-linux
 
 ENV RUBY_TARGET="arm-linux" \
     RUST_TARGET="arm-unknown-linux-gnueabihf" \

--- a/docker/Dockerfile.arm64-darwin
+++ b/docker/Dockerfile.arm64-darwin
@@ -1,4 +1,4 @@
-FROM larskanis/rake-compiler-dock-mri-arm64-darwin:1.2.2
+FROM ghcr.io/rake-compiler/rake-compiler-dock-snapshot:arm64-darwin
 
 ENV RUBY_TARGET="arm64-darwin" \
     RUST_TARGET="aarch64-apple-darwin" \

--- a/docker/Dockerfile.x64-mingw-ucrt
+++ b/docker/Dockerfile.x64-mingw-ucrt
@@ -1,4 +1,4 @@
-FROM larskanis/rake-compiler-dock-mri-x64-mingw-ucrt:1.2.2
+FROM ghcr.io/rake-compiler/rake-compiler-dock-snapshot:x64-mingw-ucrt
 
 ENV RUBY_TARGET="x64-mingw-ucrt" \
     RUST_TARGET="x86_64-pc-windows-gnu" \

--- a/docker/Dockerfile.x64-mingw32
+++ b/docker/Dockerfile.x64-mingw32
@@ -1,4 +1,4 @@
-FROM larskanis/rake-compiler-dock-mri-x64-mingw32:1.2.2
+FROM ghcr.io/rake-compiler/rake-compiler-dock-snapshot:x64-mingw32
 
 ENV RUBY_TARGET="x64-mingw32" \
     RUST_TARGET="x86_64-pc-windows-gnu" \

--- a/docker/Dockerfile.x86-linux
+++ b/docker/Dockerfile.x86-linux
@@ -1,4 +1,4 @@
-FROM larskanis/rake-compiler-dock-mri-x86-linux:1.2.2
+FROM ghcr.io/rake-compiler/rake-compiler-dock-snapshot:x86-linux
 
 ENV RUBY_TARGET="x86-linux" \
     RUST_TARGET="i686-unknown-linux-gnu" \

--- a/docker/Dockerfile.x86-mingw32
+++ b/docker/Dockerfile.x86-mingw32
@@ -1,4 +1,4 @@
-FROM larskanis/rake-compiler-dock-mri-x86-mingw32:1.2.2
+FROM ghcr.io/rake-compiler/rake-compiler-dock-snapshot:x86-mingw32
 
 ENV RUBY_TARGET="x86-mingw32" \
     RUST_TARGET="i686-pc-windows-gnu" \

--- a/docker/Dockerfile.x86_64-darwin
+++ b/docker/Dockerfile.x86_64-darwin
@@ -1,4 +1,4 @@
-FROM larskanis/rake-compiler-dock-mri-x86_64-darwin:1.2.2
+FROM ghcr.io/rake-compiler/rake-compiler-dock-snapshot:x86_64-darwin
 
 ENV RUBY_TARGET="x86_64-darwin" \
     RUST_TARGET="x86_64-apple-darwin" \

--- a/docker/Dockerfile.x86_64-linux
+++ b/docker/Dockerfile.x86_64-linux
@@ -1,4 +1,4 @@
-FROM larskanis/rake-compiler-dock-mri-x86_64-linux:1.2.2
+FROM ghcr.io/rake-compiler/rake-compiler-dock-snapshot:x86_64-linux
 
 ENV RUBY_TARGET="x86_64-linux" \
     RUST_TARGET="x86_64-unknown-linux-gnu" \

--- a/docker/Dockerfile.x86_64-linux-musl
+++ b/docker/Dockerfile.x86_64-linux-musl
@@ -9,6 +9,7 @@ FROM messense/rust-musl-cross:x86_64-musl
 RUN apt-get -y update && \
     apt-get install -y \
     build-essential \
+    autoconf \
     cmake \
     curl \
     dirmngr \
@@ -25,7 +26,10 @@ RUN apt-get -y update && \
     unzip \
     wget \
     xz-utils \
+    libsqlite0-dev \
+    libyaml-dev \
     zlib1g-dev \
+    libffi-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Add "rvm" as system group, to avoid conflicts with host GIDs typically starting with 1000
@@ -134,7 +138,7 @@ RUN echo "source /etc/profile.d/rcd-env.sh" >> /etc/rubybashrc
 # Install sudoers configuration
 COPY setup/musl/sudoers /etc/sudoers.d/rake-compiler-dock
 
-ENV RUBY_CC_VERSION 3.1.0:3.0.0:2.7.0
+ENV RUBY_CC_VERSION 3.2.0:3.1.0:3.0.0:2.7.0
 
 CMD bash
 

--- a/docker/setup/rubygems.sh
+++ b/docker/setup/rubygems.sh
@@ -7,12 +7,7 @@ set -euo pipefail
 source /lib.sh
 
 main() {
-  local version
-  version="3.3.22"
-  gem update --system "${version}" --no-document
-  set +u
-  rvm rubygems "${version}"
-  set -u
+  gem update --system --no-document
 }
 
 main "${@}"


### PR DESCRIPTION
This PR makes some changes to support Ruby 3.2. I made the docker images inherit from the RCD snapshot image. My thinking is this will give us frequent updates, and stability should be OK.  @flavorjones do you have any thoughts on this?

Testing this build here: https://github.com/oxidize-rb/rb-sys/actions/runs/3864719313