### PR TITLE
Make `RbSys::ExtensionTask` work without gem spec

### DIFF
--- a/gem/lib/rb_sys/extensiontask.rb
+++ b/gem/lib/rb_sys/extensiontask.rb
@@ -22,7 +22,11 @@ module RbSys
   # @param gem_spec [Gem::Specification] the gem specification to build (needed for cross-compiling)
   # @return [Rake::ExtensionTask]
   class ExtensionTask < Rake::ExtensionTask
-    def init(name = nil, gem_spec = :undefined)
+    def initialize(name = nil, gem_spec = :undefined)
+      super
+    end
+
+    def init(name = nil, gem_spec = nil)
       super(name, lint_gem_spec(name, gem_spec))
 
       @orginal_ext_dir = @ext_dir


### PR DESCRIPTION
Currently, if users use `RbSys::ExtensionTask` without a gem spec, `RbSys::ExtensionTask` raises `ArgumentError`.

This is because `Rake::BaseExtensionTask#initialize` calls `RbSys::ExtensionTask#init` with `gem_spec=nil`.
https://github.com/rake-compiler/rake-compiler/blob/f845901f79681ddee8d387c20212585dee494990/lib/rake/baseextensiontask.rb#L28-L29

So `gem_spec` it to be `nil`, not ` :undefined`. That's why `RbSys::ExtensionTask#lint_gem_spec` raises `ArgumentError`.

This fixed to override initialize and set `gem_spec` as expected.