### PR TITLE
Do not allow unaligned-references

### DIFF
--- a/crates/rb-sys/src/bindings.rs
+++ b/crates/rb-sys/src/bindings.rs
@@ -8,7 +8,6 @@
 #![allow(unknown_lints)]
 #![allow(deref_nullptr)]
 #![warn(unknown_lints)]
-#![allow(unaligned_references)]
 #![allow(clippy::all)]
 #![allow(rustdoc::broken_intra_doc_links)]
 #![allow(rustdoc::invalid_rust_codeblocks)]


### PR DESCRIPTION
[Since they will be converted to a hard error in the future](https://github.com/rust-lang/rust/issues/82523)
