### PR TITLE
Filter out strip directives when linking

### DIFF
--- a/crates/rb-sys/build/main.rs
+++ b/crates/rb-sys/build/main.rs
@@ -54,7 +54,8 @@ fn main() {
 }
 
 fn add_unsupported_link_args_to_blocklist(rbconfig: &mut RbConfig) {
-    rbconfig.blocklist_link_arg("compress-debug-sections");
+    rbconfig.blocklist_link_arg("-Wl,--compress-debug-sections=zlib");
+    rbconfig.blocklist_link_arg("-s");
 }
 
 fn add_libruby_to_blocklist(rbconfig: &mut RbConfig) {

--- a/gem/lib/rb_sys/cargo_builder/link_flag_converter.rb
+++ b/gem/lib/rb_sys/cargo_builder/link_flag_converter.rb
@@ -7,7 +7,8 @@ module RbSys
     # Converts Ruby link flags into something cargo understands
     class LinkFlagConverter
       FILTERED_PATTERNS = [
-        /compress-debug-sections/ # Not supported by all linkers, and not required for Rust
+        /compress-debug-sections/, # Not supported by all linkers, and not required for Rust
+        /^\s*-s\s*$/
       ]
 
       def self.convert(args)

--- a/gem/test/test_link_flag_converter.rb
+++ b/gem/test/test_link_flag_converter.rb
@@ -17,4 +17,12 @@ class TestLinkFlagConverter < Minitest::Test
 
     assert_equal ["-l", "shlwapi", "-C", "link-arg=-l:libssp.a"], args
   end
+
+  def test_filtering_out_flags
+    flags = "-Wl,--compress-debug-sections=zlib -s -lfoo -somethingtokeep"
+    args = Shellwords.split(flags)
+    args = args.flat_map { |arg| RbSys::CargoBuilder::LinkFlagConverter.convert(arg) }
+
+    assert_equal ["-l", "foo", "-C", "link-arg=-somethingtokeep"], args
+  end
 end


### PR DESCRIPTION
Let's let the user [decide to on this in their `Cargo.toml`](https://doc.rust-lang.org/cargo/reference/profiles.html#strip). Otherwise, profiling in release builds becomes impossible.