### PR TITLE
RbConfig: check if config dump succeeded

### DIFF
--- a/crates/rb-sys-build/src/rb_config.rs
+++ b/crates/rb-sys-build/src/rb_config.rs
@@ -82,6 +82,9 @@ impl RbConfig {
                     .arg("print RbConfig::CONFIG.map {|kv| kv.join(\"\x1F\")}.join(\"\x1E\")")
                     .output()
                     .unwrap_or_else(|e| panic!("ruby not found: {}", e));
+                if !config.status.success() {
+                    panic!("non-zero exit status while dumping RbConfig: {:?}", config);
+                }
                 String::from_utf8(config.stdout).expect("RbConfig value not UTF-8!")
             });
 


### PR DESCRIPTION
Adds a defensive check to make sure the call to dump the `RbConfig::CONFIG` exited successfully.

This makes it easier to diagnose a failure due to bazel misconfiguration. Without this the failure manifests as an empty config map and later as `panicked at 'Key not found: MAJOR'`