### PR TITLE
Allow to add a space between Ruby versions in `rb-sys-dock`

### DIFF
--- a/gem/exe/rb-sys-dock
+++ b/gem/exe/rb-sys-dock
@@ -93,7 +93,7 @@ OptionParser.new do |opts|
   end
 
   opts.on("-r", "--ruby-versions LIST", "List all supported Ruby versions") do |arg|
-    vers = arg.split(/[^0-9.]/).map do |v|
+    vers = arg.split(/[^0-9.]+/).map do |v|
       parts = v.split(".")
       parts[2] = "0" if parts[2].nil?
       parts.join(".")


### PR DESCRIPTION
I tried to specify `--ruby-versions` of `rb-sys-dock` like `'3.1, 3.2'` at the first time. But the current parse process treats space as a value too. So Ruby versions will be `["3.1.0", "..0", "3.2.0"]` at last. Of course, these are not expected values.

In my personal opinion, adding space between values is happened often. So this patch fixes to allow it.