### PR TITLE
Update syn to 2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -242,7 +242,7 @@ dependencies = [
  "quote",
  "regex",
  "shell-words",
- "syn",
+ "syn 2.0.5",
 ]
 
 [[package]]
@@ -266,7 +266,7 @@ dependencies = [
  "quote",
  "rb-sys",
  "rb-sys-test-helpers",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -354,6 +354,17 @@ name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89c2d1c76a26822187a1fbb5964e3fff108bc208f02e820ab9dac1234f6b388a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,11 +13,11 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.62.0"
+version = "0.66.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6720a8b7b2d39dd533285ed438d458f65b31b5c257e6ac7bb3d7e82844dd722"
+checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
 dependencies = [
- "bitflags",
+ "bitflags 2.3.2",
  "cexpr",
  "clang-sys",
  "lazy_static",
@@ -28,7 +28,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -36,6 +36,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbe3c979c178231552ecba20214a8272df4e09f232a87aef4320cf06539aded"
 
 [[package]]
 name = "cc"
@@ -242,7 +248,7 @@ dependencies = [
  "quote",
  "regex",
  "shell-words",
- "syn 2.0.5",
+ "syn",
 ]
 
 [[package]]
@@ -266,7 +272,7 @@ dependencies = [
  "quote",
  "rb-sys",
  "rb-sys-test-helpers",
- "syn 2.0.5",
+ "syn",
 ]
 
 [[package]]
@@ -285,7 +291,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -317,7 +323,7 @@ version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
@@ -351,20 +357,9 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
-version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89c2d1c76a26822187a1fbb5964e3fff108bc208f02e820ab9dac1234f6b388a"
+checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,7 +266,7 @@ dependencies = [
  "quote",
  "rb-sys",
  "rb-sys-test-helpers",
- "syn 1.0.109",
+ "syn 2.0.5",
 ]
 
 [[package]]

--- a/crates/rb-sys-build/Cargo.toml
+++ b/crates/rb-sys-build/Cargo.toml
@@ -17,7 +17,7 @@ regex = "1"
 shell-words = "1.1"
 bindgen = { version = "0.62", default-features = false, features = ["runtime"] }
 cc-impl = { version = "1.0", optional = true, package = "cc" }
-syn = { version = "1.0", features = ["parsing", "full", "extra-traits"] }
+syn = { version = "2.0", features = ["parsing", "full", "extra-traits"] }
 quote = "1.0"
 lazy_static = "1.4.0"
 proc-macro2 = "1.0"

--- a/crates/rb-sys-build/Cargo.toml
+++ b/crates/rb-sys-build/Cargo.toml
@@ -6,7 +6,7 @@ description = "Build system for rb-sys"
 homepage = "https://github.com/oxidize-rb/rb-sys"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/oxidize-rb/rb-sys"
-rust-version = "1.57"
+rust-version = "1.60"
 
 [lib]
 bench = false
@@ -15,7 +15,7 @@ doctest = false
 [dependencies]
 regex = "1"
 shell-words = "1.1"
-bindgen = { version = "0.62", default-features = false, features = ["runtime"] }
+bindgen = { version = "0.66", default-features = false, features = ["runtime"] }
 cc-impl = { version = "1.0", optional = true, package = "cc" }
 syn = { version = "2.0", features = ["parsing", "full", "extra-traits"] }
 quote = "1.0"

--- a/crates/rb-sys-build/src/bindings.rs
+++ b/crates/rb-sys-build/src/bindings.rs
@@ -126,7 +126,6 @@ fn clean_docs(rbconfig: &RbConfig, syntax: &mut syn::File) {
 
 fn default_bindgen(clang_args: Vec<String>) -> bindgen::Builder {
     let bindings = bindgen::Builder::default()
-        .rustfmt_bindings(false) // We use syn so this is pointless
         .rustified_enum(".*")
         .no_copy("rb_data_type_struct")
         .derive_eq(true)

--- a/crates/rb-sys-build/src/bindings/sanitizer.rs
+++ b/crates/rb-sys-build/src/bindings/sanitizer.rs
@@ -1,8 +1,9 @@
-use proc_macro2::{Literal, TokenTree};
-use quote::ToTokens;
 use regex::Regex;
-use std::{borrow::Cow, error::Error};
-use syn::{Attribute, Item};
+use std::{
+    borrow::{Borrow, Cow},
+    error::Error,
+};
+use syn::{Attribute, Expr, Item, Lit, LitStr, Meta};
 
 lazy_static::lazy_static! {
     static ref URL_REGEX: Regex = Regex::new(r#"https?://[^\s'"]+"#).unwrap();
@@ -100,19 +101,16 @@ pub fn cleanup_docs(syntax: &mut syn::File, ruby_version: &str) -> Result<(), Bo
 }
 
 fn clean_doc_line(attr: &mut Attribute) -> bool {
-    if !attr.path.is_ident("doc") {
+    if !attr.path().is_ident("doc") {
         return false;
     }
 
     let mut deprecated: bool = false;
 
-    let new_tokens = attr
-        .tokens
-        .to_token_stream()
-        .into_iter()
-        .map(|token| {
-            if let TokenTree::Literal(l) = token {
-                let cleaned = l.to_string();
+    if let Meta::NameValue(name_value) = &mut attr.meta {
+        if let Expr::Lit(expr_lit) = &mut name_value.value {
+            if let Lit::Str(lit_str) = &mut expr_lit.lit {
+                let cleaned = lit_str.value();
                 let cleaned = cleaned.trim_matches('"').trim();
                 let cleaned = URL_REGEX.replace_all(cleaned, "<${0}>");
                 let cleaned =
@@ -125,24 +123,21 @@ fn clean_doc_line(attr: &mut Attribute) -> bool {
                     });
                 let cleaned = PARAM_DIRECTIVE_REGEX.replace(&cleaned, "- **$1** `$2` $3");
                 let cleaned = OTHER_DIRECTIVE_REGEX.replace(&cleaned, "- **$1** $2");
-                let cleaned = BARE_CODE_REF_REGEX.replace_all(&cleaned, "${1}[`${2}`]");
+                let mut cleaned = BARE_CODE_REF_REGEX.replace_all(&cleaned, "${1}[`${2}`]");
 
                 if cleaned.is_empty() {
-                    return TokenTree::Literal(Literal::string("\n"));
+                    cleaned = "\n".into();
                 }
 
                 if cleaned.contains("@deprecated") {
                     deprecated = true;
                 }
 
-                Literal::string(&cleaned).into()
-            } else {
-                token
+                *lit_str = LitStr::new(cleaned.borrow(), lit_str.span());
             }
-        })
-        .collect();
+        }
+    }
 
-    attr.tokens = new_tokens;
     deprecated
 }
 

--- a/crates/rb-sys-env/Cargo.toml
+++ b/crates/rb-sys-env/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/oxidize-rb/rb-sys"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/oxidize-rb/rb-sys"
 readme = "readme.md"
-rust-version = "1.57"
+rust-version = "1.60"
 
 [lib]
 bench = false

--- a/crates/rb-sys-test-helpers-macros/Cargo.toml
+++ b/crates/rb-sys-test-helpers-macros/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/oxidize-rb/rb-sys"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/oxidize-rb/rb-sys"
 readme = "readme.md"
-rust-version = "1.57"
+rust-version = "1.60"
 
 [lib]
 proc-macro = true

--- a/crates/rb-sys-test-helpers-macros/Cargo.toml
+++ b/crates/rb-sys-test-helpers-macros/Cargo.toml
@@ -15,7 +15,7 @@ bench = false
 doctest = true
 
 [dependencies]
-syn = { version = "1.0", features = ["parsing", "full"] }
+syn = { version = "2.0", features = ["parsing", "full"] }
 quote = "1.0"
 
 [dev-dependencies]

--- a/crates/rb-sys-test-helpers/Cargo.toml
+++ b/crates/rb-sys-test-helpers/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/oxidize-rb/rb-sys"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/oxidize-rb/rb-sys"
 readme = "readme.md"
-rust-version = "1.57"
+rust-version = "1.60"
 
 [lib]
 bench = false

--- a/crates/rb-sys-tests/Cargo.toml
+++ b/crates/rb-sys-tests/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.9.79"
 edition = "2018"
 autotests = false
 publish = false
-rust-version = "1.57"
+rust-version = "1.60"
 
 [lib]
 bench = false

--- a/crates/rb-sys/Cargo.toml
+++ b/crates/rb-sys/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://github.com/oxidize-rb/rb-sys"
 license = "MIT OR Apache-2.0"
 links = "rb"
 repository = "https://github.com/oxidize-rb/rb-sys"
-rust-version = "1.57"
+rust-version = "1.60"
 
 [build-dependencies]
 rb-sys-build = { version = "0.9.79", path = "../rb-sys-build" }

--- a/data/toolchains.json
+++ b/data/toolchains.json
@@ -1,7 +1,7 @@
 {
   "policy": {
     "minimum-supported-ruby-version": "2.4",
-    "minimum-supported-rust-version": "1.57"
+    "minimum-supported-rust-version": "1.60"
   },
   "toolchains": [
     {

--- a/examples/rust_reverse/ext/rust_reverse/Cargo.lock
+++ b/examples/rust_reverse/ext/rust_reverse/Cargo.lock
@@ -136,9 +136,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -207,9 +207,9 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "89c2d1c76a26822187a1fbb5964e3fff108bc208f02e820ab9dac1234f6b388a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/readme.md
+++ b/readme.md
@@ -42,8 +42,7 @@ building your own gem.
 
 - Ruby: <!--toolchains .policy.minimum-supported-ruby-version -->2.4<!--/toolchains-->+ (for full compatibility with
   Rubygems)
-- Rust: <!--toolchains .policy.minimum-supported-rust-version -->1.57<!--/toolchains-->+ (for old versions of rust
-  toolchains ubuntu)
+- Rust: <!--toolchains .policy.minimum-supported-rust-version -->1.60<!--/toolchains-->+
 
 ## Supported Platforms
 


### PR DESCRIPTION
This takes the changes from #171 (Thanks @dylanahsmith, hope you don't mind), rebases them on main, and adds a couple more.

The motivation behind this is, I've updated Magnus to syn 2.0 and it'd be nice to have rb-sys and Magnus be able to use the same syn so it only need to be compiled once.

The biggest change is probably upping the minimum supported Rust version to 1.60, so that bindgen can be updated to 0.66, so that its syn dependency is upped to 2.0. Without this change the whole motivation for making any change is lost. Increasing the MSRV isn't something that bothers me right now as I'm going to be increasing it to 1.61 in Magnus, but if it doesn't work with your plans, then no worries, this whole change is just a nice to have, not critical, I'd be ok with dropping it.