### PR TITLE
Keep other metadata when sets `rubygems_mfa_required`

### DIFF
--- a/gem/rb_sys.gemspec
+++ b/gem/rb_sys.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
   # Security
   spec.cert_chain = ["certs/ianks.pem"]
   spec.signing_key = File.expand_path("~/.ssh/gem-private_key.pem") if $0.end_with?("gem")
-  spec.metadata = {"rubygems_mfa_required" => "true"}
+  spec.metadata["rubygems_mfa_required"] = "true"
 end


### PR DESCRIPTION
Currently, metadata is overridden when set `rubygems_mfa_required`.  So other metadata, like `source_code_uri` is lost. This fixes to keep all metadata.