### PR TITLE
Stop avoiding linking to ruby when linting to avoid dynamic link errors

### DIFF
--- a/crates/rb-sys/build/features.rs
+++ b/crates/rb-sys/build/features.rs
@@ -57,10 +57,6 @@ pub fn is_ruby_static_enabled(rbconfig: &RbConfig) -> bool {
 }
 
 pub fn is_link_ruby_enabled() -> bool {
-    if is_linting() {
-        return false;
-    }
-
     if is_no_link_ruby_enabled() {
         false
     } else if is_mswin_or_mingw() {


### PR DESCRIPTION
## Problem

When developing code using rb-sys on ARM64 macOS, I've occasionally had unit tests failing with an error like

```
$ cargo test
   Compiling rb-sys v0.9.54
   Compiling ext v0.1.0 (/Users/dylants/Downloads/src/oxi-test/ext)
    Finished test [unoptimized + debuginfo] target(s) in 0.77s
     Running unittests src/lib.rs (target/debug/deps/ext-4c633f51b6928390)
dyld[65553]: symbol not found in flat namespace '_rb_define_module'
error: test failed, to rerun pass `--lib`

Caused by:
  process didn't exit successfully: `/Users/dylants/Downloads/src/oxi-test/target/debug/deps/ext-4c633f51b6928390` (signal: 6, SIGABRT: process abort signal)
```

after that, using `otool -L target/debug/deps/ext-4c633f51b6928390` shows that it isn't compiled to link against libruby, which it would be after doing a `cargo clean` of rb-sys and packages that depend on it and retrying `cargo test`, which is why it isn't managing to dynamically link against ruby.

I was able to reproduce this in the oxi-test repo using VSCode with the following .vscode/settings.json and the rust-analyzer plugin installed

```
{
  "editor.formatOnSave": true,
  "rust-analyzer.checkOnSave.command": "clippy"
}
```

with the following steps:

1. `cargo clean -p rb-sys` to get into a state that requires recompilation of crates that link to ruby
2. Save a change in VSCode to ext/src/lib.rs trigger rust-analyzer
3. `cargo test`

which reproduces that `cargo test` dynamic link error I posted above.

## Solution

@ianks pointed out that rb-sys skips linking when the linter is detected, so I removed the condition the conditional branch that skips linking.

## Manual Testing

I tested this branch with the above reproduction steps in oxi-test using the following in the top-level Cargo.toml

```
[patch.crates-io]
rb-sys = { git = "https://github.com/dylanahsmith/rb-sys", branch = "fix-linking-when-linting" }
```

which prevented the linking error I was seeing.