### PR TITLE
Add Config#use_cargo_build:

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -34,14 +34,14 @@ jobs:
         ruby: ["2.7", "3.2", "3.3"]
         exclude:
           - os: windows-latest
-            ruby: '3.3' # remove this once 3.3 binaries are available for windows
+            ruby: "3.3" # remove this once 3.3 binaries are available for windows
             repo:
               name: "matsadler/magnus"
               slug: magnus-head
               ref: "05359fcd2369f014570f1e417c7c2d462625af5e"
               run: cargo test
           - os: windows-latest
-            ruby: '3.3' # remove this once 3.3 binaries are available for windows
+            ruby: "3.3" # remove this once 3.3 binaries are available for windows
             repo:
               name: "matsadler/magnus"
               slug: magnus-0.5

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,8 +31,7 @@ make contribution easier. Here are the steps to use it:
 
 ## Running benchmarks
 
-To run the benchmarks, make sure your dev environment, then run `cargo bench`.
-This will run the `criterion` benchmarks and print the results to the console.
+To run the benchmarks, make sure your dev environment, then run `cargo bench`. This will run the `criterion` benchmarks
+and print the results to the console.
 
-To see see plots of the results, you can open
-`target/criterion/report/index.html` in your browser.
+To see see plots of the results, you can open `target/criterion/report/index.html` in your browser.

--- a/gem/lib/rb_sys/cargo_builder.rb
+++ b/gem/lib/rb_sys/cargo_builder.rb
@@ -9,7 +9,7 @@ module RbSys
     WELL_KNOWN_WRAPPERS = %w[sccache cachepot].freeze
 
     attr_accessor :spec, :runner, :env, :features, :target, :extra_rustc_args, :dry_run, :ext_dir, :extra_rustflags,
-      :extra_cargo_args
+      :extra_cargo_args, :config
     attr_writer :profile
 
     def initialize(spec)
@@ -66,7 +66,11 @@ module RbSys
 
     def cargo_command(dest_path, args = [])
       cmd = []
-      cmd += ["cargo", "rustc"]
+      if config.use_cargo_build
+        cmd += ["cargo", "build"]
+      else
+        cmd += ["cargo", "rustc"]
+      end
       cmd += ["--target", target] if target
       cmd += ["--target-dir", dest_path]
       cmd += ["--features", features.join(",")] unless features.empty?
@@ -74,9 +78,11 @@ module RbSys
       cmd += ["--profile", profile.to_s]
       cmd += Gem::Command.build_args
       cmd += args
-      cmd += ["--"]
-      cmd += [*rustc_args(dest_path)]
-      cmd += extra_rustc_args
+      if !config.use_cargo_build
+        cmd += ["--"]
+        cmd += [*rustc_args(dest_path)]
+        cmd += extra_rustc_args
+      end
       cmd
     end
 

--- a/gem/lib/rb_sys/cargo_builder.rb
+++ b/gem/lib/rb_sys/cargo_builder.rb
@@ -66,10 +66,10 @@ module RbSys
 
     def cargo_command(dest_path, args = [])
       cmd = []
-      if config.use_cargo_build
-        cmd += ["cargo", "build"]
+      cmd += if config.use_cargo_build
+        ["cargo", "build"]
       else
-        cmd += ["cargo", "rustc"]
+        ["cargo", "rustc"]
       end
       cmd += ["--target", target] if target
       cmd += ["--target-dir", dest_path]

--- a/gem/lib/rb_sys/mkmf/config.rb
+++ b/gem/lib/rb_sys/mkmf/config.rb
@@ -25,8 +25,13 @@ module RbSys
       # Use compiled C code fallback for stable API for ruby-head (default: false)
       attr_accessor :use_stable_api_compiled_fallback
 
+      # Instead of the default `cargo rustc` behaviour, just call `cargo build`.
+      # Requires manually setting relevant rb-sys environment (default: false)
+      attr_accessor :use_cargo_build
+
       def initialize(builder)
         @builder = builder
+        @builder.config = self
         @force_install_rust_toolchain = false
         @auto_install_rust_toolchain = true
         @use_stable_api_compiled_fallback = false

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,8 @@ it's not easy, it's a bug.
 
 ## New to `rb-sys`?
 
-- [Ruby on Rust Book 📖](https://oxidize-rb.github.io/rb-sys/) to describe how to build, test, and deploy a Rusty Ruby Gem
+- [Ruby on Rust Book 📖](https://oxidize-rb.github.io/rb-sys/) to describe how to build, test, and deploy a Rusty Ruby
+  Gem
 - [Contributing Docs 💻](./CONTRIBUTING.md) to get started in making your first contributions to rb-sys
 - [`rb-sys` gem 💎](./gem/README.md) to learn more about the `rb-sys` gem for **compiling extensions**
 
@@ -58,14 +59,14 @@ directory for automation purposes):
 
 | Platform          | Supported | Docker Image                                   |
 | ----------------- | --------- | ---------------------------------------------- |
-| x86_64-linux      | ✅         | [`rbsys/x86_64-linux:0.9.89`][docker-hub]      |
-| x86_64-linux-musl | ✅         | [`rbsys/x86_64-linux-musl:0.9.89`][docker-hub] |
-| aarch64-linux     | ✅         | [`rbsys/aarch64-linux:0.9.89`][docker-hub]     |
-| arm-linux         | ✅         | [`rbsys/arm-linux:0.9.89`][docker-hub]         |
-| arm64-darwin      | ✅         | [`rbsys/arm64-darwin:0.9.89`][docker-hub]      |
-| x64-mingw32       | ✅         | [`rbsys/x64-mingw32:0.9.89`][docker-hub]       |
-| x64-mingw-ucrt    | ✅         | [`rbsys/x64-mingw-ucrt:0.9.89`][docker-hub]    |
-| mswin             | ✅         | not available on Docker                        |
+| x86_64-linux      | ✅        | [`rbsys/x86_64-linux:0.9.89`][docker-hub]      |
+| x86_64-linux-musl | ✅        | [`rbsys/x86_64-linux-musl:0.9.89`][docker-hub] |
+| aarch64-linux     | ✅        | [`rbsys/aarch64-linux:0.9.89`][docker-hub]     |
+| arm-linux         | ✅        | [`rbsys/arm-linux:0.9.89`][docker-hub]         |
+| arm64-darwin      | ✅        | [`rbsys/arm64-darwin:0.9.89`][docker-hub]      |
+| x64-mingw32       | ✅        | [`rbsys/x64-mingw32:0.9.89`][docker-hub]       |
+| x64-mingw-ucrt    | ✅        | [`rbsys/x64-mingw-ucrt:0.9.89`][docker-hub]    |
+| mswin             | ✅        | not available on Docker                        |
 
 ## Getting Help
 


### PR DESCRIPTION
This switches behaviour to use `cargo build` instead of `cargo rustc`, which has the effect of sharing cache better with `cargo build`, but requires setting rb_sys environment in the default build.