### PR TITLE
Detect duplicate `sccache` wrappers

### DIFF
--- a/gem/lib/rb_sys/cargo_builder.rb
+++ b/gem/lib/rb_sys/cargo_builder.rb
@@ -6,6 +6,8 @@ module RbSys
   # A class to build a Ruby gem Cargo. Extracted from `rubygems` gem, with some modifications.
   # @api private
   class CargoBuilder < Gem::Ext::Builder
+    WELL_KNOWN_WRAPPERS = %w[sccache cachepot].freeze
+
     attr_accessor :spec, :runner, :env, :features, :target, :extra_rustc_args, :dry_run, :ext_dir, :extra_rustflags,
       :extra_cargo_args
     attr_writer :profile
@@ -148,6 +150,11 @@ module RbSys
     def linker_args
       cc_flag = Shellwords.split(makefile_config("CC"))
       linker = cc_flag.shift
+
+      if WELL_KNOWN_WRAPPERS.any? { |w| linker.include?(w) }
+        linker = cc_flag.shift
+      end
+
       link_args = cc_flag.flat_map { |a| ["-C", "link-arg=#{a}"] }
 
       return mswin_link_args if linker == "cl"


### PR DESCRIPTION
Previously, there was issues when using `sccache` in a certain scenario. 

1. If a user's `RbConfig::CONFIG["CC"] = "sccache gcc"` _and_ the env var `RUSTC_WRAPPER=sccache`, we would try to compile with:

```
$ sccache sccache gcc
```

2. We didn't detect `sccache` when setting the Cargo `linker`, leading to failed compilation

This PR fixes both of these issues so `sccache` should work well in all scenarios.