### PR TITLE
Implemented StableApiDefinition::thread_sleep for TruffleRuby.

### DIFF
--- a/crates/rb-sys-tests/src/stable_api_test.rs
+++ b/crates/rb-sys-tests/src/stable_api_test.rs
@@ -647,3 +647,11 @@ parity_test!(
     },
     expected: true
 );
+
+parity_test!(
+    name: test_rb_thread_sleep,
+    func: thread_sleep,
+    data_factory: {
+        std::time::Duration::from_secs(1)
+    }
+);

--- a/crates/rb-sys-tests/src/stable_api_test.rs
+++ b/crates/rb-sys-tests/src/stable_api_test.rs
@@ -652,6 +652,6 @@ parity_test!(
     name: test_rb_thread_sleep,
     func: thread_sleep,
     data_factory: {
-        std::time::Duration::from_secs(1)
+        std::time::Duration::from_millis(100)
     }
 );

--- a/crates/rb-sys/src/stable_api.rs
+++ b/crates/rb-sys/src/stable_api.rs
@@ -14,7 +14,7 @@
 use crate::VALUE;
 use std::{
     os::raw::{c_char, c_long},
-    ptr::NonNull,
+    ptr::NonNull, time::Duration,
 };
 
 pub trait StableApiDefinition {
@@ -171,6 +171,9 @@ pub trait StableApiDefinition {
     /// access to underlying flags of the RString. The caller must ensure that
     /// the `VALUE` is a valid pointer to an RString.
     unsafe fn rstring_interned_p(&self, obj: VALUE) -> bool;
+
+    /// Blocks the current thread until the given duration has passed.
+    fn thread_sleep(&self, duration: Duration);
 }
 
 #[cfg(stable_api_enable_compiled_mod)]

--- a/crates/rb-sys/src/stable_api.rs
+++ b/crates/rb-sys/src/stable_api.rs
@@ -14,7 +14,8 @@
 use crate::VALUE;
 use std::{
     os::raw::{c_char, c_long},
-    ptr::NonNull, time::Duration,
+    ptr::NonNull,
+    time::Duration,
 };
 
 pub trait StableApiDefinition {

--- a/crates/rb-sys/src/stable_api/compiled.c
+++ b/crates/rb-sys/src/stable_api/compiled.c
@@ -115,3 +115,9 @@ impl_rstring_interned_p(VALUE obj) {
 
   return !(FL_TEST(obj, RSTRING_FSTR) == 0);
 }
+
+void
+impl_thread_sleep(struct timeval time) {
+  rb_thread_wait_for(time);
+}
+

--- a/crates/rb-sys/src/stable_api/compiled.rs
+++ b/crates/rb-sys/src/stable_api/compiled.rs
@@ -1,8 +1,9 @@
 use super::StableApiDefinition;
-use crate::{ruby_value_type, VALUE};
+use crate::{ruby_value_type, timeval, VALUE};
 use std::{
     os::raw::{c_char, c_long},
     ptr::NonNull,
+    time::Duration,
 };
 
 #[allow(dead_code)]
@@ -75,6 +76,9 @@ extern "C" {
 
     #[link_name = "impl_rstring_interned_p"]
     fn impl_rstring_interned_p(obj: VALUE) -> bool;
+
+    #[link_name = "impl_thread_sleep"]
+    fn impl_thread_sleep(interval: timeval);
 }
 
 pub struct Definition;
@@ -192,7 +196,21 @@ impl StableApiDefinition for Definition {
         impl_integer_type_p(obj)
     }
 
+    #[inline]
     unsafe fn rstring_interned_p(&self, obj: VALUE) -> bool {
         impl_rstring_interned_p(obj)
     }
+
+    #[inline]
+    fn thread_sleep(&self, duration: Duration) {
+        let seconds = duration.as_secs() as i64;
+        let microseconds = duration.subsec_micros() as i64;
+
+        let time = crate::timeval {
+            tv_sec: seconds,
+            tv_usec: microseconds,
+        };
+        
+        unsafe { impl_thread_sleep(time) }
+    }   
 }

--- a/crates/rb-sys/src/stable_api/compiled.rs
+++ b/crates/rb-sys/src/stable_api/compiled.rs
@@ -203,14 +203,14 @@ impl StableApiDefinition for Definition {
 
     #[inline]
     fn thread_sleep(&self, duration: Duration) {
-        let seconds = duration.as_secs() as i64;
-        let microseconds = duration.subsec_micros() as i64;
+        let seconds = duration.as_secs() as _;
+        let microseconds = duration.subsec_micros() as _;
 
         let time = crate::timeval {
             tv_sec: seconds,
             tv_usec: microseconds,
         };
-        
+
         unsafe { impl_thread_sleep(time) }
-    }   
+    }
 }

--- a/crates/rb-sys/src/stable_api/ruby_2_6.rs
+++ b/crates/rb-sys/src/stable_api/ruby_2_6.rs
@@ -9,6 +9,7 @@ use crate::{
 use std::{
     os::raw::{c_char, c_long},
     ptr::NonNull,
+    time::Duration,
 };
 
 #[cfg(not(ruby_eq_2_6))]
@@ -261,5 +262,18 @@ impl StableApiDefinition for Definition {
         let flags = rstring.basic.flags;
 
         (flags & crate::ruby_rstring_flags::RSTRING_FSTR as VALUE) != 0
+    }
+
+    #[inline]
+    fn thread_sleep(&self, duration: Duration) {
+        let seconds = duration.as_secs() as i64;
+        let microseconds = duration.subsec_micros() as i64;
+
+        let time = crate::timeval {
+            tv_sec: seconds,
+            tv_usec: microseconds,
+        };
+
+        unsafe { crate::rb_thread_wait_for(time) }
     }
 }

--- a/crates/rb-sys/src/stable_api/ruby_2_6.rs
+++ b/crates/rb-sys/src/stable_api/ruby_2_6.rs
@@ -104,7 +104,7 @@ impl StableApiDefinition for Definition {
         if self.special_const_p(obj) {
             true
         } else {
-            let rbasic = obj as *const crate::Rbasic;
+            let rbasic = obj as *const crate::RBasic;
             ((*rbasic).flags & crate::ruby_fl_type::RUBY_FL_FREEZE as VALUE) != 0
         }
     }
@@ -266,8 +266,8 @@ impl StableApiDefinition for Definition {
 
     #[inline]
     fn thread_sleep(&self, duration: Duration) {
-        let seconds = duration.as_secs() as i64;
-        let microseconds = duration.subsec_micros() as i64;
+        let seconds = duration.as_secs() as _;
+        let microseconds = duration.subsec_micros() as _;
 
         let time = crate::timeval {
             tv_sec: seconds,

--- a/crates/rb-sys/src/stable_api/ruby_2_7.rs
+++ b/crates/rb-sys/src/stable_api/ruby_2_7.rs
@@ -266,8 +266,8 @@ impl StableApiDefinition for Definition {
 
     #[inline]
     fn thread_sleep(&self, duration: Duration) {
-        let seconds = duration.as_secs() as i64;
-        let microseconds = duration.subsec_micros() as i64;
+        let seconds = duration.as_secs() as _;
+        let microseconds = duration.subsec_micros() as _;
 
         let time = crate::timeval {
             tv_sec: seconds,

--- a/crates/rb-sys/src/stable_api/ruby_2_7.rs
+++ b/crates/rb-sys/src/stable_api/ruby_2_7.rs
@@ -6,6 +6,7 @@ use crate::{
 use std::{
     os::raw::{c_char, c_long},
     ptr::NonNull,
+    time::Duration,
 };
 
 #[cfg(not(ruby_eq_2_7))]
@@ -261,5 +262,18 @@ impl StableApiDefinition for Definition {
         let flags = rstring.basic.flags;
 
         (flags & crate::ruby_rstring_flags::RSTRING_FSTR as VALUE) != 0
+    }
+
+    #[inline]
+    fn thread_sleep(&self, duration: Duration) {
+        let seconds = duration.as_secs() as i64;
+        let microseconds = duration.subsec_micros() as i64;
+
+        let time = crate::timeval {
+            tv_sec: seconds,
+            tv_usec: microseconds,
+        };
+
+        unsafe { crate::rb_thread_wait_for(time) }
     }
 }

--- a/crates/rb-sys/src/stable_api/ruby_3_0.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_0.rs
@@ -6,6 +6,7 @@ use crate::{
 use std::{
     os::raw::{c_char, c_long},
     ptr::NonNull,
+    time::Duration,
 };
 
 #[cfg(not(ruby_eq_3_0))]
@@ -269,5 +270,18 @@ impl StableApiDefinition for Definition {
         let flags = rstring.basic.flags;
 
         (flags & crate::ruby_rstring_flags::RSTRING_FSTR as VALUE) != 0
+    }
+
+    #[inline]
+    fn thread_sleep(&self, duration: Duration) {
+        let seconds = duration.as_secs() as i64;
+        let microseconds = duration.subsec_micros() as i64;
+
+        let time = crate::timeval {
+            tv_sec: seconds,
+            tv_usec: microseconds,
+        };
+
+        unsafe { crate::rb_thread_wait_for(time) }
     }
 }

--- a/crates/rb-sys/src/stable_api/ruby_3_0.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_0.rs
@@ -274,8 +274,8 @@ impl StableApiDefinition for Definition {
 
     #[inline]
     fn thread_sleep(&self, duration: Duration) {
-        let seconds = duration.as_secs() as i64;
-        let microseconds = duration.subsec_micros() as i64;
+        let seconds = duration.as_secs() as _;
+        let microseconds = duration.subsec_micros() as _;
 
         let time = crate::timeval {
             tv_sec: seconds,

--- a/crates/rb-sys/src/stable_api/ruby_3_1.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_1.rs
@@ -6,6 +6,7 @@ use crate::{
 use std::{
     os::raw::{c_char, c_long},
     ptr::NonNull,
+    time::Duration,
 };
 
 #[cfg(not(ruby_eq_3_1))]
@@ -262,5 +263,18 @@ impl StableApiDefinition for Definition {
         let flags = rstring.basic.flags;
 
         (flags & crate::ruby_rstring_flags::RSTRING_FSTR as VALUE) != 0
+    }
+
+    #[inline]
+    fn thread_sleep(&self, duration: Duration) {
+        let seconds = duration.as_secs() as i64;
+        let microseconds = duration.subsec_micros() as i64;
+
+        let time = crate::timeval {
+            tv_sec: seconds,
+            tv_usec: microseconds,
+        };
+
+        unsafe { crate::rb_thread_wait_for(time) }
     }
 }

--- a/crates/rb-sys/src/stable_api/ruby_3_1.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_1.rs
@@ -267,8 +267,8 @@ impl StableApiDefinition for Definition {
 
     #[inline]
     fn thread_sleep(&self, duration: Duration) {
-        let seconds = duration.as_secs() as i64;
-        let microseconds = duration.subsec_micros() as i64;
+        let seconds = duration.as_secs() as _;
+        let microseconds = duration.subsec_micros() as _;
 
         let time = crate::timeval {
             tv_sec: seconds,

--- a/crates/rb-sys/src/stable_api/ruby_3_2.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_2.rs
@@ -265,8 +265,8 @@ impl StableApiDefinition for Definition {
 
     #[inline]
     fn thread_sleep(&self, duration: Duration) {
-        let seconds = duration.as_secs() as i64;
-        let microseconds = duration.subsec_micros() as i64;
+        let seconds = duration.as_secs() as _;
+        let microseconds = duration.subsec_micros() as _;
 
         let time = crate::timeval {
             tv_sec: seconds,

--- a/crates/rb-sys/src/stable_api/ruby_3_2.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_2.rs
@@ -6,6 +6,7 @@ use crate::{
 use std::{
     os::raw::{c_char, c_long},
     ptr::NonNull,
+    time::Duration,
 };
 
 #[cfg(not(ruby_eq_3_2))]
@@ -260,5 +261,18 @@ impl StableApiDefinition for Definition {
         let flags = rstring.basic.flags;
 
         (flags & crate::ruby_rstring_flags::RSTRING_FSTR as VALUE) != 0
+    }
+
+    #[inline]
+    fn thread_sleep(&self, duration: Duration) {
+        let seconds = duration.as_secs() as i64;
+        let microseconds = duration.subsec_micros() as i64;
+
+        let time = crate::timeval {
+            tv_sec: seconds,
+            tv_usec: microseconds,
+        };
+
+        unsafe { crate::rb_thread_wait_for(time) }
     }
 }

--- a/crates/rb-sys/src/stable_api/ruby_3_3.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_3.rs
@@ -6,6 +6,7 @@ use crate::{
 use std::{
     os::raw::{c_char, c_long},
     ptr::NonNull,
+    time::Duration,
 };
 
 #[cfg(not(ruby_eq_3_3))]
@@ -253,5 +254,18 @@ impl StableApiDefinition for Definition {
         let flags = rstring.basic.flags;
 
         (flags & crate::ruby_rstring_flags::RSTRING_FSTR as VALUE) != 0
+    }
+
+    #[inline]
+    fn thread_sleep(&self, duration: Duration) {
+        let seconds = duration.as_secs() as i64;
+        let microseconds = duration.subsec_micros() as i64;
+
+        let time = crate::timeval {
+            tv_sec: seconds,
+            tv_usec: microseconds,
+        };
+        
+        unsafe { crate::rb_thread_wait_for(time) }
     }
 }

--- a/crates/rb-sys/src/stable_api/ruby_3_3.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_3.rs
@@ -258,14 +258,14 @@ impl StableApiDefinition for Definition {
 
     #[inline]
     fn thread_sleep(&self, duration: Duration) {
-        let seconds = duration.as_secs() as i64;
-        let microseconds = duration.subsec_micros() as i64;
+        let seconds = duration.as_secs() as _;
+        let microseconds = duration.subsec_micros() as _;
 
         let time = crate::timeval {
             tv_sec: seconds,
             tv_usec: microseconds,
         };
-        
+
         unsafe { crate::rb_thread_wait_for(time) }
     }
 }

--- a/crates/rb-sys/src/stable_api/ruby_3_4.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_4.rs
@@ -6,6 +6,7 @@ use crate::{
 use std::{
     os::raw::{c_char, c_long},
     ptr::NonNull,
+    time::Duration,
 };
 
 #[cfg(not(ruby_eq_3_4))]
@@ -253,5 +254,18 @@ impl StableApiDefinition for Definition {
         let flags = rstring.basic.flags;
 
         (flags & crate::ruby_rstring_flags::RSTRING_FSTR as VALUE) != 0
+    }
+
+    #[inline]
+    fn thread_sleep(&self, duration: Duration) {
+        let seconds = duration.as_secs() as i64;
+        let microseconds = duration.subsec_micros() as i64;
+
+        let time = crate::timeval {
+            tv_sec: seconds,
+            tv_usec: microseconds,
+        };
+
+        unsafe { crate::rb_thread_wait_for(time) }
     }
 }

--- a/crates/rb-sys/src/stable_api/ruby_3_4.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_4.rs
@@ -258,8 +258,8 @@ impl StableApiDefinition for Definition {
 
     #[inline]
     fn thread_sleep(&self, duration: Duration) {
-        let seconds = duration.as_secs() as i64;
-        let microseconds = duration.subsec_micros() as i64;
+        let seconds = duration.as_secs() as _;
+        let microseconds = duration.subsec_micros() as _;
 
         let time = crate::timeval {
             tv_sec: seconds,


### PR DESCRIPTION
Closes https://github.com/oxidize-rb/rb-sys/issues/450

Very naive implementation, I think we probably should be using something that allows us to go sub-second. someting that takes a pointer to `rb_cTime or directly a timeval.