### PR TITLE
Add ability to provide extra cargo args in `rb_sys/mkmf`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,35 +10,24 @@ def extra_args
   seperator_index && ARGV[(seperator_index + 1)..-1] || []
 end
 
-def cargo_test(*args)
-  ENV["RUST_TEST_THREADS"] = "1"
-  default_args = ENV["CI"] || extra_args.include?("--verbose") ? [] : ["--quiet"]
-  sh "cargo", "test", *default_args, *extra_args, *args
+def cargo_test_task(name, *args)
+  task_name = "cargo:#{name}"
+
+  desc "Run cargo tests for #{name.inspect} against current Ruby"
+  task task_name do
+    ENV["RUST_TEST_THREADS"] ||= "1"
+    default_args = ENV["CI"] || extra_args.include?("--verbose") ? [] : ["--quiet"]
+    sh "cargo", "test", *default_args, *extra_args, *args
+  end
+
+  task cargo: task_name
 end
 
 namespace :test do
-  desc "Run rb-sys tests"
-  task "rb-sys" do
-    cargo_test "-p", "rb-sys", "--features", "bindgen-layout-tests"
-  end
-
-  desc "Run rb-sys-build tests"
-  task "rb-sys-build" do
-    cargo_test "-p", "rb-sys-build"
-  end
-
-  desc "Run rb-sys-tests tests"
-  task "rb-sys-tests" do
-    cargo_test "-p", "rb-sys-tests"
-  end
-
-  desc "Run rb-sys-tests tests"
-  task "rb-sys-env" do
-    cargo_test "-p", "rb-sys-env"
-  end
-
-  desc "Run cargo test against current Ruby"
-  task cargo: ["test:rb-sys", "test:rb-sys-build", "test:rb-sys-tests", "test:rb-sys-env"]
+  cargo_test_task "rb-sys", "--features", "bindgen-layout-tests"
+  cargo_test_task "rb-sys-build"
+  cargo_test_task "rb-sys-tests"
+  cargo_test_task "rb-sys-env"
 
   desc "Test against all installed Rubies"
   task :rubies do

--- a/examples/rust_reverse/ext/rust_reverse/extconf.rb
+++ b/examples/rust_reverse/ext/rust_reverse/extconf.rb
@@ -20,9 +20,12 @@ create_rust_makefile("rust_reverse/rust_reverse") do |r|
   r.ext_dir = "."
 
   # Extra flags to pass to the $RUSTFLAGS environment variable (optional)
-  r.extra_rustflags = ["--cfg=some_nested_config_var_for_crate"]
+  r.extra_rustflags << "--cfg=some_nested_config_var_for_crate"
 
   # Force a rust toolchain to be installed via rustup (optional)
   # You can also set the env var `RB_SYS_FORCE_INSTALL_RUST_TOOLCHAIN=true`
   r.force_install_rust_toolchain = false
+
+  # Extra args to pass to the `cargo rustc` command (optional)
+  r.extra_cargo_args << "--frozen"
 end

--- a/examples/rust_reverse/test/test_rust_reverse.rb
+++ b/examples/rust_reverse/test/test_rust_reverse.rb
@@ -17,7 +17,7 @@ class TestRustReverse < Minitest::Test
 
       expected = "a" * 10000
 
-      1000.times do
+      10.times do
         assert_equal expected, RustReverse.reverse("a" * 10000)
       end
     ensure

--- a/gem/lib/rb_sys/cargo_builder.rb
+++ b/gem/lib/rb_sys/cargo_builder.rb
@@ -1,9 +1,12 @@
+require "rubygems/ext"
+require "rubygems/ext/builder"
 require_relative "cargo_builder/link_flag_converter"
 
 module RbSys
   # A class to build a Ruby gem Cargo. Extracted from `rubygems` gem, with some modifications.
   class CargoBuilder < Gem::Ext::Builder
-    attr_accessor :spec, :runner, :env, :features, :target, :extra_rustc_args, :dry_run, :ext_dir, :extra_rustflags
+    attr_accessor :spec, :runner, :env, :features, :target, :extra_rustc_args, :dry_run, :ext_dir, :extra_rustflags,
+      :extra_cargo_args
     attr_writer :profile
 
     def initialize(spec)
@@ -17,6 +20,7 @@ module RbSys
       @features = []
       @target = ENV["CARGO_BUILD_TARGET"] || ENV["RUST_TARGET"]
       @extra_rustc_args = []
+      @extra_cargo_args = []
       @dry_run = true
       @ext_dir = nil
       @extra_rustflags = []
@@ -68,7 +72,7 @@ module RbSys
       cmd += Gem::Command.build_args
       cmd += args
       cmd += ["--"]
-      cmd += [*cargo_rustc_args(dest_path)]
+      cmd += [*rustc_args(dest_path)]
       cmd += extra_rustc_args
       cmd
     end
@@ -105,7 +109,7 @@ module RbSys
       result
     end
 
-    def cargo_rustc_args(dest_dir)
+    def rustc_args(dest_dir)
       [
         *linker_args,
         *mkmf_libpath,

--- a/gem/lib/rb_sys/mkmf.rb
+++ b/gem/lib/rb_sys/mkmf.rb
@@ -68,6 +68,7 @@ module RbSys
         #{conditional_assign("RB_SYS_CARGO_FEATURES", builder.features.join(","))}
         #{conditional_assign("RB_SYS_GLOBAL_RUSTFLAGS", GLOBAL_RUSTFLAGS.join(" "))}
         #{conditional_assign("RB_SYS_EXTRA_RUSTFLAGS", builder.extra_rustflags.join(" "))}
+        #{conditional_assign("RB_SYS_EXTRA_CARGO_ARGS", builder.extra_cargo_args.join(" "))}
 
         # Set dirname for the profile, since the profiles do not directly map to target dir (i.e. dev -> debug)
         #{if_eq_stmt("$(RB_SYS_CARGO_PROFILE)", "dev")}
@@ -163,7 +164,11 @@ module RbSys
       args = ARGV.dup
       args.shift if args.first == "--"
       cargo_cmd = builder.cargo_command(dest_path, args)
-      Shellwords.join(cargo_cmd).gsub("\\=", "=").gsub(/\Acargo/, "$(CARGO)").gsub(/-v=\d/, "")
+      cmd = Shellwords.join(cargo_cmd)
+      cmd.gsub!("\\=", "=")
+      cmd.gsub!(/\Acargo rustc/, "$(CARGO) rustc $(RB_SYS_EXTRA_CARGO_ARGS)")
+      cmd.gsub!(/-v=\d/, "")
+      cmd
     end
 
     def env_vars(builder)

--- a/gem/test/test_rb_sys.rb
+++ b/gem/test/test_rb_sys.rb
@@ -16,7 +16,7 @@ class TestRbSys < Minitest::Test
   def test_invokes_cargo_rustc
     makefile = create_makefile
 
-    assert_match(/\$\(CARGO\) rustc --target-dir/, makefile.read)
+    assert_match(/\$\(CARGO\) rustc/, makefile.read)
   end
 
   def test_invokes_custom_env
@@ -61,6 +61,15 @@ class TestRbSys < Minitest::Test
     end
 
     assert_match(/-C debuginfo=42$/, makefile.read)
+  end
+
+  def test_uses_extra_cargo_args
+    makefile = create_makefile do |b|
+      b.extra_cargo_args = ["--crate-type", "cdylib"]
+    end
+
+    assert_match(/--crate-type cdylib/, makefile.read)
+    assert_includes(makefile.read, "rustc $(RB_SYS_EXTRA_CARGO_ARGS)")
   end
 
   def test_uses_extra_rustflags


### PR DESCRIPTION
This PR allows users to provide extra cargo args when generating a Makefile. 

For example, this can be useful in certain scenarios, such as having a crate that is usable as both a gem and Rust crate. In this situation, you would _not_ want to specify `crate-type = ["cdylib"]` in your `Cargo.toml`. Instead, you could do this:

```ruby
require "mkmf"
require "rb_sys/mkmf"

create_rust_makefile("my_gem/my_gem") do |ext|
  ext.extra_cargo_args << "--crate-type=cdylib"
end
```

In fact, this is the preferred way of doing it. However, it's only been stable since `1.64` so we cannot default to it (yet).