### PR TITLE
Implemented StableApiDefinition::rstring_interned_p methods for TruffleRuby.

### DIFF
--- a/crates/rb-sys-tests/src/stable_api_test.rs
+++ b/crates/rb-sys-tests/src/stable_api_test.rs
@@ -535,3 +535,21 @@ parity_test!(
     },
     expected: false
 );
+
+parity_test!(
+    name: test_rb_string_interned_p,
+    func: rstring_interned_p,
+    data_factory: {
+        ruby_eval!("'foo'")
+    },
+    expected: false
+);
+
+parity_test!(
+    name: test_rb_string_interned_p_frozen_str,
+    func: rstring_interned_p,
+    data_factory: {
+        ruby_eval!("'foo'.freeze")
+    },
+    expected: true
+);

--- a/crates/rb-sys/src/stable_api.rs
+++ b/crates/rb-sys/src/stable_api.rs
@@ -132,6 +132,14 @@ pub trait StableApiDefinition {
     /// This function is unsafe because it could dereference a raw pointer when
     /// attemping to access the underlying [`RBasic`] struct.
     unsafe fn rb_type(&self, obj: VALUE) -> crate::ruby_value_type;
+
+    /// Check if a Ruby string is interned (akin to `RSTRING_FSTR`).
+    ///
+    /// # Safety
+    /// This function is unsafe because it dereferences a raw pointer to get
+    /// access to underlying flags of the RString. The caller must ensure that
+    /// the `VALUE` is a valid pointer to an RString.
+    unsafe fn rstring_interned_p(&self, obj: VALUE) -> bool;
 }
 
 #[cfg(stable_api_enable_compiled_mod)]

--- a/crates/rb-sys/src/stable_api/compiled.c
+++ b/crates/rb-sys/src/stable_api/compiled.c
@@ -93,9 +93,5 @@ int
 impl_rstring_interned_p(VALUE obj) {
   Check_Type(obj, T_STRING);
 
-  if (FL_TEST(obj, RSTRING_FSTR) == 0) {
-    return false;
-  } 
-
-  return true;
+  return (FL_TEST(obj, RSTRING_FSTR) ? true : false);
 }

--- a/crates/rb-sys/src/stable_api/compiled.c
+++ b/crates/rb-sys/src/stable_api/compiled.c
@@ -93,5 +93,5 @@ int
 impl_rstring_interned_p(VALUE obj) {
   Check_Type(obj, T_STRING);
 
-  return (FL_TEST(obj, RSTRING_FSTR) ? true : false);
+  return !(FL_TEST(obj, RSTRING_FSTR) == 0);
 }

--- a/crates/rb-sys/src/stable_api/compiled.c
+++ b/crates/rb-sys/src/stable_api/compiled.c
@@ -1,5 +1,4 @@
 #include "ruby.h"
-#include "ruby/internal/value_type.h"
 
 long
 impl_rstring_len(VALUE obj) {

--- a/crates/rb-sys/src/stable_api/compiled.c
+++ b/crates/rb-sys/src/stable_api/compiled.c
@@ -87,3 +87,8 @@ int
 impl_integer_type_p(VALUE obj) {
   return RB_INTEGER_TYPE_P(obj);
 }
+
+int
+impl_rstring_interned_p(VALUE obj) {
+  return FL_TEST(obj, RSTRING_FSTR);
+}

--- a/crates/rb-sys/src/stable_api/compiled.c
+++ b/crates/rb-sys/src/stable_api/compiled.c
@@ -1,4 +1,5 @@
 #include "ruby.h"
+#include "ruby/internal/value_type.h"
 
 long
 impl_rstring_len(VALUE obj) {
@@ -90,5 +91,11 @@ impl_integer_type_p(VALUE obj) {
 
 int
 impl_rstring_interned_p(VALUE obj) {
-  return FL_TEST(obj, RSTRING_FSTR);
+  Check_Type(obj, T_STRING);
+
+  if (FL_TEST(obj, RSTRING_FSTR) == 0) {
+    return false;
+  } 
+
+  return true;
 }

--- a/crates/rb-sys/src/stable_api/compiled.rs
+++ b/crates/rb-sys/src/stable_api/compiled.rs
@@ -57,6 +57,9 @@ extern "C" {
 
     #[link_name = "impl_integer_type_p"]
     fn impl_integer_type_p(obj: VALUE) -> bool;
+
+    #[link_name = "impl_rstring_interned_p"]
+    fn impl_rstring_interned_p(obj: VALUE) -> bool;
 }
 
 pub struct Definition;
@@ -153,5 +156,9 @@ impl StableApiDefinition for Definition {
     #[inline]
     unsafe fn integer_type_p(&self, obj: VALUE) -> bool {
         impl_integer_type_p(obj)
+    }
+
+    unsafe fn rstring_interned_p(&self, obj: VALUE) -> bool {
+        impl_rstring_interned_p(obj)
     }
 }

--- a/crates/rb-sys/src/stable_api/ruby_2_6.rs
+++ b/crates/rb-sys/src/stable_api/ruby_2_6.rs
@@ -225,4 +225,14 @@ impl StableApiDefinition for Definition {
             self.builtin_type(obj) == value_type::RUBY_T_BIGNUM
         }
     }
+
+    #[inline]
+    unsafe fn rstring_interned_p(&self, obj: VALUE) -> bool {
+        assert!(self.type_p(obj, value_type::RUBY_T_STRING));
+
+        let rstring: &RString = &*(obj as *const RString);
+        let flags = rstring.basic.flags;
+
+        (flags & crate::ruby_rstring_flags::RSTRING_FSTR as VALUE) != 0
+    }
 }

--- a/crates/rb-sys/src/stable_api/ruby_2_7.rs
+++ b/crates/rb-sys/src/stable_api/ruby_2_7.rs
@@ -225,4 +225,14 @@ impl StableApiDefinition for Definition {
             self.builtin_type(obj) == value_type::RUBY_T_BIGNUM
         }
     }
+
+    #[inline]
+    unsafe fn rstring_interned_p(&self, obj: VALUE) -> bool {
+        assert!(self.type_p(obj, value_type::RUBY_T_STRING));
+
+        let rstring: &RString = &*(obj as *const RString);
+        let flags = rstring.basic.flags;
+
+        (flags & crate::ruby_rstring_flags::RSTRING_FSTR as VALUE) != 0
+    }
 }

--- a/crates/rb-sys/src/stable_api/ruby_3_0.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_0.rs
@@ -233,4 +233,14 @@ impl StableApiDefinition for Definition {
             self.builtin_type(obj) == value_type::RUBY_T_BIGNUM
         }
     }
+
+    #[inline]
+    unsafe fn rstring_interned_p(&self, obj: VALUE) -> bool {
+        assert!(self.type_p(obj, value_type::RUBY_T_STRING));
+
+        let rstring: &RString = &*(obj as *const RString);
+        let flags = rstring.basic.flags;
+
+        (flags & crate::ruby_rstring_flags::RSTRING_FSTR as VALUE) != 0
+    }
 }

--- a/crates/rb-sys/src/stable_api/ruby_3_1.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_1.rs
@@ -226,4 +226,14 @@ impl StableApiDefinition for Definition {
             self.builtin_type(obj) == value_type::RUBY_T_BIGNUM
         }
     }
+
+    #[inline]
+    unsafe fn rstring_interned_p(&self, obj: VALUE) -> bool {
+        assert!(self.type_p(obj, value_type::RUBY_T_STRING));
+
+        let rstring: &RString = &*(obj as *const RString);
+        let flags = rstring.basic.flags;
+
+        (flags & crate::ruby_rstring_flags::RSTRING_FSTR as VALUE) != 0
+    }
 }

--- a/crates/rb-sys/src/stable_api/ruby_3_2.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_2.rs
@@ -224,4 +224,14 @@ impl StableApiDefinition for Definition {
             self.builtin_type(obj) == value_type::RUBY_T_BIGNUM
         }
     }
+
+    #[inline]
+    unsafe fn rstring_interned_p(&self, obj: VALUE) -> bool {
+        assert!(self.type_p(obj, value_type::RUBY_T_STRING));
+
+        let rstring: &RString = &*(obj as *const RString);
+        let flags = rstring.basic.flags;
+
+        (flags & crate::ruby_rstring_flags::RSTRING_FSTR as VALUE) != 0
+    }
 }

--- a/crates/rb-sys/src/stable_api/ruby_3_3.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_3.rs
@@ -217,4 +217,14 @@ impl StableApiDefinition for Definition {
             self.builtin_type(obj) == value_type::RUBY_T_BIGNUM
         }
     }
+
+    #[inline]
+    unsafe fn rstring_interned_p(&self, obj: VALUE) -> bool {
+        assert!(self.type_p(obj, value_type::RUBY_T_STRING));
+
+        let rstring: &RString = &*(obj as *const RString);
+        let flags = rstring.basic.flags;
+
+        (flags & crate::ruby_rstring_flags::RSTRING_FSTR as VALUE) != 0
+    }
 }

--- a/crates/rb-sys/src/stable_api/ruby_3_4.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_4.rs
@@ -217,4 +217,14 @@ impl StableApiDefinition for Definition {
             self.builtin_type(obj) == value_type::RUBY_T_BIGNUM
         }
     }
+
+    #[inline]
+    unsafe fn rstring_interned_p(&self, obj: VALUE) -> bool {
+        assert!(self.type_p(obj, value_type::RUBY_T_STRING));
+
+        let rstring: &RString = &*(obj as *const RString);
+        let flags = rstring.basic.flags;
+
+        (flags & crate::ruby_rstring_flags::RSTRING_FSTR as VALUE) != 0
+    }
 }


### PR DESCRIPTION
Part of full TruffleRuby support.

Closes https://github.com/oxidize-rb/rb-sys/issues/444