### PR TITLE
Ensure references to opaque structs are qualified for `std::fmt::Debug`

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -27,26 +27,11 @@ jobs:
             run: cargo test
           - name: "matsadler/magnus"
             slug: magnus-head
-            ref: "05359fcd2369f014570f1e417c7c2d462625af5e"
+            ref: "627755429885eb1a84929e4d876f8cd8ec7303cf"
             run: cargo test
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
         rust: ["stable"]
         ruby: ["2.7", "3.2", "3.3"]
-        exclude:
-          - os: windows-latest
-            ruby: "3.3" # remove this once 3.3 binaries are available for windows
-            repo:
-              name: "matsadler/magnus"
-              slug: magnus-head
-              ref: "05359fcd2369f014570f1e417c7c2d462625af5e"
-              run: cargo test
-          - os: windows-latest
-            ruby: "3.3" # remove this once 3.3 binaries are available for windows
-            repo:
-              name: "matsadler/magnus"
-              slug: magnus-0.5
-              ref: "0.5.5"
-              run: cargo test
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/Rakefile
+++ b/Rakefile
@@ -30,6 +30,7 @@ namespace :test do
   cargo_test_task "rb-sys-tests"
   cargo_test_task "rb-sys-env"
   cargo_test_task "rb-sys-test-helpers"
+  cargo_test_task "rb-sys", "--all-targets", "--features", "bindgen-impl-debug,link-ruby" # Cover debian use case
 
   desc "Test against all installed Rubies"
   task :rubies do


### PR DESCRIPTION
resolves #355