### PR TITLE
Use stable RCD base docker images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -85,6 +85,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: ./docker
+          file: ./docker/Dockerfile.${{ matrix.platform.ruby_target }}
           platforms: linux/amd64
           load: true
           tags: ${{ steps.meta.outputs.tags }}
@@ -110,6 +111,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         with:
           context: ./docker
+          file: ./docker/Dockerfile.${{ matrix.platform.ruby_target }}
           platforms: linux/amd64
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -69,8 +69,9 @@ jobs:
           images: |
             ${{ secrets.DOCKER_HUB_USERNAME }}/${{ matrix.platform.ruby_target }}
             ${{ secrets.DOCKER_HUB_USERNAME }}/rake-compiler-dock-mri-${{ matrix.platform.ruby_target }}
-          tags: |
+          flavor: |
             latest=true
+          tags: |
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,9 +14,6 @@ on:
 jobs:
   docker_images:
     runs-on: ubuntu-latest
-    env:
-      RBSYS_DOCKER: "docker buildx"
-      RBSYS_DOCKER_BUILD_EXTRA_ARGS: "--cache-from=type=local,src=/tmp/.buildx-cache --cache-to=type=local,mode=max,dest=/tmp/.buildx-cache-new --load"
     strategy:
       fail-fast: false
       matrix:
@@ -40,25 +37,24 @@ jobs:
           repository: "oxidize-rb/oxi-test"
           path: "tmp/oxi-test"
 
-      - name: Print env info
-        run: |
-          env
-
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.1"
-          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
       - name: Login to Docker Hub
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
-      - uses: ruby/setup-ruby@v1
+      - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
         with:
-          ruby-version: "3.0"
-          bundler-cache: true
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
@@ -66,25 +62,34 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Cache Docker layers
-        uses: actions/cache@v3
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
         with:
-          path: /tmp/.buildx-cache
-          key: ${{ matrix.platform.ruby_target }}-buildx-v4-${{ github.sha }}
-          restore-keys: |
-            ${{ matrix.platform.ruby_target }}-buildx-v4
+          images: |
+            ${{ secrets.DOCKER_HUB_USERNAME }}/${{ matrix.platform.ruby_target }}
+            ${{ secrets.DOCKER_HUB_USERNAME }}/rake-compiler-dock-mri-${{ matrix.platform.ruby_target }}
+          tags: |
+            latest=true
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=sha,format=long
+          labels:
+            org.opencontainers.image.description=Image for building native Rust extensions for Ruby on ${{ matrix.platform.ruby_target }}
+            org.opencontainers.image.vendor=oxidize-rb
+            org.oxidize-rb.ruby.platform=${{ matrix.platform.ruby_target }}
 
-      - name: Build images
-        run: rake docker:build:${{ matrix.platform.ruby_target }}
-
-      - name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-
-      - uses: ruby/setup-ruby@v1
+      - name: Docker build
+        uses: docker/build-push-action@v2
         with:
-          ruby-version: "3.1"
+          context: ./docker
+          platforms: linux/amd64
+          load: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Run tests
         run: |
@@ -94,11 +99,19 @@ jobs:
 
           export RB_SYS_DOCK_UID=$(id -u)
           export RB_SYS_DOCK_GID=$(id -g)
+          export RCD_IMAGE=${{ secrets.DOCKER_HUB_USERNAME }}/${{ matrix.platform.ruby_target }}:sha-${{ github.sha }}
 
           # Soft fail for now
-          rb-sys-dock --platform ${{ matrix.platform.ruby_target }} --latest -- \
-            "bundle install && bundle exec rake native:${{ matrix.platform.ruby_target }} gem || true"
+          rb-sys-dock --platform ${{ matrix.platform.ruby_target }} --build
 
-      - name: Push images
+      - name: Docker push
+        uses: docker/build-push-action@v2
         if: startsWith(github.ref, 'refs/tags/v')
-        run: rake docker:push:${{ matrix.platform.ruby_target }}
+        with:
+          context: ./docker
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: |
             ${{ secrets.DOCKER_HUB_USERNAME }}/${{ matrix.platform.ruby_target }}
@@ -82,7 +82,7 @@ jobs:
             org.oxidize-rb.ruby.platform=${{ matrix.platform.ruby_target }}
 
       - name: Docker build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: ./docker
           platforms: linux/amd64
@@ -106,7 +106,7 @@ jobs:
           rb-sys-dock --platform ${{ matrix.platform.ruby_target }} --build
 
       - name: Docker push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         if: startsWith(github.ref, 'refs/tags/v')
         with:
           context: ./docker

--- a/docker/Dockerfile.aarch64-linux
+++ b/docker/Dockerfile.aarch64-linux
@@ -1,4 +1,4 @@
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:snapshot-mri-aarch64-linux
+FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.3.0-mri-aarch64-linux
 
 ENV RUBY_TARGET="aarch64-linux" \
     RUST_TARGET="aarch64-unknown-linux-gnu" \

--- a/docker/Dockerfile.arm-linux
+++ b/docker/Dockerfile.arm-linux
@@ -1,4 +1,4 @@
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:snapshot-mri-arm-linux
+FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.3.0-mri-arm-linux
 
 ENV RUBY_TARGET="arm-linux" \
     RUST_TARGET="arm-unknown-linux-gnueabihf" \

--- a/docker/Dockerfile.arm64-darwin
+++ b/docker/Dockerfile.arm64-darwin
@@ -1,4 +1,4 @@
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:snapshot-mri-arm64-darwin
+FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.3.0-mri-arm64-darwin
 
 ENV RUBY_TARGET="arm64-darwin" \
     RUST_TARGET="aarch64-apple-darwin" \

--- a/docker/Dockerfile.x64-mingw-ucrt
+++ b/docker/Dockerfile.x64-mingw-ucrt
@@ -1,4 +1,4 @@
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:snapshot-mri-x64-mingw-ucrt
+FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.3.0-mri-x64-mingw-ucrt
 
 ENV RUBY_TARGET="x64-mingw-ucrt" \
     RUST_TARGET="x86_64-pc-windows-gnu" \

--- a/docker/Dockerfile.x64-mingw32
+++ b/docker/Dockerfile.x64-mingw32
@@ -1,4 +1,4 @@
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:snapshot-mri-x64-mingw32
+FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.3.0-mri-x64-mingw32
 
 ENV RUBY_TARGET="x64-mingw32" \
     RUST_TARGET="x86_64-pc-windows-gnu" \

--- a/docker/Dockerfile.x86-linux
+++ b/docker/Dockerfile.x86-linux
@@ -1,4 +1,4 @@
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:snapshot-mri-x86-linux
+FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.3.0-mri-x86-linux
 
 ENV RUBY_TARGET="x86-linux" \
     RUST_TARGET="i686-unknown-linux-gnu" \

--- a/docker/Dockerfile.x86-mingw32
+++ b/docker/Dockerfile.x86-mingw32
@@ -1,4 +1,4 @@
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:snapshot-mri-x86-mingw32
+FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.3.0-mri-x86-mingw32
 
 ENV RUBY_TARGET="x86-mingw32" \
     RUST_TARGET="i686-pc-windows-gnu" \

--- a/docker/Dockerfile.x86_64-darwin
+++ b/docker/Dockerfile.x86_64-darwin
@@ -1,4 +1,4 @@
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:snapshot-mri-x86_64-darwin
+FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.3.0-mri-x86_64-darwin
 
 ENV RUBY_TARGET="x86_64-darwin" \
     RUST_TARGET="x86_64-apple-darwin" \

--- a/docker/Dockerfile.x86_64-linux
+++ b/docker/Dockerfile.x86_64-linux
@@ -1,4 +1,4 @@
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:snapshot-mri-x86_64-linux
+FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.3.0-mri-x86_64-linux
 
 ENV RUBY_TARGET="x86_64-linux" \
     RUST_TARGET="x86_64-unknown-linux-gnu" \

--- a/gem/exe/rb-sys-dock
+++ b/gem/exe/rb-sys-dock
@@ -301,7 +301,7 @@ def download_image(options)
 end
 
 def log_some_useful_info(_options)
-  if ARGV.empty?
+  if ARGV.empty? && !options[:build]
     log(:notice, "Entering shell in Docker container #{ENV["RCD_IMAGE"].inspect}")
   else
     log(:notice, "Running command #{ARGV.inspect} in Docker container #{ENV["RCD_IMAGE"].inspect}")


### PR DESCRIPTION
Gets us off the snapshot images since 1.3.0 was released.