### PR TITLE
Bump bindgen to 0.62

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -19,8 +19,12 @@ jobs:
             ref: main
             run: rake
           - name: "matsadler/magnus"
-            slug: magnus
-            ref: "0.5.0"
+            slug: magnus-0.5
+            ref: "0.5.3"
+            run: cargo test
+          - name: "matsadler/magnus"
+            slug: magnus-head
+            ref: "51d154ce32a3ef06542454fc720ad4f291dba86a"
             run: cargo test
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
         rust: ["stable"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.60.1"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "062dddbc1ba4aca46de6338e2bf87771414c335f7b2f2036e8f3e9befebf88e6"
+checksum = "c6720a8b7b2d39dd533285ed438d458f65b31b5c257e6ac7bb3d7e82844dd722"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -28,6 +28,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
+ "syn",
 ]
 
 [[package]]
@@ -215,9 +216,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.27"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]

--- a/crates/rb-sys-build/Cargo.toml
+++ b/crates/rb-sys-build/Cargo.toml
@@ -6,7 +6,7 @@ description = "Build system for rb-sys"
 homepage = "https://github.com/oxidize-rb/rb-sys"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/oxidize-rb/rb-sys"
-rust-version = "1.54"
+rust-version = "1.57"
 
 [lib]
 bench = false
@@ -15,7 +15,7 @@ doctest = false
 [dependencies]
 regex = "1"
 shell-words = "1.1"
-bindgen = { version = "0.60", default-features = false, features = ["runtime"] }
+bindgen = { version = "0.62", default-features = false, features = ["runtime"] }
 cc-impl = { version = "1.0", optional = true, package = "cc" }
 syn = { version = "1.0", features = ["parsing", "full", "extra-traits"] }
 quote = "1.0"
@@ -29,3 +29,6 @@ bindgen-rbimpls = []
 bindgen-deprecated-types = []
 bindgen-layout-tests = []
 bindgen-impl-debug = []
+bindgen-sizet-is-usize = []
+bindgen-return-const-encoding-pointers = []
+bindgen-enable-function-attribute-detection = []

--- a/crates/rb-sys-build/src/bindings.rs
+++ b/crates/rb-sys-build/src/bindings.rs
@@ -73,7 +73,7 @@ pub fn generate(
         syn::parse_file(&code_string)?
     };
 
-    let ruby_version = rbconfig.ruby_version();
+    let ruby_version = rbconfig.ruby_program_version();
     let ruby_platform = rbconfig.platform();
     let crate_version = env!("CARGO_PKG_VERSION");
     let out_path = out_dir.join(format!(
@@ -82,11 +82,13 @@ pub fn generate(
     ));
 
     let code = {
+        sanitizer::ensure_backwards_compatible_encoding_pointers(&mut tokens);
         clean_docs(rbconfig, &mut tokens);
 
         if is_msvc() {
             qualify_symbols_for_msvc(&mut tokens, static_ruby, rbconfig);
         }
+
         push_cargo_cfg_from_bindings(&tokens, cfg_out).expect("write cfg");
         tokens.into_token_stream().to_string()
     };
@@ -115,7 +117,7 @@ fn clean_docs(rbconfig: &RbConfig, syntax: &mut syn::File) {
         return;
     }
 
-    let ver = rbconfig.ruby_version();
+    let ver = rbconfig.ruby_program_version();
 
     sanitizer::cleanup_docs(syntax, &ver).unwrap_or_else(|e| {
         eprintln!("Failed to clean up docs, skipping: {}", e);
@@ -123,8 +125,7 @@ fn clean_docs(rbconfig: &RbConfig, syntax: &mut syn::File) {
 }
 
 fn default_bindgen(clang_args: Vec<String>) -> bindgen::Builder {
-    bindgen::Builder::default()
-        .use_core()
+    let bindings = bindgen::Builder::default()
         .rustfmt_bindings(false) // We use syn so this is pointless
         .rustified_enum(".*")
         .no_copy("rb_data_type_struct")
@@ -136,8 +137,16 @@ fn default_bindgen(clang_args: Vec<String>) -> bindgen::Builder {
         .blocklist_item("^_opaque_pthread.*")
         .blocklist_item("^pthread_.*")
         .blocklist_item("^rb_native.*")
+        .merge_extern_blocks(true)
+        .size_t_is_usize(env::var("CARGO_FEATURE_BINDGEN_SIZE_T_IS_USIZE").is_ok())
         .impl_debug(cfg!(feature = "bindgen-impl-debug"))
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks));
+
+    if env::var("CARGO_FEATURE_BINDGEN_ENABLE_FUNCTION_ATTRIBUTE_DETECTION").is_ok() {
+        bindings.enable_function_attribute_detection()
+    } else {
+        bindings
+    }
 }
 
 // This is needed because bindgen doesn't support the `__declspec(dllimport)` on

--- a/crates/rb-sys-build/src/bindings.rs
+++ b/crates/rb-sys-build/src/bindings.rs
@@ -5,7 +5,7 @@ use crate::RbConfig;
 use quote::ToTokens;
 use std::fs::File;
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::{env, error::Error};
 use syn::{Expr, ExprLit, ItemConst, Lit};
 
@@ -100,7 +100,7 @@ pub fn generate(
     Ok(out_path)
 }
 
-fn run_rustfmt(path: &PathBuf) {
+fn run_rustfmt(path: &Path) {
     let mut cmd = std::process::Command::new("rustfmt");
     cmd.stderr(std::process::Stdio::inherit());
     cmd.stdout(std::process::Stdio::inherit());

--- a/crates/rb-sys-env/Cargo.toml
+++ b/crates/rb-sys-env/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/oxidize-rb/rb-sys"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/oxidize-rb/rb-sys"
 readme = "readme.md"
-rust-version = "1.54"
+rust-version = "1.57"
 
 [lib]
 bench = false

--- a/crates/rb-sys-test-helpers-macros/Cargo.toml
+++ b/crates/rb-sys-test-helpers-macros/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/oxidize-rb/rb-sys"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/oxidize-rb/rb-sys"
 readme = "readme.md"
-rust-version = "1.54"
+rust-version = "1.57"
 
 [lib]
 proc-macro = true

--- a/crates/rb-sys-test-helpers/Cargo.toml
+++ b/crates/rb-sys-test-helpers/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/oxidize-rb/rb-sys"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/oxidize-rb/rb-sys"
 readme = "readme.md"
-rust-version = "1.54"
+rust-version = "1.57"
 
 [lib]
 bench = false

--- a/crates/rb-sys-tests/Cargo.toml
+++ b/crates/rb-sys-tests/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.9.76"
 edition = "2018"
 autotests = false
 publish = false
-rust-version = "1.54"
+rust-version = "1.57"
 
 [lib]
 bench = false

--- a/crates/rb-sys/Cargo.toml
+++ b/crates/rb-sys/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://github.com/oxidize-rb/rb-sys"
 license = "MIT OR Apache-2.0"
 links = "rb"
 repository = "https://github.com/oxidize-rb/rb-sys"
-rust-version = "1.54"
+rust-version = "1.57"
 
 [build-dependencies]
 rb-sys-build = { version = "0.9.76", path = "../rb-sys-build" }
@@ -30,6 +30,9 @@ bindgen-rbimpls = ["rb-sys-build/bindgen-rbimpls"]
 bindgen-deprecated-types = ["rb-sys-build/bindgen-deprecated-types"]
 bindgen-layout-tests = ["rb-sys-build/bindgen-layout-tests"]
 bindgen-impl-debug = ["rb-sys-build/bindgen-impl-debug"]
+bindgen-sizet-is-usize = ["rb-sys-build/bindgen-sizet-is-usize"]
+bindgen-return-const-encoding-pointers = ["rb-sys-build/bindgen-return-const-encoding-pointers"]
+bindgen-enable-function-attribute-detection = ["rb-sys-build/bindgen-enable-function-attribute-detection"]
 
 [lib]
 doctest = false

--- a/crates/rb-sys/build/main.rs
+++ b/crates/rb-sys/build/main.rs
@@ -28,7 +28,7 @@ fn main() {
     let mut rbconfig = RbConfig::current();
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
 
-    let ruby_version = rbconfig.ruby_version();
+    let ruby_version = rbconfig.ruby_program_version();
     let ruby_platform = rbconfig.platform();
     let crate_version = env!("CARGO_PKG_VERSION");
     let cfg_capture_path = out_dir.join(format!(

--- a/data/toolchains.json
+++ b/data/toolchains.json
@@ -1,7 +1,7 @@
 {
   "policy": {
     "minimum-supported-ruby-version": "2.4",
-    "minimum-supported-rust-version": "1.54"
+    "minimum-supported-rust-version": "1.57"
   },
   "toolchains": [
     {

--- a/examples/rust_reverse/ext/rust_reverse/Cargo.lock
+++ b/examples/rust_reverse/ext/rust_reverse/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.60.1"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "062dddbc1ba4aca46de6338e2bf87771414c335f7b2f2036e8f3e9befebf88e6"
+checksum = "c6720a8b7b2d39dd533285ed438d458f65b31b5c257e6ac7bb3d7e82844dd722"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -28,6 +28,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
+ "syn",
 ]
 
 [[package]]

--- a/gem/lib/rb_sys/mkmf.rb
+++ b/gem/lib/rb_sys/mkmf.rb
@@ -80,12 +80,8 @@ module RbSys
         #{conditional_assign("RB_SYS_CARGO_PROFILE_DIR", "$(RB_SYS_CARGO_PROFILE)", indent: 1)}
         #{endif_stmt}
 
-        # Set the build profile (dev, release, etc.) Compat with Rust 1.54.
-        #{if_eq_stmt("$(RB_SYS_CARGO_PROFILE)", "release")}
-        #{assign_stmt("RB_SYS_CARGO_PROFILE_FLAG", "--release", indent: 1)}
-        #{else_stmt}
+        # Set the build profile (dev, release, etc.).
         #{assign_stmt("RB_SYS_CARGO_PROFILE_FLAG", "--profile $(RB_SYS_CARGO_PROFILE)", indent: 1)}
-        #{endif_stmt}
 
         # Account for sub-directories when using `--target` argument with Cargo
         #{conditional_assign("RB_SYS_CARGO_TARGET_DIR", "target")}
@@ -332,8 +328,8 @@ module RbSys
         raise "libclang version 5.0.0 or greater is required (current #{libclang_version})"
       end
 
-      if libclang_version >= Gem::Version.new("15.0.0")
-        raise "libclang version > 14.0.0 or greater is required (current #{libclang_version})"
+      if libclang_version >= Gem::Version.new("17.0.0")
+        raise "libclang version < 17.0.0 or greater is required (current #{libclang_version})"
       end
     end
 

--- a/readme.md
+++ b/readme.md
@@ -42,7 +42,7 @@ building your own gem.
 
 - Ruby: <!--toolchains .policy.minimum-supported-ruby-version -->2.4<!--/toolchains-->+ (for full compatibility with
   Rubygems)
-- Rust: <!--toolchains .policy.minimum-supported-rust-version -->1.54<!--/toolchains-->+ (for old versions of rust
+- Rust: <!--toolchains .policy.minimum-supported-rust-version -->1.57<!--/toolchains-->+ (for old versions of rust
   toolchains ubuntu)
 
 ## Supported Platforms


### PR DESCRIPTION
Due to getting multiple reports of libclang issues (i.e. #207), I've prioritized getting [bindgen bumped to 0.62](https://github.com/rust-lang/rust-bindgen/blob/main/CHANGELOG.md#0620) which addresses a number of these issues.

### Caveats

Doing this requires that we bump the minimum supported rust version from 1.54 to 1.57, but other than that I made sure there were no breaking changes with generated code so we remain compatible with magnus, etc.

### New Features

- `bindgen-sizet-is-usize` - allows for upstream users to use `usize` instead of `size_t` 
- `bindgen-return-const-encoding-pointers` - allow bindgen to generate `*const rb_encoding` return types (which it used to by default, but that older versions generated `*mut _` which would have caused breakage)
- `bindgen-enable-function-attribute-detection` - [see docs](https://github.com/rust-lang/rust-bindgen/blob/948d0d489a327e81157ef36dda840f04ed9a1a18/bindgen/options/mod.rs#L697)

### Links

- [bindgen diff (`v0.60.1...v0.62.0`)](https://github.com/rust-lang/rust-bindgen/compare/v0.60.1...v0.62.0)

resolves #207 
resolves #198 