### PR TITLE
Support FreeBSD

### DIFF
--- a/crates/rb-sys-build/src/bindings.rs
+++ b/crates/rb-sys-build/src/bindings.rs
@@ -137,6 +137,7 @@ fn default_bindgen(clang_args: Vec<String>) -> bindgen::Builder {
         .blocklist_item("^_opaque_pthread.*")
         .blocklist_item("^pthread_.*")
         .blocklist_item("^rb_native.*")
+        .opaque_type("^__sFILE$")
         .merge_extern_blocks(true)
         .size_t_is_usize(env::var("CARGO_FEATURE_BINDGEN_SIZE_T_IS_USIZE").is_ok())
         .impl_debug(cfg!(feature = "bindgen-impl-debug"))


### PR DESCRIPTION
FreeBSD's FILE structure is fully defined in stdio.h, and it includes pthread types. Since it's only defined to support a handful of inline functions and is still intended to be opaque, treat it as such in rust.