### PR TITLE
Silence new unexpected_cfgs lint

### DIFF
--- a/crates/rb-sys-build/src/bindings.rs
+++ b/crates/rb-sys-build/src/bindings.rs
@@ -192,6 +192,10 @@ fn push_cargo_cfg_from_bindings(
             if is_defines(&conf_name) {
                 let name = conf_name.to_lowercase();
                 let val = conf.value_bool().to_string();
+                println!(
+                    r#"cargo:rustc-check-cfg=cfg(ruby_{}, values("true", "false"))"#,
+                    name
+                );
                 println!("cargo:rustc-cfg=ruby_{}=\"{}\"", name, val);
                 println!("cargo:defines_{}={}", name, val);
                 writeln!(cfg_out, "cargo:defines_{}={}", name, val)?;

--- a/crates/rb-sys-env/src/defines.rs
+++ b/crates/rb-sys-env/src/defines.rs
@@ -28,10 +28,11 @@ impl Defines {
 
     pub(crate) fn print_cargo_rustc_cfg(&self) {
         for (key, val) in self.raw_environment.iter() {
-            if key.starts_with("DEFINES_") && val == "true" {
-                let key = key.trim_start_matches("DEFINES_");
-                rustc_cfg!("ruby_{}", key.to_lowercase());
-            }
+            rustc_cfg!(
+                key.starts_with("DEFINES_") && val == "true",
+                "ruby_{}",
+                key.trim_start_matches("DEFINES_").to_lowercase()
+            );
         }
     }
 }

--- a/crates/rb-sys-env/src/ruby_version.rs
+++ b/crates/rb-sys-env/src/ruby_version.rs
@@ -50,46 +50,26 @@ impl RubyVersion {
     }
 
     pub fn print_cargo_rustc_cfg(&self) {
-        rustc_cfg!("ruby_{}", self.major);
-        rustc_cfg!("ruby_{}_{}", self.major, self.minor);
-        rustc_cfg!("ruby_{}_{}_{}", self.major, self.minor, self.teeny);
+        rustc_cfg!(true, "ruby_{}", self.major);
+        rustc_cfg!(true, "ruby_{}_{}", self.major, self.minor);
+        rustc_cfg!(true, "ruby_{}_{}_{}", self.major, self.minor, self.teeny);
 
         for v in &COMPARABLE_RUBY_MINORS {
-            if self.major_minor() < *v {
-                rustc_cfg!(r#"ruby_lt_{}_{}"#, v.0, v.1);
-            }
-            if self.major_minor() <= *v {
-                rustc_cfg!(r#"ruby_lte_{}_{}"#, v.0, v.1);
-            }
-            if self.major_minor() == *v {
-                rustc_cfg!(r#"ruby_{}_{}"#, v.0, v.1);
-                rustc_cfg!(r#"ruby_eq_{}_{}"#, v.0, v.1);
-            }
-            if self.major_minor() >= *v {
-                rustc_cfg!(r#"ruby_gte_{}_{}"#, v.0, v.1);
-            }
-            if self.major_minor() > *v {
-                rustc_cfg!(r#"ruby_gt_{}_{}"#, v.0, v.1);
-            }
+            rustc_cfg!(self.major_minor() < *v, r#"ruby_lt_{}_{}"#, v.0, v.1);
+            rustc_cfg!(self.major_minor() <= *v, r#"ruby_lte_{}_{}"#, v.0, v.1);
+            rustc_cfg!(self.major_minor() == *v, r#"ruby_{}_{}"#, v.0, v.1);
+            rustc_cfg!(self.major_minor() == *v, r#"ruby_eq_{}_{}"#, v.0, v.1);
+            rustc_cfg!(self.major_minor() >= *v, r#"ruby_gte_{}_{}"#, v.0, v.1);
+            rustc_cfg!(self.major_minor() > *v, r#"ruby_gt_{}_{}"#, v.0, v.1);
         }
 
         for v in &COMPARABLE_RUBY_MAJORS {
-            if self.major() < *v {
-                rustc_cfg!(r#"ruby_lt_{}"#, v);
-            }
-            if self.major() <= *v {
-                rustc_cfg!(r#"ruby_lte_{}"#, v);
-            }
-            if self.major() == *v {
-                rustc_cfg!(r#"ruby_{}"#, v);
-                rustc_cfg!(r#"ruby_eq_{}"#, v);
-            }
-            if self.major() >= *v {
-                rustc_cfg!(r#"ruby_gte_{}"#, v);
-            }
-            if self.major() > *v {
-                rustc_cfg!(r#"ruby_gt_{}"#, v);
-            }
+            rustc_cfg!(self.major() < *v, r#"ruby_lt_{}"#, v);
+            rustc_cfg!(self.major() <= *v, r#"ruby_lte_{}"#, v);
+            rustc_cfg!(self.major() == *v, r#"ruby_{}"#, v);
+            rustc_cfg!(self.major() == *v, r#"ruby_eq_{}"#, v);
+            rustc_cfg!(self.major() >= *v, r#"ruby_gte_{}"#, v);
+            rustc_cfg!(self.major() > *v, r#"ruby_gt_{}"#, v);
         }
     }
 }

--- a/crates/rb-sys-env/src/utils.rs
+++ b/crates/rb-sys-env/src/utils.rs
@@ -1,6 +1,9 @@
 #[macro_export]
 macro_rules! rustc_cfg {
-    ($var:literal, $($cfg:tt)*) => {
-        println!(concat!("cargo:rustc-cfg=", $var), $($cfg)*);
+    ($enable:expr, $var:literal, $($cfg:tt)*) => {
+        println!(concat!("cargo:rustc-check-cfg=cfg(", $var, ")"), $($cfg)*);
+        if $enable {
+            println!(concat!("cargo:rustc-cfg=", $var), $($cfg)*);
+        }
     };
 }

--- a/crates/rb-sys/Cargo.toml
+++ b/crates/rb-sys/Cargo.toml
@@ -51,3 +51,10 @@ bindgen-enable-function-attribute-detection = [
 
 [lib]
 doctest = false
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+  "cfg(rb_sys_gem)",
+  "cfg(rb_sys_use_stable_api_compiled_fallback)",
+  "cfg(rb_sys_force_stable_api_compiled)",
+] }

--- a/crates/rb-sys/build/main.rs
+++ b/crates/rb-sys/build/main.rs
@@ -122,14 +122,17 @@ fn export_cargo_cfg(rbconfig: &mut RbConfig, cap: &mut File) {
     rustc_cfg(rbconfig, "ruby_patchlevel", "PATCHLEVEL");
     rustc_cfg(rbconfig, "ruby_api_version", "RUBY_API_VERSION");
 
+    println!("cargo:rustc-check-cfg=cfg(use_global_allocator)");
     if is_global_allocator_enabled(rbconfig) {
         println!("cargo:rustc-cfg=use_global_allocator");
     }
 
+    println!("cargo:rustc-check-cfg=cfg(use_ruby_abi_version)");
     if is_gem_enabled() {
         println!("cargo:rustc-cfg=use_ruby_abi_version");
     }
 
+    println!("cargo:rustc-check-cfg=cfg(has_ruby_abi_version)");
     if rbconfig.has_ruby_dln_check_abi() {
         println!("cargo:rustc-cfg=has_ruby_abi_version");
     }
@@ -139,6 +142,11 @@ fn export_cargo_cfg(rbconfig: &mut RbConfig, cap: &mut File) {
     for v in SUPPORTED_RUBY_VERSIONS.iter() {
         let v = v.to_owned();
 
+        println!(
+            "cargo:rustc-check-cfg=cfg(ruby_lt_{}_{})",
+            v.major(),
+            v.minor()
+        );
         if version < v {
             println!(r#"cargo:rustc-cfg=ruby_lt_{}_{}"#, v.major(), v.minor());
             cfg_capture!(cap, r#"cargo:version_lt_{}_{}=true"#, v.major(), v.minor());
@@ -146,6 +154,11 @@ fn export_cargo_cfg(rbconfig: &mut RbConfig, cap: &mut File) {
             cfg_capture!(cap, r#"cargo:version_lt_{}_{}=false"#, v.major(), v.minor());
         }
 
+        println!(
+            "cargo:rustc-check-cfg=cfg(ruby_lte_{}_{})",
+            v.major(),
+            v.minor()
+        );
         if version <= v {
             println!(r#"cargo:rustc-cfg=ruby_lte_{}_{}"#, v.major(), v.minor());
             cfg_capture!(cap, r#"cargo:version_lte_{}_{}=true"#, v.major(), v.minor());
@@ -158,6 +171,11 @@ fn export_cargo_cfg(rbconfig: &mut RbConfig, cap: &mut File) {
             );
         }
 
+        println!(
+            "cargo:rustc-check-cfg=cfg(ruby_eq_{}_{})",
+            v.major(),
+            v.minor()
+        );
         if version == v {
             println!(r#"cargo:rustc-cfg=ruby_eq_{}_{}"#, v.major(), v.minor());
             cfg_capture!(cap, r#"cargo:version_eq_{}_{}=true"#, v.major(), v.minor());
@@ -165,6 +183,11 @@ fn export_cargo_cfg(rbconfig: &mut RbConfig, cap: &mut File) {
             cfg_capture!(cap, r#"cargo:version_eq_{}_{}=false"#, v.major(), v.minor());
         }
 
+        println!(
+            "cargo:rustc-check-cfg=cfg(ruby_gte_{}_{})",
+            v.major(),
+            v.minor()
+        );
         if version >= v {
             println!(r#"cargo:rustc-cfg=ruby_gte_{}_{}"#, v.major(), v.minor());
             cfg_capture!(cap, r#"cargo:version_gte_{}_{}=true"#, v.major(), v.minor());
@@ -177,6 +200,11 @@ fn export_cargo_cfg(rbconfig: &mut RbConfig, cap: &mut File) {
             );
         }
 
+        println!(
+            "cargo:rustc-check-cfg=cfg(ruby_gt_{}_{})",
+            v.major(),
+            v.minor()
+        );
         if version > v {
             println!(r#"cargo:rustc-cfg=ruby_gt_{}_{}"#, v.major(), v.minor());
             cfg_capture!(cap, r#"cargo:version_gt_{}_{}=true"#, v.major(), v.minor());
@@ -209,6 +237,7 @@ fn export_cargo_cfg(rbconfig: &mut RbConfig, cap: &mut File) {
 }
 
 fn rustc_cfg(rbconfig: &RbConfig, name: &str, key: &str) {
+    println!("cargo:rustc-check-cfg=cfg({})", name);
     if let Some(k) = rbconfig.get_optional(key) {
         println!("cargo:rustc-cfg={}=\"{}\"", name, k);
     }

--- a/crates/rb-sys/build/stable_api_config.rs
+++ b/crates/rb-sys/build/stable_api_config.rs
@@ -54,6 +54,10 @@ impl TryFrom<Version> for Strategy {
 
 impl Strategy {
     fn apply(self) -> Result<(), Box<dyn Error>> {
+        println!("cargo:rustc-check-cfg=cfg(stable_api_include_rust_impl)");
+        println!("cargo:rustc-check-cfg=cfg(stable_api_enable_compiled_mod)");
+        println!("cargo:rustc-check-cfg=cfg(stable_api_export_compiled_as_api)");
+        println!("cargo:rustc-check-cfg=cfg(stable_api_has_rust_impl)");
         match self {
             Strategy::RustOnly(current_ruby_version) => {
                 if current_ruby_version.is_stable() {


### PR DESCRIPTION
Rust 1.80 got a new [lint to warn on unexpected cfg](https://blog.rust-lang.org/2024/07/25/Rust-1.80.0.html#checked-cfg-names-and-values), which generates a lot of noise building both Magnus and rb-sys.

To make cfg expected we either need to output `cargo::rustc-check-cfg=cfg(name)` from build.rs or add:

``` toml
[lints.rust]
unexpected_cfgs = { level = "warn", check-cfg = ['cfg(name)'] }
```

to Cargo.toml.

Both `cargo::rustc-check-cfg` and `cargo:rustc-check-cfg` (two or one colons) are accepted. `::` is the 'correct' syntax as of Rust 1.77, but will error on some earlier versions. The `:` syntax is accepted (with warnings on some older versions) with both old and new versions, so these changes use `:`.