### PR TITLE
Mount current directory, then CD to the working directory

### DIFF
--- a/gem/exe/rb-sys-dock
+++ b/gem/exe/rb-sys-dock
@@ -359,7 +359,7 @@ def rcd(input_args)
   cmd = <<~SH
     #{default_docker_command} run \
       --platform #{OPTIONS.fetch(:docker_platform)} \
-      -v #{working_directory}:#{working_directory} \
+      -v $(pwd):$(pwd) \
       #{mount_tmp_dir} \
       #{mount_target_dir} \
       #{mount_cargo_registry} \


### PR DESCRIPTION
Currently the docker image mounts the provided working directory. However, when building extensions that require parent hierarchies, this doesn't work.

Consider this example

```
api/ruby/
  Gemfile
  Cargo.toml
packages/core/
  Cargo.toml
Cargo.toml
```

The ruby gem's `Cargo.toml` requires the relative `../../packages/core/Cargo.toml` to complete building.
For the bundler to execute, you would pass the -directory (or from the actions working_directory argument) as `api/ruby`. However, this currently only results in the working_directory folder being mounted, making it so the build cannot complete.

I believe the most logical approach is to mount the current directory, and then change directories.

