### PR TITLE
Implementing StableApiDefinition RBasic methods for TruffleRuby.

### DIFF
--- a/crates/rb-sys-tests/src/stable_api_test.rs
+++ b/crates/rb-sys-tests/src/stable_api_test.rs
@@ -182,6 +182,44 @@ parity_test!(
 );
 
 parity_test!(
+    name: test_rbasic_class_of_array,
+    func: rbasic_class,
+    data_factory: {
+        unsafe { rb_sys::rb_ary_new() }
+    },
+    expected: {
+        unsafe { rb_sys::rb_cArray }
+    }
+);
+
+parity_test!(
+    name: test_rbasic_class_of_array_evaled,
+    func: rbasic_class,
+    data_factory: {
+      ruby_eval!("[]")
+    },
+    expected: ruby_eval!("Array")
+);
+
+parity_test!(
+    name: test_rbasic_frozen_p_not_frozen_obj,
+    func: rbasic_frozen_p,
+    data_factory: {
+      ruby_eval!("[1]")
+    },
+    expected: false
+);
+
+parity_test!(
+    name: test_rbasic_frozen_p_frozen_obj,
+    func: rbasic_frozen_p,
+    data_factory: {
+      ruby_eval!("[1].freeze")
+    },
+    expected: true
+);
+
+parity_test!(
     name: test_special_const_p_for_bool,
     func: special_const_p,
     data_factory: {

--- a/crates/rb-sys-tests/src/stable_api_test.rs
+++ b/crates/rb-sys-tests/src/stable_api_test.rs
@@ -1,4 +1,4 @@
-use rb_sys::StableApiDefinition;
+use rb_sys::{StableApiDefinition, VALUE};
 use rb_sys_test_helpers::rstring as gen_rstring;
 
 macro_rules! parity_test {
@@ -185,10 +185,10 @@ parity_test!(
     name: test_rbasic_class_of_array,
     func: rbasic_class,
     data_factory: {
-        unsafe { rb_sys::rb_ary_new() }
+        unsafe { rb_sys::rb_ary_new() as VALUE }
     },
     expected: {
-        unsafe { rb_sys::rb_cArray }
+        unsafe { Some(std::ptr::NonNull::new_unchecked(rb_sys::rb_cArray as _)) }
     }
 );
 
@@ -198,7 +198,9 @@ parity_test!(
     data_factory: {
       ruby_eval!("[]")
     },
-    expected: ruby_eval!("Array")
+    expected: {
+      unsafe { Some(std::ptr::NonNull::new_unchecked(ruby_eval!("Array") as *mut VALUE)) }
+    }
 );
 
 parity_test!(

--- a/crates/rb-sys-tests/src/stable_api_test.rs
+++ b/crates/rb-sys-tests/src/stable_api_test.rs
@@ -203,7 +203,7 @@ parity_test!(
 
 parity_test!(
     name: test_rbasic_frozen_p_not_frozen_obj,
-    func: rbasic_frozen_p,
+    func: frozen_p,
     data_factory: {
       ruby_eval!("[1]")
     },
@@ -212,7 +212,7 @@ parity_test!(
 
 parity_test!(
     name: test_rbasic_frozen_p_frozen_obj,
-    func: rbasic_frozen_p,
+    func: frozen_p,
     data_factory: {
       ruby_eval!("[1].freeze")
     },

--- a/crates/rb-sys/src/stable_api.rs
+++ b/crates/rb-sys/src/stable_api.rs
@@ -54,6 +54,16 @@ pub trait StableApiDefinition {
     /// is valid.
     unsafe fn rarray_const_ptr(&self, obj: VALUE) -> *const VALUE;
 
+    /// Get the class from a VALUE which contains an RBasic struct.
+    ///
+    /// `VALUE` is a valid pointer to a non-immediate object.
+    unsafe fn rbasic_class(&self, obj: VALUE) -> VALUE;
+
+    /// Checks if the given object is frozen.
+    ///
+    /// `VALUE` is a valid pointer to a non-immediate object.
+    unsafe fn rbasic_frozen_p(&self, obj: VALUE) -> bool;
+
     /// Tests if a bignum is positive.
     ///
     /// # Safety

--- a/crates/rb-sys/src/stable_api.rs
+++ b/crates/rb-sys/src/stable_api.rs
@@ -62,7 +62,7 @@ pub trait StableApiDefinition {
     /// Checks if the given object is frozen.
     ///
     /// `VALUE` is a valid pointer to a non-immediate object.
-    unsafe fn rbasic_frozen_p(&self, obj: VALUE) -> bool;
+    unsafe fn frozen_p(&self, obj: VALUE) -> bool;
 
     /// Tests if a bignum is positive.
     ///

--- a/crates/rb-sys/src/stable_api.rs
+++ b/crates/rb-sys/src/stable_api.rs
@@ -12,7 +12,10 @@
 //!    changes in production.
 
 use crate::VALUE;
-use std::os::raw::{c_char, c_long};
+use std::{
+    os::raw::{c_char, c_long},
+    ptr::NonNull,
+};
 
 pub trait StableApiDefinition {
     const VERSION_MAJOR: u32;
@@ -57,7 +60,7 @@ pub trait StableApiDefinition {
     /// Get the class from a VALUE which contains an RBasic struct.
     ///
     /// `VALUE` is a valid pointer to a non-immediate object.
-    unsafe fn rbasic_class(&self, obj: VALUE) -> VALUE;
+    unsafe fn rbasic_class(&self, obj: VALUE) -> Option<NonNull<VALUE>>;
 
     /// Checks if the given object is frozen.
     ///

--- a/crates/rb-sys/src/stable_api/compiled.c
+++ b/crates/rb-sys/src/stable_api/compiled.c
@@ -20,6 +20,16 @@ impl_rarray_const_ptr(VALUE obj) {
   return RARRAY_CONST_PTR(obj);
 }
 
+VALUE
+impl_rbasic_class(VALUE obj) {
+  return RBASIC_CLASS(obj);
+}
+
+int
+impl_rbasic_frozen_p(VALUE obj) {
+  return RB_OBJ_FROZEN(obj);
+}
+
 int
 impl_special_const_p(VALUE obj) {
   return SPECIAL_CONST_P(obj);

--- a/crates/rb-sys/src/stable_api/compiled.c
+++ b/crates/rb-sys/src/stable_api/compiled.c
@@ -26,7 +26,7 @@ impl_rbasic_class(VALUE obj) {
 }
 
 int
-impl_rbasic_frozen_p(VALUE obj) {
+impl_frozen_p(VALUE obj) {
   return RB_OBJ_FROZEN(obj);
 }
 

--- a/crates/rb-sys/src/stable_api/compiled.rs
+++ b/crates/rb-sys/src/stable_api/compiled.rs
@@ -1,6 +1,9 @@
 use super::StableApiDefinition;
 use crate::{ruby_value_type, VALUE};
-use std::os::raw::{c_char, c_long};
+use std::{
+    os::raw::{c_char, c_long},
+    ptr::NonNull,
+};
 
 #[allow(dead_code)]
 extern "C" {
@@ -100,8 +103,9 @@ impl StableApiDefinition for Definition {
         impl_rarray_const_ptr(obj)
     }
 
-    unsafe fn rbasic_class(&self, obj: VALUE) -> VALUE {
-        impl_rbasic_class(obj)
+    #[inline]
+    unsafe fn rbasic_class(&self, obj: VALUE) -> Option<NonNull<VALUE>> {
+        NonNull::<VALUE>::new(impl_rbasic_class(obj) as _)
     }
 
     unsafe fn frozen_p(&self, obj: VALUE) -> bool {

--- a/crates/rb-sys/src/stable_api/compiled.rs
+++ b/crates/rb-sys/src/stable_api/compiled.rs
@@ -16,6 +16,12 @@ extern "C" {
     #[link_name = "impl_rarray_const_ptr"]
     fn impl_rarray_const_ptr(ary: VALUE) -> *const VALUE;
 
+    #[link_name = "impl_rbasic_class"]
+    fn impl_rbasic_class(obj: VALUE) -> VALUE;
+
+    #[link_name = "impl_rbasic_frozen_p"]
+    fn impl_rbasic_frozen_p(obj: VALUE) -> bool;
+
     #[link_name = "impl_special_const_p"]
     fn impl_special_const_p(value: VALUE) -> bool;
 
@@ -92,6 +98,14 @@ impl StableApiDefinition for Definition {
     #[inline]
     unsafe fn rarray_const_ptr(&self, obj: VALUE) -> *const VALUE {
         impl_rarray_const_ptr(obj)
+    }
+
+    unsafe fn rbasic_class(&self, obj: VALUE) -> VALUE {
+        impl_rbasic_class(obj)
+    }
+
+    unsafe fn rbasic_frozen_p(&self, obj: VALUE) -> bool {
+        impl_rbasic_frozen_p(obj)
     }
 
     #[inline]

--- a/crates/rb-sys/src/stable_api/compiled.rs
+++ b/crates/rb-sys/src/stable_api/compiled.rs
@@ -19,8 +19,8 @@ extern "C" {
     #[link_name = "impl_rbasic_class"]
     fn impl_rbasic_class(obj: VALUE) -> VALUE;
 
-    #[link_name = "impl_rbasic_frozen_p"]
-    fn impl_rbasic_frozen_p(obj: VALUE) -> bool;
+    #[link_name = "impl_frozen_p"]
+    fn impl_frozen_p(obj: VALUE) -> bool;
 
     #[link_name = "impl_special_const_p"]
     fn impl_special_const_p(value: VALUE) -> bool;
@@ -104,8 +104,8 @@ impl StableApiDefinition for Definition {
         impl_rbasic_class(obj)
     }
 
-    unsafe fn rbasic_frozen_p(&self, obj: VALUE) -> bool {
-        impl_rbasic_frozen_p(obj)
+    unsafe fn frozen_p(&self, obj: VALUE) -> bool {
+        impl_frozen_p(obj)
     }
 
     #[inline]

--- a/crates/rb-sys/src/stable_api/ruby_2_6.rs
+++ b/crates/rb-sys/src/stable_api/ruby_2_6.rs
@@ -96,6 +96,16 @@ impl StableApiDefinition for Definition {
     }
 
     #[inline]
+    unsafe fn frozen_p(&self, obj: VALUE) -> bool {
+        if self.special_const_p(obj) {
+            true
+        } else {
+            let rbasic = obj as *const crate::Rbasic;
+            ((*rbasic).flags & crate::ruby_fl_type::RUBY_FL_FREEZE as VALUE) != 0
+        }
+    }
+
+    #[inline]
     fn special_const_p(&self, value: VALUE) -> bool {
         let is_immediate = value & (crate::special_consts::IMMEDIATE_MASK as VALUE) != 0;
         let test = (value & !(crate::Qnil as VALUE)) != 0;

--- a/crates/rb-sys/src/stable_api/ruby_2_6.rs
+++ b/crates/rb-sys/src/stable_api/ruby_2_6.rs
@@ -6,7 +6,10 @@ use crate::{
     internal::{RArray, RString},
     value_type, VALUE,
 };
-use std::os::raw::{c_char, c_long};
+use std::{
+    os::raw::{c_char, c_long},
+    ptr::NonNull,
+};
 
 #[cfg(not(ruby_eq_2_6))]
 compile_error!("This file should only be included in Ruby 2.6 builds");
@@ -89,10 +92,10 @@ impl StableApiDefinition for Definition {
     }
 
     #[inline]
-    unsafe fn bignum_positive_p(&self, obj: VALUE) -> bool {
+    unsafe fn rbasic_class(&self, obj: VALUE) -> Option<NonNull<VALUE>> {
         let rbasic = obj as *const crate::RBasic;
 
-        ((*rbasic).flags & crate::ruby_fl_type::RUBY_FL_USER1 as VALUE) != 0
+        NonNull::<VALUE>::new((*rbasic).klass as _)
     }
 
     #[inline]
@@ -103,6 +106,13 @@ impl StableApiDefinition for Definition {
             let rbasic = obj as *const crate::Rbasic;
             ((*rbasic).flags & crate::ruby_fl_type::RUBY_FL_FREEZE as VALUE) != 0
         }
+    }
+
+    #[inline]
+    unsafe fn bignum_positive_p(&self, obj: VALUE) -> bool {
+        let rbasic = obj as *const crate::RBasic;
+
+        ((*rbasic).flags & crate::ruby_fl_type::RUBY_FL_USER1 as VALUE) != 0
     }
 
     #[inline]

--- a/crates/rb-sys/src/stable_api/ruby_2_7.rs
+++ b/crates/rb-sys/src/stable_api/ruby_2_7.rs
@@ -3,7 +3,10 @@ use crate::{
     internal::{RArray, RString},
     value_type, VALUE,
 };
-use std::os::raw::{c_char, c_long};
+use std::{
+    os::raw::{c_char, c_long},
+    ptr::NonNull,
+};
 
 #[cfg(not(ruby_eq_2_7))]
 compile_error!("This file should only be included in Ruby 2.7 builds");
@@ -89,10 +92,10 @@ impl StableApiDefinition for Definition {
     }
 
     #[inline]
-    unsafe fn bignum_positive_p(&self, obj: VALUE) -> bool {
+    unsafe fn rbasic_class(&self, obj: VALUE) -> Option<NonNull<VALUE>> {
         let rbasic = obj as *const crate::RBasic;
 
-        ((*rbasic).flags & crate::ruby_fl_type::RUBY_FL_USER1 as VALUE) != 0
+        NonNull::<VALUE>::new((*rbasic).klass as _)
     }
 
     #[inline]
@@ -103,6 +106,13 @@ impl StableApiDefinition for Definition {
             let rbasic = obj as *const crate::RBasic;
             ((*rbasic).flags & crate::ruby_fl_type::RUBY_FL_FREEZE as VALUE) != 0
         }
+    }
+
+    #[inline]
+    unsafe fn bignum_positive_p(&self, obj: VALUE) -> bool {
+        let rbasic = obj as *const crate::RBasic;
+
+        ((*rbasic).flags & crate::ruby_fl_type::RUBY_FL_USER1 as VALUE) != 0
     }
 
     #[inline]

--- a/crates/rb-sys/src/stable_api/ruby_2_7.rs
+++ b/crates/rb-sys/src/stable_api/ruby_2_7.rs
@@ -96,6 +96,16 @@ impl StableApiDefinition for Definition {
     }
 
     #[inline]
+    unsafe fn frozen_p(&self, obj: VALUE) -> bool {
+        if self.special_const_p(obj) {
+            true
+        } else {
+            let rbasic = obj as *const crate::RBasic;
+            ((*rbasic).flags & crate::ruby_fl_type::RUBY_FL_FREEZE as VALUE) != 0
+        }
+    }
+
+    #[inline]
     fn special_const_p(&self, value: VALUE) -> bool {
         let is_immediate = value & (crate::special_consts::IMMEDIATE_MASK as VALUE) != 0;
         let test = (value & !(crate::Qnil as VALUE)) != 0;

--- a/crates/rb-sys/src/stable_api/ruby_3_0.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_0.rs
@@ -3,7 +3,10 @@ use crate::{
     internal::{RArray, RString},
     value_type, VALUE,
 };
-use std::os::raw::{c_char, c_long};
+use std::{
+    os::raw::{c_char, c_long},
+    ptr::NonNull,
+};
 
 #[cfg(not(ruby_eq_3_0))]
 compile_error!("This file should only be included in Ruby 3.0 builds");
@@ -97,10 +100,10 @@ impl StableApiDefinition for Definition {
     }
 
     #[inline]
-    unsafe fn bignum_positive_p(&self, obj: VALUE) -> bool {
+    unsafe fn rbasic_class(&self, obj: VALUE) -> Option<NonNull<VALUE>> {
         let rbasic = obj as *const crate::RBasic;
 
-        ((*rbasic).flags & crate::ruby_fl_type::RUBY_FL_USER1 as VALUE) != 0
+        NonNull::<VALUE>::new((*rbasic).klass as _)
     }
 
     #[inline]
@@ -111,6 +114,13 @@ impl StableApiDefinition for Definition {
             let rbasic = obj as *const crate::RBasic;
             ((*rbasic).flags & crate::ruby_fl_type::RUBY_FL_FREEZE as VALUE) != 0
         }
+    }
+
+    #[inline]
+    unsafe fn bignum_positive_p(&self, obj: VALUE) -> bool {
+        let rbasic = obj as *const crate::RBasic;
+
+        ((*rbasic).flags & crate::ruby_fl_type::RUBY_FL_USER1 as VALUE) != 0
     }
 
     #[inline]

--- a/crates/rb-sys/src/stable_api/ruby_3_0.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_0.rs
@@ -104,6 +104,16 @@ impl StableApiDefinition for Definition {
     }
 
     #[inline]
+    unsafe fn frozen_p(&self, obj: VALUE) -> bool {
+        if self.special_const_p(obj) {
+            true
+        } else {
+            let rbasic = obj as *const crate::RBasic;
+            ((*rbasic).flags & crate::ruby_fl_type::RUBY_FL_FREEZE as VALUE) != 0
+        }
+    }
+
+    #[inline]
     fn special_const_p(&self, value: VALUE) -> bool {
         let is_immediate = value & (crate::special_consts::IMMEDIATE_MASK as VALUE) != 0;
         let test = (value & !(crate::Qnil as VALUE)) != 0;

--- a/crates/rb-sys/src/stable_api/ruby_3_1.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_1.rs
@@ -3,7 +3,10 @@ use crate::{
     internal::{RArray, RString},
     value_type, VALUE,
 };
-use std::os::raw::{c_char, c_long};
+use std::{
+    os::raw::{c_char, c_long},
+    ptr::NonNull,
+};
 
 #[cfg(not(ruby_eq_3_1))]
 compile_error!("This file should only be included in Ruby 3.1 builds");
@@ -90,10 +93,10 @@ impl StableApiDefinition for Definition {
     }
 
     #[inline]
-    unsafe fn bignum_positive_p(&self, obj: VALUE) -> bool {
+    unsafe fn rbasic_class(&self, obj: VALUE) -> Option<NonNull<VALUE>> {
         let rbasic = obj as *const crate::RBasic;
 
-        ((*rbasic).flags & crate::ruby_fl_type::RUBY_FL_USER1 as VALUE) != 0(*rbasic).klass
+        NonNull::<VALUE>::new((*rbasic).klass as _)
     }
 
     #[inline]
@@ -104,6 +107,13 @@ impl StableApiDefinition for Definition {
             let rbasic = obj as *const crate::RBasic;
             ((*rbasic).flags & crate::ruby_fl_type::RUBY_FL_FREEZE as VALUE) != 0
         }
+    }
+
+    #[inline]
+    unsafe fn bignum_positive_p(&self, obj: VALUE) -> bool {
+        let rbasic = obj as *const crate::RBasic;
+
+        ((*rbasic).flags & crate::ruby_fl_type::RUBY_FL_USER1 as VALUE) != 0
     }
 
     #[inline]

--- a/crates/rb-sys/src/stable_api/ruby_3_1.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_1.rs
@@ -93,7 +93,17 @@ impl StableApiDefinition for Definition {
     unsafe fn bignum_positive_p(&self, obj: VALUE) -> bool {
         let rbasic = obj as *const crate::RBasic;
 
-        ((*rbasic).flags & crate::ruby_fl_type::RUBY_FL_USER1 as VALUE) != 0
+        ((*rbasic).flags & crate::ruby_fl_type::RUBY_FL_USER1 as VALUE) != 0(*rbasic).klass
+    }
+
+    #[inline]
+    unsafe fn frozen_p(&self, obj: VALUE) -> bool {
+        if self.special_const_p(obj) {
+            true
+        } else {
+            let rbasic = obj as *const crate::RBasic;
+            ((*rbasic).flags & crate::ruby_fl_type::RUBY_FL_FREEZE as VALUE) != 0
+        }
     }
 
     #[inline]

--- a/crates/rb-sys/src/stable_api/ruby_3_2.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_2.rs
@@ -91,6 +91,16 @@ impl StableApiDefinition for Definition {
     }
 
     #[inline]
+    unsafe fn frozen_p(&self, obj: VALUE) -> bool {
+        if self.special_const_p(obj) {
+            true
+        } else {
+            let rbasic = obj as *const crate::RBasic;
+            ((*rbasic).flags & crate::ruby_fl_type::RUBY_FL_FREEZE as VALUE) != 0
+        }
+    }
+
+    #[inline]
     fn special_const_p(&self, value: VALUE) -> bool {
         let is_immediate = (value) & (crate::special_consts::IMMEDIATE_MASK as VALUE) != 0;
         let test = (value & !(crate::Qnil as VALUE)) != 0;

--- a/crates/rb-sys/src/stable_api/ruby_3_2.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_2.rs
@@ -3,7 +3,10 @@ use crate::{
     internal::{RArray, RString},
     value_type, VALUE,
 };
-use std::os::raw::{c_char, c_long};
+use std::{
+    os::raw::{c_char, c_long},
+    ptr::NonNull,
+};
 
 #[cfg(not(ruby_eq_3_2))]
 compile_error!("This file should only be included in Ruby 3.2 builds");
@@ -84,10 +87,10 @@ impl StableApiDefinition for Definition {
     }
 
     #[inline]
-    unsafe fn bignum_positive_p(&self, obj: VALUE) -> bool {
+    unsafe fn rbasic_class(&self, obj: VALUE) -> Option<NonNull<VALUE>> {
         let rbasic = obj as *const crate::RBasic;
 
-        ((*rbasic).flags & crate::ruby_fl_type::RUBY_FL_USER1 as VALUE) != 0
+        NonNull::<VALUE>::new((*rbasic).klass as _)
     }
 
     #[inline]
@@ -98,6 +101,13 @@ impl StableApiDefinition for Definition {
             let rbasic = obj as *const crate::RBasic;
             ((*rbasic).flags & crate::ruby_fl_type::RUBY_FL_FREEZE as VALUE) != 0
         }
+    }
+
+    #[inline]
+    unsafe fn bignum_positive_p(&self, obj: VALUE) -> bool {
+        let rbasic = obj as *const crate::RBasic;
+
+        ((*rbasic).flags & crate::ruby_fl_type::RUBY_FL_USER1 as VALUE) != 0
     }
 
     #[inline]

--- a/crates/rb-sys/src/stable_api/ruby_3_3.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_3.rs
@@ -84,7 +84,7 @@ impl StableApiDefinition for Definition {
     }
 
     #[inline]
-    unsafe fn rbasic_frozen_p(&self, obj: VALUE) -> bool {
+    unsafe fn frozen_p(&self, obj: VALUE) -> bool {
         if self.special_const_p(obj) {
             true
         } else {

--- a/crates/rb-sys/src/stable_api/ruby_3_3.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_3.rs
@@ -3,7 +3,10 @@ use crate::{
     internal::{RArray, RString},
     value_type, VALUE,
 };
-use std::os::raw::{c_char, c_long};
+use std::{
+    os::raw::{c_char, c_long},
+    ptr::NonNull,
+};
 
 #[cfg(not(ruby_eq_3_3))]
 compile_error!("This file should only be included in Ruby 3.3 builds");
@@ -77,10 +80,10 @@ impl StableApiDefinition for Definition {
     }
 
     #[inline]
-    unsafe fn rbasic_class(&self, obj: VALUE) -> VALUE {
+    unsafe fn rbasic_class(&self, obj: VALUE) -> Option<NonNull<VALUE>> {
         let rbasic = obj as *const crate::RBasic;
 
-        (*rbasic).klass
+        NonNull::<VALUE>::new((*rbasic).klass as _)
     }
 
     #[inline]

--- a/crates/rb-sys/src/stable_api/ruby_3_3.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_3.rs
@@ -77,6 +77,23 @@ impl StableApiDefinition for Definition {
     }
 
     #[inline]
+    unsafe fn rbasic_class(&self, obj: VALUE) -> VALUE {
+        let rbasic = obj as *const crate::RBasic;
+
+        (*rbasic).klass
+    }
+
+    #[inline]
+    unsafe fn rbasic_frozen_p(&self, obj: VALUE) -> bool {
+        if self.special_const_p(obj) {
+            true
+        } else {
+            let rbasic = obj as *const crate::RBasic;
+            ((*rbasic).flags & crate::ruby_fl_type::RUBY_FL_FREEZE as VALUE) != 0
+        }
+    }
+
+    #[inline]
     unsafe fn bignum_positive_p(&self, obj: VALUE) -> bool {
         let rbasic = obj as *const crate::RBasic;
 

--- a/crates/rb-sys/src/stable_api/ruby_3_4.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_4.rs
@@ -41,23 +41,6 @@ impl StableApiDefinition for Definition {
     }
 
     #[inline]
-    unsafe fn rbasic_class(&self, obj: VALUE) -> VALUE {
-        let rbasic = obj as *const crate::RBasic;
-
-        (*rbasic).klass
-    }
-
-    #[inline]
-    unsafe fn frozen_p(&self, obj: VALUE) -> bool {
-        if self.special_const_p(obj) {
-            true
-        } else {
-            let rbasic = obj as *const crate::RBasic;
-            ((*rbasic).flags & crate::ruby_fl_type::RUBY_FL_FREEZE as VALUE) != 0
-        }
-    }
-
-    #[inline]
     unsafe fn rarray_len(&self, obj: VALUE) -> c_long {
         assert!(self.type_p(obj, value_type::RUBY_T_ARRAY));
 
@@ -99,6 +82,23 @@ impl StableApiDefinition for Definition {
         let test = (value & !(crate::Qnil as VALUE)) != 0;
 
         is_immediate || !test
+    }
+
+    #[inline]
+    unsafe fn rbasic_class(&self, obj: VALUE) -> Option<NonNull<VALUE>> {
+        let rbasic = obj as *const crate::RBasic;
+
+        NonNull::<VALUE>::new((*rbasic).klass as _)
+    }
+
+    #[inline]
+    unsafe fn frozen_p(&self, obj: VALUE) -> bool {
+        if self.special_const_p(obj) {
+            true
+        } else {
+            let rbasic = obj as *const crate::RBasic;
+            ((*rbasic).flags & crate::ruby_fl_type::RUBY_FL_FREEZE as VALUE) != 0
+        }
     }
 
     #[inline]

--- a/crates/rb-sys/src/stable_api/ruby_3_4.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_4.rs
@@ -1,9 +1,12 @@
 use super::StableApiDefinition;
 use crate::{
     internal::{RArray, RString},
-    rb_obj_frozen_p, value_type, VALUE,
+    value_type, VALUE,
 };
-use std::os::raw::{c_char, c_long};
+use std::{
+    os::raw::{c_char, c_long},
+    ptr::NonNull,
+};
 
 #[cfg(not(ruby_eq_3_4))]
 compile_error!("This file should only be included in Ruby 3.3 builds");
@@ -77,14 +80,6 @@ impl StableApiDefinition for Definition {
     }
 
     #[inline]
-    fn special_const_p(&self, value: VALUE) -> bool {
-        let is_immediate = (value) & (crate::special_consts::IMMEDIATE_MASK as VALUE) != 0;
-        let test = (value & !(crate::Qnil as VALUE)) != 0;
-
-        is_immediate || !test
-    }
-
-    #[inline]
     unsafe fn rbasic_class(&self, obj: VALUE) -> Option<NonNull<VALUE>> {
         let rbasic = obj as *const crate::RBasic;
 
@@ -99,6 +94,14 @@ impl StableApiDefinition for Definition {
             let rbasic = obj as *const crate::RBasic;
             ((*rbasic).flags & crate::ruby_fl_type::RUBY_FL_FREEZE as VALUE) != 0
         }
+    }
+
+    #[inline]
+    fn special_const_p(&self, value: VALUE) -> bool {
+        let is_immediate = (value) & (crate::special_consts::IMMEDIATE_MASK as VALUE) != 0;
+        let test = (value & !(crate::Qnil as VALUE)) != 0;
+
+        is_immediate || !test
     }
 
     #[inline]

--- a/crates/rb-sys/src/stable_api/ruby_3_4.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_4.rs
@@ -1,7 +1,7 @@
 use super::StableApiDefinition;
 use crate::{
     internal::{RArray, RString},
-    value_type, VALUE,
+    rb_obj_frozen_p, value_type, VALUE,
 };
 use std::os::raw::{c_char, c_long};
 
@@ -38,6 +38,23 @@ impl StableApiDefinition for Definition {
         assert!(!ptr.is_null());
 
         ptr
+    }
+
+    #[inline]
+    unsafe fn rbasic_class(&self, obj: VALUE) -> VALUE {
+        let rbasic = obj as *const crate::RBasic;
+
+        (*rbasic).klass
+    }
+
+    #[inline]
+    unsafe fn rbasic_frozen_p(&self, obj: VALUE) -> bool {
+        if self.special_const_p(obj) {
+            true
+        } else {
+            let rbasic = obj as *const crate::RBasic;
+            ((*rbasic).flags & crate::fl_type_::RUBY_FL_FREEZE as VALUE) != 0
+        }
     }
 
     #[inline]

--- a/crates/rb-sys/src/stable_api/ruby_3_4.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_4.rs
@@ -48,12 +48,12 @@ impl StableApiDefinition for Definition {
     }
 
     #[inline]
-    unsafe fn rbasic_frozen_p(&self, obj: VALUE) -> bool {
+    unsafe fn frozen_p(&self, obj: VALUE) -> bool {
         if self.special_const_p(obj) {
             true
         } else {
             let rbasic = obj as *const crate::RBasic;
-            ((*rbasic).flags & crate::fl_type_::RUBY_FL_FREEZE as VALUE) != 0
+            ((*rbasic).flags & crate::ruby_fl_type::RUBY_FL_FREEZE as VALUE) != 0
         }
     }
 


### PR DESCRIPTION
Closes https://github.com/oxidize-rb/rb-sys/issues/446

Not sure if calling `rb_obj_frozen_p` is correct in the Rust side. 

Tried to do what MRI does but `ruby_fl_type` does not seem to be available in bindgen's output.