### PR TITLE
install extra rustup targets from makefile

### DIFF
--- a/examples/rust_reverse/ext/rust_reverse/extconf.rb
+++ b/examples/rust_reverse/ext/rust_reverse/extconf.rb
@@ -31,4 +31,7 @@ create_rust_makefile("rust_reverse/rust_reverse") do |r|
 
   # Extra args to pass to the `rustc` command (optional)
   r.extra_rustc_args = []
+
+  # Extra targets to install via rustup (optional)
+  r.extra_rustup_targets = ["wasm32-unknown-unknown"]
 end

--- a/gem/lib/rb_sys/mkmf.rb
+++ b/gem/lib/rb_sys/mkmf.rb
@@ -253,10 +253,17 @@ module RbSys
         \t$(Q) curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --no-modify-path --profile $(RB_SYS_RUSTUP_PROFILE) --default-toolchain none -y
         \t$(Q) $(CARGO_HOME)/bin/rustup toolchain install $(RB_SYS_DEFAULT_TOOLCHAIN) --profile $(RB_SYS_RUSTUP_PROFILE)
         \t$(Q) $(CARGO_HOME)/bin/rustup default $(RB_SYS_DEFAULT_TOOLCHAIN)
+        #{install_extra_rustup_targets(builder)}
 
         $(RUSTLIB): $(CARGO)
         #{endif_stmt}
       MAKE
+    end
+
+    def install_extra_rustup_targets(builder)
+      builder.extra_rustup_targets.map do |target|
+        "\t$(Q) $(CARGO_HOME)/bin/rustup target add #{target}"
+      end.join("\n")
     end
 
     def force_install_rust_toolchain?(builder)

--- a/gem/lib/rb_sys/mkmf/config.rb
+++ b/gem/lib/rb_sys/mkmf/config.rb
@@ -19,12 +19,16 @@ module RbSys
       # Directories to clean after installing with Rubygems
       attr_accessor :rubygems_clean_dirs
 
+      # Extra targets to install
+      attr_accessor :extra_rustup_targets
+
       def initialize(builder)
         @builder = builder
         @force_install_rust_toolchain = false
         @auto_install_rust_toolchain = true
         @clean_after_install = rubygems_invoked?
         @rubygems_clean_dirs = ["./cargo-vendor"]
+        @extra_rustup_targets = []
       end
 
       # @api private

--- a/gem/test/test_rb_sys.rb
+++ b/gem/test/test_rb_sys.rb
@@ -63,6 +63,17 @@ class TestRbSys < Minitest::Test
     assert_match(/-C debuginfo=42$/, makefile.read)
   end
 
+  def test_installs_extra_rustup_targets
+    makefile = create_makefile do |b|
+      b.extra_rustup_targets = ["wasm32-unknown-unknown", "wasm32-wasi-unknown"]
+    end
+
+    makefile_output = makefile.read
+
+    assert_match(/rustup target add wasm32-unknown-unknown$/, makefile_output)
+    assert_match(/rustup target add wasm32-wasi-unknown$/, makefile_output)
+  end
+
   def test_uses_extra_cargo_args
     makefile = create_makefile do |b|
       b.extra_cargo_args = ["--crate-type", "cdylib"]


### PR DESCRIPTION
### What are you trying to solve?

Add a new config for mkmf to install rustup target.
The gems that are targeting `wasm32-unknown-unknown` can install the required target in the makefile.