### PR TITLE
Add ability to mount rustup toolchain in rb-sys-dock

### DIFF
--- a/gem/exe/rb-sys-dock
+++ b/gem/exe/rb-sys-dock
@@ -1,88 +1,65 @@
 #!/usr/bin/env ruby
 
+$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
+
 require "optparse"
+require "open3"
 require "rb_sys/version"
 require "rb_sys/toolchain_info"
+require "rb_sys/util/logger"
 require "fileutils"
 require "tmpdir"
 
-options = {
+OPTIONS = {
+  docker_platform: "linux/amd64",
   version: RbSys::VERSION,
-  docker_platform: "linux/amd64"
+  directory: Dir.pwd
 }
 
-def log(level, message, emoji: true, io: $stderr)
-  emoji_opt, shellcode = case level
-  when :error
-    ["❌", "\e[1;31m"]
-  when :warn
-    ["⚠️", "\e[1;33m"]
-  when :info
-    ["ℹ️", "\e[1;37m"]
-  when :notice
-    ["🐳", "\e[1;34m"]
-  when :trace
-    return unless ENV["LOG_LEVEL"] == "trace"
+def logger
+  return @logger if @logger
 
-    ["🔍", "\e[1;2m"]
-  else raise "Unknown log level: #{level.inspect}"
-  end
-
-  emoji_opt = if emoji.is_a?(String)
-    emoji + " "
-  elsif emoji
-    emoji_opt + " "
-  end
-
-  # Escape the message for bash shell codes (e.g. \e[1;31m)
-  escaped = message.gsub("\\", "\\\\\\").gsub("\e", "\\e")
-
-  io.puts "#{shellcode}#{emoji_opt}#{escaped}\e[0m"
-end
-
-def default_docker_command
-  return @default_docker_command if defined?(@default_docker_command)
-
-  @default_docker_command = ENV.fetch("DOCKER", "docker")
-end
-
-def run_command!(cmd)
-  log(:trace, "Running command: $ #{cmd}")
-  stdout, stderr, status = Open3.capture3(cmd)
-
-  if status.success?
-    stdout
-  else
-    log(:error, "Error running command: $ #{cmd}")
-    warn(stderr)
-    exit(status.exitstatus)
-  end
-end
-
-def docker(cmd)
-  require "open3"
-
-  run_command!("#{default_docker_command} #{cmd}")
-rescue Errno::ENOENT
-  log(:trace, "Could not find docker command, trying podman")
-
-  begin
-    stdout = run_command!("podman #{cmd}")
-    @default_docker_command = "podman"
-    stdout
-  rescue Errno::ENOENT
-    log(:error, "Could not find docker or podman command, please install one of them")
-    exit(1)
-  end
+  io = ARGV.include?("--quiet") ? File.open(File::NULL, "w") : $stderr
+  @logger ||= RbSys::Util::Logger.new(io: io)
 end
 
 OptionParser.new do |opts|
-  opts.banner = "Usage: rb-sys-dock --platform PLATFORM [COMMAND]"
+  opts.banner = <<~MSG
+    Usage: rb-sys-dock [OPTIONS] [COMMAND]
+
+    A CLI to facillitate building Ruby on Rust extensions using Docker.
+
+    Examples:
+
+        Build for Linux (x86_64)
+            $ rb-sys-dock --platform x86_64-linux --build
+
+        Build for macOS (Ruby 3.1 and 3.2)
+            $ rb-sys-dock -p arm64-darwin --ruby-versions 3.1,3.2 --build
+
+        Enter a shell
+            $ rb-sys-dock --list-platforms
+
+        Run a command in the container with a specific directory mounted
+            $ rb-sys-dock -p x64-mingw-ucrt -d /tmp/mygem -- "env | grep RUBY"
+
+        List all supported platforms
+            $ rb-sys-dock --list-platforms
+
+    Options:
+  MSG
+
+  opts.on("--quiet", "Prints no logging output") do
+  end
 
   opts.on("-v", "--version", "Prints version") do
     require "rb_sys/version"
     puts RbSys::VERSION
     exit
+  end
+
+  opts.on("--build", "Run the default command to cross-compile a gem") do
+    OPTIONS[:build] = true
   end
 
   opts.on("-p", "--platform PLATFORM", "Platform to build for (i.e. x86_64-linux)") do |p|
@@ -92,40 +69,38 @@ OptionParser.new do |opts|
       supported_list = RbSys::ToolchainInfo.all
       supported_list.select!(&:supported?)
       list = supported_list.map { |p| "- #{p} (#{p.rust_target})" }.join("\n")
-      log(:error, "Platform #{p} is not supported, please use one of:\n\n#{list}")
+      logger.error("Platform #{p} is not supported, please use one of:\n\n#{list}")
       exit(1)
     end
 
-    options[:platform] = p
-    options[:toolchain_info] = toolchain_info
+    OPTIONS[:platform] = p
+    OPTIONS[:toolchain_info] = toolchain_info
   end
 
-  opts.on("--latest", "Use the latest version of the Docker image") do
-    log(:notice, "Using latest version of the Docker image", emoji: "🆕")
-    options[:version] = "latest"
-    options[:no_cache] = true
-  end
-
-  opts.on("--list-platforms", "--list", "List all supported platforms") do
-    log(:notice, "Supported platforms listed below:")
-
-    RbSys::ToolchainInfo.supported.each do |p|
-      log(:info, "- #{p} (#{p.rust_target})", emoji: false, io: $stdout)
-    end
-
-    exit(0)
-  end
-
-  opts.on("--ruby-versions LIST", "List all supported Ruby versions") do |arg|
-    log(:notice, "Requested Ruby versions: #{arg}")
-
+  opts.on("-r", "--ruby-versions LIST", "List all supported Ruby versions") do |arg|
     vers = arg.split(/[^0-9.]/).map do |v|
       parts = v.split(".")
       parts[2] = "0" if parts[2].nil?
       parts.join(".")
     end
 
+    OPTIONS[:ruby_versions] = vers
+
+    logger.notice("Building for Ruby requested versions: #{vers}")
+
     ENV["RUBY_CC_VERSION"] = vers.join(":")
+  end
+
+  opts.on("--tag TAG", "Use a specific version of the Docker image") do |tag|
+    logger.notice("Using version #{tag} of the Docker image")
+    OPTIONS[:version] = tag
+    OPTIONS[:no_cache] = tag == "latest"
+  end
+
+  opts.on("--list-platforms", "--list", "List all supported platforms") do
+    logger.notice("Supported platforms listed below:")
+    list_platforms
+    exit(0)
   end
 
   opts.on("-h", "--help", "Prints this help") do
@@ -136,13 +111,59 @@ OptionParser.new do |opts|
   opts.on("-V", "--verbose", "Prints verbose output") do
     ENV["LOG_LEVEL"] = "trace"
     ENV["VERBOSE"] = "1"
-    options[:verbose] = true
+    logger.level = :trace
+    OPTIONS[:verbose] = true
   end
 
-  opts.on("--build", "Build the Docker image") do
-    options[:build] = true
+  opts.on("--mount-toolchains", "Mount local Rustup toolchain (instead of pre-installed from Docker container)") do
+    OPTIONS[:mount_rustup_toolchains] = true
+  end
+
+  opts.on("-d", "--directory DIR", "Directory to run the command in") do |val|
+    OPTIONS[:directory] = File.expand_path(val)
   end
 end.parse!
+
+def list_platforms
+  RbSys::ToolchainInfo.supported.each do |p|
+    old = logger.io
+    logger.io = $stdout
+    logger.info("- #{p.platform}", emoji: false)
+  ensure
+    logger.io = old
+  end
+end
+
+def default_docker_command
+  return @default_docker_command if defined?(@default_docker_command)
+
+  @default_docker_command = ENV.fetch("DOCKER") do
+    if !(docker = `which docker`).empty?
+      docker.strip
+    elsif !(podman = `which podman`).empty?
+      podman.strip
+    else
+      logger.fatal("Could not find docker or podman command, please install one of them")
+    end
+  end
+end
+
+def run_command!(*cmd)
+  logger.trace("Running command:\n\t$ #{cmd.join(" ")}")
+  stdout, stderr, status = Open3.capture3(*cmd)
+
+  if status.success?
+    stdout
+  else
+    logger.error("Error running command: $ #{cmd}")
+    warn(stderr)
+    exit(status.exitstatus)
+  end
+end
+
+def docker(cmd)
+  run_command!("#{default_docker_command} #{cmd}")
+end
 
 def determine_cache_dir
   return ENV["RB_SYS_DOCK_CACHE_DIR"] if ENV["RB_SYS_DOCK_CACHE_DIR"]
@@ -173,53 +194,93 @@ def mount_cargo_registry
   end
 
   dir = File.join("registry")
-  log(:trace, "Mounting cargo registry dir: #{dir}")
+  logger.trace("Mounting cargo registry dir: #{dir}")
   FileUtils.mkdir_p(dir)
 
-  "--mount type=bind,source=#{File.join(local_registry_dir, dir)},target=#{File.join("/usr/local/cargo", dir)},readonly=false"
+  mount_shared_bind_dir(File.join(local_registry_dir, dir), File.join("/usr/local/cargo", dir))
+end
+
+def mount_rustup_toolchains
+  return unless OPTIONS[:mount_rustup_toolchains]
+
+  local_rustup_dir = if OPTIONS[:mount_rustup_toolchains].is_a?(String)
+    OPTIONS[:mount_rustup_toolchains]
+  elsif ENV["RUSTUP_HOME"]
+    ENV["RUSTUP_HOME"]
+  elsif File.exist?(rustup_home = File.join(ENV["HOME"], ".rustup"))
+    rustup_home
+  else
+    logger.fatal("Could not find Rustup home directory, please set RUSTUP_HOME")
+  end
+
+  logger.notice("Mounting rustup toolchains from #{local_rustup_dir}")
+
+  target_triple = OPTIONS[:toolchain_info].rust_target
+  dkr_triple = "x86_64-unknown-linux-gnu"
+  dkr_toolchain = "stable-#{dkr_triple}"
+  dkr_toolchain_dir = "/usr/local/rustup/toolchains/#{dkr_toolchain}"
+  installed_toolchains = Dir.glob(File.join(local_rustup_dir, "toolchains", "*")).map { |f| File.basename(f) }
+  has_host_toolchain = installed_toolchains.any? { |t| t.end_with?(dkr_toolchain) }
+
+  if !has_host_toolchain
+    logger.notice("Installing default toolchain for docker image (#{dkr_toolchain})")
+    run_command!("rustup", "toolchain", "add", dkr_toolchain, "--force-non-host")
+  end
+
+  has_target = run_command!("rustup target list --installed --toolchain #{dkr_toolchain}").include?(target_triple)
+
+  if !has_target
+    logger.notice("Installing target for docker image (#{target_triple})")
+    run_command!("rustup", "target", "add", target_triple, "--toolchain", dkr_toolchain)
+  end
+
+  volume("#{local_rustup_dir}/toolchains/#{dkr_toolchain}", dkr_toolchain_dir, mode: "z,ro")
 end
 
 def volume(src, dest, mode: "rw")
   "--volume #{src}:#{dest}:rw"
 end
 
-def mount_bundle_cache(options)
-  dir = File.join(cache_dir, options.fetch(:toolchain_info).platform, "bundle")
+def mount_bundle_cache
+  dir = File.join(cache_dir, ruby_platform, "bundle")
   bundle_path = File.join(docker_tmp, "bundle")
   FileUtils.mkdir_p(dir)
-  log(:trace, "Mounting bundle cache: #{dir}")
+  logger.trace("Mounting bundle cache: #{dir}")
 
   "#{volume(dir, bundle_path)} -e BUNDLE_PATH=#{bundle_path.inspect}"
 end
 
-def tmp_target_dir(options)
+def tmp_target_dir
   return @tmp_target_dir if defined?(@tmp_target_dir)
 
-  dir = File.join(Dir.pwd, "tmp", "rb-sys-dock", options.fetch(:toolchain_info).platform, "target")
+  dir = File.join(working_directory, "tmp", "rb-sys-dock", ruby_platform, "target")
   FileUtils.mkdir_p(dir)
   @tmp_target_dir = dir
 end
 
-def mount_target_dir(options)
-  "-v #{tmp_target_dir(options)}:#{File.join(Dir.pwd, "target")}"
+def working_directory
+  OPTIONS.fetch(:directory)
 end
 
-def mount_command_history(options)
+def mount_target_dir
+  "-v #{tmp_target_dir}:#{File.join(working_directory, "target")}"
+end
+
+def mount_command_history
   return unless $stdin.tty?
 
-  history_dir = File.join(cache_dir, options.fetch(:platform), "commandhistory")
+  history_dir = File.join(cache_dir, OPTIONS.fetch(:platform), "commandhistory")
   FileUtils.mkdir_p(history_dir)
   "-v #{history_dir}:#{File.join(docker_tmp, "commandhistory")}"
 end
 
-def default_command_to_run(input_args, options)
+def default_command_to_run(input_args)
   input_cmd = input_args.empty? ? "true" : input_args.join(" ")
 
-  if options[:build]
+  if OPTIONS[:build]
     with_bundle = +"test -f Gemfile && bundle install && #{input_cmd} && bundle exec rake native:$RUBY_TARGET gem"
     without_bundle = "#{input_cmd} && rake native:$RUBY_TARGET gem"
-    log(:notice, "Running default build command:")
-    log(:notice, "    $ rake native:#{options[:toolchain_info].platform} gem")
+    logger.notice("Running default build command (rake native:#{ruby_platform} gem)")
     "bash -c '(#{with_bundle}) || (#{without_bundle})'"
   else
     input_args.empty? ? "bash" : "bash -c '#{input_args.join(" ")}'"
@@ -243,11 +304,27 @@ def interactive?(input_args)
   $stdin.tty?
 end
 
-def mount_tmp_dir(options)
-  "--mount type=bind,source=#{Dir.mktmpdir},destination=#{Dir.pwd}/tmp/#{options.fetch(:toolchain_info).platform},readonly=false"
+def mount_shared_bind_dir(src, dest)
+  "--mount type=bind,source=#{src},destination=#{dest},readonly=false"
 end
 
-def rcd(input_args, options)
+def mount_tmp_dir
+  "--mount type=bind,source=#{Dir.mktmpdir},destination=#{working_directory}/tmp/#{ruby_platform},readonly=false"
+end
+
+def toolchain_info
+  @toolchain_info ||= OPTIONS.fetch(:toolchain_info) do
+    logger.error("Could not determine ruby platform, please set ruby platform with --platform to one of:")
+    list_platforms
+    logger.fatal("Exiting...")
+  end
+end
+
+def ruby_platform
+  @ruby_platform ||= toolchain_info.platform
+end
+
+def rcd(input_args)
   wrapper_command = []
   wrapper_command << "sigfw" unless interactive?(input_args)
   wrapper_command << "runas"
@@ -257,13 +334,14 @@ def rcd(input_args, options)
 
   cmd = <<~SH
     #{default_docker_command} run \
-      --platform #{options.fetch(:docker_platform)} \
-      -v #{Dir.pwd}:#{Dir.pwd} \
-      #{mount_tmp_dir(options)} \
-      #{mount_target_dir(options)} \
+      --platform #{OPTIONS.fetch(:docker_platform)} \
+      -v #{working_directory}:#{working_directory} \
+      #{mount_tmp_dir} \
+      #{mount_target_dir} \
       #{mount_cargo_registry} \
-      #{mount_bundle_cache(options)} \
-      #{mount_command_history(options)} \
+      #{mount_rustup_toolchains} \
+      #{mount_bundle_cache} \
+      #{mount_command_history} \
       #{user_mapping} \
       -e GEM_PRIVATE_KEY_PASSPHRASE \
       -e ftp_proxy \
@@ -271,52 +349,54 @@ def rcd(input_args, options)
       -e https_proxy \
       -e RCD_HOST_RUBY_PLATFORM=#{RbConfig::CONFIG["arch"]} \
       -e RCD_HOST_RUBY_VERSION=#{RUBY_VERSION} \
+      -e RUSTUP_PERMIT_COPY_RENAME=true \
       -e RCD_IMAGE \
       -e RB_SYS_DOCK_TMPDIR="/tmp/rb-sys-dock" \
-      -e RB_SYS_CARGO_TARGET_DIR=#{tmp_target_dir(options).inspect} \
+      -e RB_SYS_CARGO_TARGET_DIR=#{tmp_target_dir.inspect} \
       #{ENV["RUBY_CC_VERSION"] ? "-e RUBY_CC_VERSION=#{ENV["RUBY_CC_VERSION"]}" : ""} \
       -e RAKEOPT \
       -e TERM \
-      -e LC_ALL=#{ENV.fetch("LC_ALL", "en_US.UTF-8")} \
-      -w #{Dir.pwd} \
+      -w #{working_directory} \
       --rm \
       --interactive \
       #{docker_options.join(" ")} \
       #{ENV.fetch("RCD_IMAGE")} \
       #{wrapper_command.join(" ")} \
-      #{default_command_to_run(input_args, options)}
+      #{default_command_to_run(input_args)}
   SH
 
-  log(:trace, "Running command: $ #{cmd}")
+  cmd.gsub!(/\s+/, " ")
+
+  logger.trace("Running command:\n\t$ #{cmd}")
 
   exec(cmd)
 end
 
-def download_image(options)
+def download_image
   image = ENV.fetch("RCD_IMAGE")
 
-  if docker("images -q #{image}").strip.empty? || options[:no_cache]
+  if docker("images -q #{image}").strip.empty? || OPTIONS[:no_cache]
     # Nicely formatted message that we are downloading the image which might take awhile
-    log(:notice, "Downloading container #{image.inspect}, this might take awhile...")
-    docker("pull #{image} --quiet --platform #{options[:docker_platform]} > /dev/null")
+    logger.notice("Downloading container #{image.inspect}, this might take awhile...")
+    docker("pull #{image} --platform #{OPTIONS[:docker_platform]} --quiet > /dev/null")
   end
 end
 
-def log_some_useful_info(options)
-  return if options[:build]
+def log_some_useful_info
+  return if OPTIONS[:build]
 
   if ARGV.empty?
-    log(:notice, "Entering shell in Docker container #{ENV["RCD_IMAGE"].inspect}")
+    logger.notice("Entering shell in Docker container #{ENV["RCD_IMAGE"].inspect}")
   else
-    log(:notice, "Running command #{ARGV.inspect} in Docker container #{ENV["RCD_IMAGE"].inspect}")
+    logger.notice("Running command #{ARGV.inspect} in Docker container #{ENV["RCD_IMAGE"].inspect}")
   end
 end
 
-def set_env(options)
-  ENV["RCD_IMAGE"] ||= "rbsys/#{options[:toolchain_info].platform}:#{options[:version]}"
+def set_env
+  ENV["RCD_IMAGE"] ||= "rbsys/#{ruby_platform}:#{OPTIONS[:version]}"
 end
 
-set_env(options)
-download_image(options)
-log_some_useful_info(options)
-rcd(ARGV, options)
+set_env
+download_image
+log_some_useful_info
+rcd(ARGV)

--- a/gem/lib/rb_sys/util/logger.rb
+++ b/gem/lib/rb_sys/util/logger.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module RbSys
+  module Util
+    class Logger
+      attr_accessor :io, :level
+
+      def initialize(io: $stderr, level: :info)
+        @io = ENV["GITHUB_ACTIONS"] ? $stdout : io
+        @level = level
+      end
+
+      def error(message, **opts)
+        add(:error, message, **opts)
+      end
+
+      def warn(message, **opts)
+        add(:warn, message, **opts)
+      end
+
+      def info(message, **opts)
+        add(:info, message, **opts)
+      end
+
+      def notice(message, **opts)
+        add(:notice, message, **opts)
+      end
+
+      def trace(message, **opts)
+        return unless level == :trace
+
+        add(:trace, message, **opts)
+      end
+
+      def fatal(message, **opts)
+        error(message, **opts)
+        abort
+      end
+
+      private
+
+      LEVEL_STYLES = {
+        warn: ["⚠️", "\e[1;33m"],
+        error: ["❌", "\e[1;31m"],
+        info: ["ℹ️", "\e[1;37m"],
+        notice: ["🐳", "\e[1;34m"],
+        trace: ["🔍", "\e[1;2m"]
+      }
+
+      if ENV["GITHUB_ACTIONS"]
+        def add(level, message, emoji: true)
+          emote, _ = LEVEL_STYLES.fetch(level.to_sym)
+          io.puts "::#{level}::#{emote} #{message}"
+        end
+      else
+        def add(level, message, emoji: true)
+          emoji_opt, shellcode = LEVEL_STYLES.fetch(level.to_sym)
+
+          emoji_opt = if emoji.is_a?(String)
+            emoji + " "
+          elsif emoji
+            emoji_opt + " "
+          end
+
+          # Escape the message for bash shell codes (e.g. \033[1;31m)
+          escaped = message.gsub("\\", "\\\\\\").gsub("\033", "\\033")
+
+          io.puts "#{shellcode}#{emoji_opt}#{escaped}\033[0m"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
I want to make these docker images smaller, bc right now they're huge. A big part of that is the rust toolchain baked in. This PR makes it possible to mount a local rust toolchain into the container, as to bypass the need to have one installed in docker.

Later, this allow us the not bundle a rust toolchain in the image.