### PR TITLE
Pass in `--crate-type cdylib` to rustc when building gem

### DIFF
--- a/examples/rust_reverse/ext/rust_reverse/Cargo.toml
+++ b/examples/rust_reverse/ext/rust_reverse/Cargo.toml
@@ -7,5 +7,8 @@ edition = "2018"
 [dependencies]
 rb-sys = { version = "0.9.58", path = "./../../../../crates/rb-sys", features = ["global-allocator"] }
 
+[lib]
+crate-type = ["cdylib"]
+
 [features]
 test-feature = []

--- a/examples/rust_reverse/ext/rust_reverse/Cargo.toml
+++ b/examples/rust_reverse/ext/rust_reverse/Cargo.toml
@@ -7,8 +7,5 @@ edition = "2018"
 [dependencies]
 rb-sys = { version = "0.9.58", path = "./../../../../crates/rb-sys", features = ["global-allocator"] }
 
-[lib]
-crate-type = ["cdylib"]
-
 [features]
 test-feature = []

--- a/gem/lib/rb_sys/cargo_builder.rb
+++ b/gem/lib/rb_sys/cargo_builder.rb
@@ -59,7 +59,6 @@ module RbSys
 
       cmd = []
       cmd += [cargo, "rustc"]
-      cmd += ["--crate-type=cdylib"]
       cmd += ["--target", target] if target
       cmd += ["--target-dir", dest_path]
       cmd += ["--features", features.join(",")] unless features.empty?
@@ -69,6 +68,7 @@ module RbSys
       cmd += Gem::Command.build_args
       cmd += args
       cmd += ["--"]
+      cmd += ["--crate-type", "cdylib"]
       cmd += [*cargo_rustc_args(dest_path)]
       cmd += extra_rustc_args
       cmd

--- a/gem/lib/rb_sys/cargo_builder.rb
+++ b/gem/lib/rb_sys/cargo_builder.rb
@@ -59,6 +59,7 @@ module RbSys
 
       cmd = []
       cmd += [cargo, "rustc"]
+      cmd += ["--crate-type", "cdylib"]
       cmd += ["--target", target] if target
       cmd += ["--target-dir", dest_path]
       cmd += ["--features", features.join(",")] unless features.empty?

--- a/gem/lib/rb_sys/cargo_builder.rb
+++ b/gem/lib/rb_sys/cargo_builder.rb
@@ -59,7 +59,7 @@ module RbSys
 
       cmd = []
       cmd += [cargo, "rustc"]
-      cmd += ["--crate-type", "cdylib"]
+      cmd += ["--crate-type=cdylib"]
       cmd += ["--target", target] if target
       cmd += ["--target-dir", dest_path]
       cmd += ["--features", features.join(",")] unless features.empty?

--- a/gem/test/test_rb_sys.rb
+++ b/gem/test/test_rb_sys.rb
@@ -16,7 +16,7 @@ class TestRbSys < Minitest::Test
   def test_invokes_cargo_rustc
     makefile = create_makefile
 
-    assert_match(/\$\(CARGO\) rustc --target-dir/, makefile.read)
+    assert_match(/\$\(CARGO\) rustc --crate-type cdylib --target-dir/, makefile.read)
   end
 
   def test_invokes_custom_env

--- a/gem/test/test_rb_sys.rb
+++ b/gem/test/test_rb_sys.rb
@@ -16,7 +16,7 @@ class TestRbSys < Minitest::Test
   def test_invokes_cargo_rustc
     makefile = create_makefile
 
-    assert_match(/\$\(CARGO\) rustc --crate-type cdylib --target-dir/, makefile.read)
+    assert_match(/\$\(CARGO\) rustc --crate-type=cdylib --target-dir/, makefile.read)
   end
 
   def test_invokes_custom_env

--- a/gem/test/test_rb_sys.rb
+++ b/gem/test/test_rb_sys.rb
@@ -15,8 +15,10 @@ class TestRbSys < Minitest::Test
 
   def test_invokes_cargo_rustc
     makefile = create_makefile
+    content = makefile.read
 
-    assert_match(/\$\(CARGO\) rustc --crate-type=cdylib --target-dir/, makefile.read)
+    assert_match(/\$\(CARGO\) rustc --target-dir/, content)
+    assert_match(/--crate-type cdylib/, content)
   end
 
   def test_invokes_custom_env


### PR DESCRIPTION
This makes it so you do not have to specify `crate-type = ["cdylib"]` in your `Cargo.toml`.