### PR TITLE
Support openbsd

### DIFF
--- a/crates/rb-sys-build/src/bindings.rs
+++ b/crates/rb-sys-build/src/bindings.rs
@@ -12,10 +12,16 @@ use std::process::Command;
 pub fn generate(rbconfig: &RbConfig, static_ruby: bool) {
     ensure_rustfmt_available();
 
+    let extension_flag = if cfg!(target_os = "openbsd") {
+        "-fdeclspec"
+    } else {
+        "-fms-extensions"
+    };
+
     let mut clang_args = vec![
         format!("-I{}", rbconfig.get("rubyhdrdir")),
         format!("-I{}", rbconfig.get("rubyarchhdrdir")),
-        "-fms-extensions".to_string(),
+        extension_flag.to_string(),
     ];
 
     clang_args.extend(rbconfig.cflags.clone());


### PR DESCRIPTION
Hey,

I know that OpenBSD is not one of your supported platforms, but I'll try anyway. I hope you are more responsive than the rutie maintainer :-).

Maybe it is okay to use `-fdecspec` for all platforms, But I don't know how to find out..

`-fmsextensions` fails on OpenBSD:

```
/usr/include/machine/_types.h:133:15: error: cannot combine with previous 'int' declaration specifier
```

https://zewaren.net/freebsd-10-build.html gave me the idea that this might have to do with `msextensions`.