### PR TITLE
Invoke `POSTLINK` script in mkmf to support codesign on macos

### DIFF
--- a/examples/rust_reverse/ext/rust_reverse/Cargo.toml
+++ b/examples/rust_reverse/ext/rust_reverse/Cargo.toml
@@ -16,3 +16,6 @@ crate-type = ["cdylib"]
 default = ["stable-api-compiled-testing"]
 test-feature = []
 stable-api-compiled-testing = ["rb-sys/stable-api-compiled-testing"]
+
+[profile.release]
+debug = true

--- a/gem/lib/rb_sys/mkmf.rb
+++ b/gem/lib/rb_sys/mkmf.rb
@@ -102,6 +102,7 @@ module RbSys
         RUSTLIBDIR = $(RB_SYS_FULL_TARGET_DIR)/$(RB_SYS_CARGO_PROFILE_DIR)
         RUSTLIB = $(RUSTLIBDIR)/$(SOEXT_PREFIX)$(TARGET_NAME).$(SOEXT)
         TIMESTAMP_DIR = .
+        POSTLINK = #{RbConfig::CONFIG["POSTLINK"] || "$(ECHO) skipping postlink (not found)"}
 
         CLEANOBJS = $(RUSTLIBDIR) $(RB_SYS_BUILD_DIR)
         CLEANLIBS = $(DLLIB) $(RUSTLIB)
@@ -132,6 +133,7 @@ module RbSys
 
         $(DLLIB): $(RUSTLIB)
         \t$(Q) $(COPY) "$(RUSTLIB)" $@
+        \t$(Q) $(POSTLINK)
 
         install-so: $(DLLIB) #{timestamp_file("sitearchdir")}
         \t$(ECHO) installing $(DLLIB) to $(RUBYARCHDIR)


### PR DESCRIPTION
This PR makes it so `POSTLINK` is automatically invoked after building gem dylibs. This means things like `RUBY_CODESIGN` will work as expected.