### PR TITLE
Add support for using the libclang gem

### DIFF
--- a/gem/README.md
+++ b/gem/README.md
@@ -76,3 +76,23 @@ end
   environment variable. This will install [rustup](https://rustup.rs/) and [cargo](https://crates.io/) in the build
   directory, so the end user does not have to have Rust pre-installed. Ideally, this should be a last resort, as it's
   better to already have the toolchain installed on your system.
+
+## Troubleshooting
+
+### Libclang issues
+
+If you see an error like this:
+
+```
+thread 'main' panicked at 'Unable to find libclang: "couldn't find any valid shared libraries matching: \['libclang.so', 'libclang-*.so', 'libclang.so.*', 'libclang-*.so.*'\], set the `LIBCLANG_PATH` environment variable to a path where one of these files can be found (invalid: \[\])"'
+```
+
+This means that bindgen is having issues finding a usable version of libclang. An easy way to fix this is to install the
+[`libclang` gem](https://github.com/oxidize-rb/libclang-rb), which will install a pre-built version of libclang for you.
+`rb_sys` will automatically detect this gem and use it.
+
+```ruby
+# Gemfile
+
+gem "libclang", "~> 14.0.6"
+```

--- a/gem/lib/rb_sys/mkmf.rb
+++ b/gem/lib/rb_sys/mkmf.rb
@@ -59,6 +59,7 @@ module RbSys
         #{conditional_assign("CARGO", "cargo")}
         #{conditional_assign("CARGO_BUILD_TARGET", builder.target)}
         #{conditional_assign("SOEXT", builder.so_ext)}
+        #{try_load_bundled_libclang(builder)}
 
         # Determine the prefix Cargo uses for the lib.
         #{if_neq_stmt("$(SOEXT)", "dll")}
@@ -314,6 +315,26 @@ module RbSys
         "!if [set #{k}=#{v}]\n!endif"
       else
         "export #{k} := #{v}"
+      end
+    end
+
+    def try_load_bundled_libclang(_builder)
+      require "libclang"
+      assert_libclang_version_valid!
+      export_env("LIBCLANG_PATH", Libclang.libdir)
+    rescue LoadError
+      # If we can't load the bundled libclang, just continue
+    end
+
+    def assert_libclang_version_valid!
+      libclang_version = Libclang.version
+
+      if libclang_version < Gem::Version.new("5.0.0")
+        raise "libclang version 5.0.0 or greater is required (current #{libclang_version})"
+      end
+
+      if libclang_version >= Gem::Version.new("15.0.0")
+        raise "libclang version > 14.0.0 or greater is required (current #{libclang_version})"
       end
     end
 


### PR DESCRIPTION
This PR adds support for using the [`libclang` gem](https://github.com/oxidize-rb/libclang-rb) for usage with bindgen.