### PR TITLE
Implemented StableApiDefinition::[bignum_positive_p|bignum_negative_p].

### DIFF
--- a/crates/rb-sys-build/src/bindings.rs
+++ b/crates/rb-sys-build/src/bindings.rs
@@ -68,9 +68,7 @@ pub fn generate(
     let bindings = if cfg!(feature = "bindgen-deprecated-types") {
         bindings
     } else {
-        bindings
-            .blocklist_item("^ruby_fl_type.*")
-            .blocklist_item("^_bindgen_ty_9.*")
+        bindings.blocklist_item("^_bindgen_ty_9.*")
     };
 
     let bindings = opaqueify_bindings(rbconfig, bindings, &mut wrapper_h);

--- a/crates/rb-sys-tests/src/stable_api_test.rs
+++ b/crates/rb-sys-tests/src/stable_api_test.rs
@@ -214,6 +214,60 @@ parity_test!(
 );
 
 parity_test!(
+    name: test_bignum_positive_p_evaled,
+    func: bignum_positive_p,
+    data_factory: {
+      ruby_eval!("2 ** 64")
+    },
+    expected: true
+);
+
+parity_test!(
+    name: test_bignum_negative_p_evaled,
+    func: bignum_negative_p,
+    data_factory: {
+      ruby_eval!("-(2 ** 64)")
+    },
+    expected: true
+);
+
+parity_test!(
+    name: test_bignum_positive_p_for_zero,
+    func: bignum_positive_p,
+    data_factory: {
+      unsafe { rb_sys::rb_int2big(0) }
+    },
+    expected: true
+);
+
+parity_test!(
+    name: test_bignum_negative_p_for_zero,
+    func: bignum_negative_p,
+    data_factory: {
+      unsafe { rb_sys::rb_int2big(0) }
+    },
+    expected: false
+);
+
+parity_test!(
+    name: test_bignum_positive_p,
+    func: bignum_positive_p,
+    data_factory: {
+      unsafe { rb_sys::rb_int2big(64) }
+    },
+    expected: true
+);
+
+parity_test!(
+    name: test_bignum_negative_p,
+    func: bignum_negative_p,
+    data_factory: {
+      unsafe { rb_sys::rb_int2big(-1) }
+    },
+    expected: true
+);
+
+parity_test!(
     name: test_builtin_type_for_string,
     func: builtin_type,
     data_factory: {

--- a/crates/rb-sys/src/stable_api.rs
+++ b/crates/rb-sys/src/stable_api.rs
@@ -54,6 +54,22 @@ pub trait StableApiDefinition {
     /// is valid.
     unsafe fn rarray_const_ptr(&self, obj: VALUE) -> *const VALUE;
 
+    /// Tests if a bignum is positive.
+    ///
+    /// # Safety
+    /// This function is unsafe because it dereferences a raw pointer to get
+    /// access to underlying RBasic struct. The caller must ensure that the
+    /// `VALUE` is a valid pointer to a bignum.
+    unsafe fn bignum_positive_p(&self, obj: VALUE) -> bool;
+
+    /// Tests if a bignum is negative.
+    ///
+    /// # Safety
+    /// This function is unsafe because it dereferences a raw pointer to get
+    /// access to underlying RBasic struct. The caller must ensure that the
+    /// `VALUE` is a valid pointer to a bignum.
+    unsafe fn bignum_negative_p(&self, obj: VALUE) -> bool;
+
     /// Tests if the given value is a special constant.
     fn special_const_p(&self, value: VALUE) -> bool;
 

--- a/crates/rb-sys/src/stable_api.rs
+++ b/crates/rb-sys/src/stable_api.rs
@@ -68,7 +68,9 @@ pub trait StableApiDefinition {
     /// This function is unsafe because it dereferences a raw pointer to get
     /// access to underlying RBasic struct. The caller must ensure that the
     /// `VALUE` is a valid pointer to a bignum.
-    unsafe fn bignum_negative_p(&self, obj: VALUE) -> bool;
+    unsafe fn bignum_negative_p(&self, obj: VALUE) -> bool {
+        !self.bignum_positive_p(obj)
+    }
 
     /// Tests if the given value is a special constant.
     fn special_const_p(&self, value: VALUE) -> bool;

--- a/crates/rb-sys/src/stable_api/compiled.c
+++ b/crates/rb-sys/src/stable_api/compiled.c
@@ -25,6 +25,17 @@ impl_special_const_p(VALUE obj) {
   return SPECIAL_CONST_P(obj);
 }
 
+int
+impl_bignum_positive_p(VALUE obj) {
+  return RBIGNUM_POSITIVE_P(obj);
+}
+
+int
+impl_bignum_negative_p(VALUE obj) {
+  return RBIGNUM_NEGATIVE_P(obj);
+}
+
+
 enum ruby_value_type
 impl_builtin_type(VALUE obj) {
   return RB_BUILTIN_TYPE(obj);

--- a/crates/rb-sys/src/stable_api/compiled.rs
+++ b/crates/rb-sys/src/stable_api/compiled.rs
@@ -19,6 +19,12 @@ extern "C" {
     #[link_name = "impl_special_const_p"]
     fn impl_special_const_p(value: VALUE) -> bool;
 
+    #[link_name = "impl_bignum_positive_p"]
+    fn impl_bignum_positive_p(obj: VALUE) -> bool;
+
+    #[link_name = "impl_bignum_negative_p"]
+    fn impl_bignum_negative_p(obj: VALUE) -> bool;
+
     #[link_name = "impl_builtin_type"]
     fn impl_builtin_type(obj: VALUE) -> ruby_value_type;
 
@@ -91,6 +97,16 @@ impl StableApiDefinition for Definition {
     #[inline]
     fn special_const_p(&self, value: VALUE) -> bool {
         unsafe { impl_special_const_p(value) }
+    }
+
+    #[inline]
+    unsafe fn bignum_positive_p(&self, obj: VALUE) -> bool {
+        impl_bignum_positive_p(obj)
+    }
+
+    #[inline]
+    unsafe fn bignum_negative_p(&self, obj: VALUE) -> bool {
+        impl_bignum_negative_p(obj)
     }
 
     #[inline]

--- a/crates/rb-sys/src/stable_api/ruby_2_6.rs
+++ b/crates/rb-sys/src/stable_api/ruby_2_6.rs
@@ -97,6 +97,16 @@ impl StableApiDefinition for Definition {
     }
 
     #[inline]
+    unsafe fn bignum_positive_p(&self, obj: VALUE) -> bool {
+        crate::rb_big_sign(obj) == 1
+    }
+
+    #[inline]
+    unsafe fn bignum_negative_p(&self, obj: VALUE) -> bool {
+        crate::rb_big_sign(obj) == 0
+    }
+
+    #[inline]
     unsafe fn builtin_type(&self, obj: VALUE) -> crate::ruby_value_type {
         let rbasic = obj as *const crate::RBasic;
         let ret: u32 = ((*rbasic).flags & crate::ruby_value_type::RUBY_T_MASK as VALUE) as _;

--- a/crates/rb-sys/src/stable_api/ruby_2_6.rs
+++ b/crates/rb-sys/src/stable_api/ruby_2_6.rs
@@ -89,16 +89,18 @@ impl StableApiDefinition for Definition {
     }
 
     #[inline]
+    unsafe fn bignum_positive_p(&self, obj: VALUE) -> bool {
+        let rbasic = obj as *const crate::RBasic;
+
+        ((*rbasic).flags & crate::ruby_fl_type::RUBY_FL_USER1 as VALUE) != 0
+    }
+
+    #[inline]
     fn special_const_p(&self, value: VALUE) -> bool {
         let is_immediate = value & (crate::special_consts::IMMEDIATE_MASK as VALUE) != 0;
         let test = (value & !(crate::Qnil as VALUE)) != 0;
 
         is_immediate || !test
-    }
-
-    #[inline]
-    unsafe fn bignum_positive_p(&self, obj: VALUE) -> bool {
-        crate::rb_big_sign(obj) == 1
     }
 
     #[inline]

--- a/crates/rb-sys/src/stable_api/ruby_2_6.rs
+++ b/crates/rb-sys/src/stable_api/ruby_2_6.rs
@@ -102,11 +102,6 @@ impl StableApiDefinition for Definition {
     }
 
     #[inline]
-    unsafe fn bignum_negative_p(&self, obj: VALUE) -> bool {
-        crate::rb_big_sign(obj) == 0
-    }
-
-    #[inline]
     unsafe fn builtin_type(&self, obj: VALUE) -> crate::ruby_value_type {
         let rbasic = obj as *const crate::RBasic;
         let ret: u32 = ((*rbasic).flags & crate::ruby_value_type::RUBY_T_MASK as VALUE) as _;

--- a/crates/rb-sys/src/stable_api/ruby_2_7.rs
+++ b/crates/rb-sys/src/stable_api/ruby_2_7.rs
@@ -97,6 +97,16 @@ impl StableApiDefinition for Definition {
     }
 
     #[inline]
+    unsafe fn bignum_positive_p(&self, obj: VALUE) -> bool {
+        crate::rb_big_sign(obj) == 1
+    }
+
+    #[inline]
+    unsafe fn bignum_negative_p(&self, obj: VALUE) -> bool {
+        crate::rb_big_sign(obj) == 0
+    }
+
+    #[inline]
     unsafe fn builtin_type(&self, obj: VALUE) -> crate::ruby_value_type {
         let rbasic = obj as *const crate::RBasic;
         let ret: u32 = ((*rbasic).flags & crate::ruby_value_type::RUBY_T_MASK as VALUE) as _;

--- a/crates/rb-sys/src/stable_api/ruby_2_7.rs
+++ b/crates/rb-sys/src/stable_api/ruby_2_7.rs
@@ -89,16 +89,18 @@ impl StableApiDefinition for Definition {
     }
 
     #[inline]
+    unsafe fn bignum_positive_p(&self, obj: VALUE) -> bool {
+        let rbasic = obj as *const crate::RBasic;
+
+        ((*rbasic).flags & crate::ruby_fl_type::RUBY_FL_USER1 as VALUE) != 0
+    }
+
+    #[inline]
     fn special_const_p(&self, value: VALUE) -> bool {
         let is_immediate = value & (crate::special_consts::IMMEDIATE_MASK as VALUE) != 0;
         let test = (value & !(crate::Qnil as VALUE)) != 0;
 
         is_immediate || !test
-    }
-
-    #[inline]
-    unsafe fn bignum_positive_p(&self, obj: VALUE) -> bool {
-        crate::rb_big_sign(obj) == 1
     }
 
     #[inline]

--- a/crates/rb-sys/src/stable_api/ruby_2_7.rs
+++ b/crates/rb-sys/src/stable_api/ruby_2_7.rs
@@ -102,11 +102,6 @@ impl StableApiDefinition for Definition {
     }
 
     #[inline]
-    unsafe fn bignum_negative_p(&self, obj: VALUE) -> bool {
-        crate::rb_big_sign(obj) == 0
-    }
-
-    #[inline]
     unsafe fn builtin_type(&self, obj: VALUE) -> crate::ruby_value_type {
         let rbasic = obj as *const crate::RBasic;
         let ret: u32 = ((*rbasic).flags & crate::ruby_value_type::RUBY_T_MASK as VALUE) as _;

--- a/crates/rb-sys/src/stable_api/ruby_3_0.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_0.rs
@@ -105,6 +105,16 @@ impl StableApiDefinition for Definition {
     }
 
     #[inline]
+    unsafe fn bignum_positive_p(&self, obj: VALUE) -> bool {
+        crate::rb_big_sign(obj) == 1
+    }
+
+    #[inline]
+    unsafe fn bignum_negative_p(&self, obj: VALUE) -> bool {
+        crate::rb_big_sign(obj) == 0
+    }
+
+    #[inline]
     unsafe fn builtin_type(&self, obj: VALUE) -> crate::ruby_value_type {
         let rbasic = obj as *const crate::RBasic;
         let ret: u32 = ((*rbasic).flags & crate::ruby_value_type::RUBY_T_MASK as VALUE) as _;

--- a/crates/rb-sys/src/stable_api/ruby_3_0.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_0.rs
@@ -105,11 +105,6 @@ impl StableApiDefinition for Definition {
     }
 
     #[inline]
-    unsafe fn bignum_positive_p(&self, obj: VALUE) -> bool {
-        crate::rb_big_sign(obj) == 1
-    }
-
-    #[inline]
     unsafe fn bignum_negative_p(&self, obj: VALUE) -> bool {
         crate::rb_big_sign(obj) == 0
     }

--- a/crates/rb-sys/src/stable_api/ruby_3_0.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_0.rs
@@ -97,16 +97,18 @@ impl StableApiDefinition for Definition {
     }
 
     #[inline]
+    unsafe fn bignum_positive_p(&self, obj: VALUE) -> bool {
+        let rbasic = obj as *const crate::RBasic;
+
+        ((*rbasic).flags & crate::ruby_fl_type::RUBY_FL_USER1 as VALUE) != 0
+    }
+
+    #[inline]
     fn special_const_p(&self, value: VALUE) -> bool {
         let is_immediate = value & (crate::special_consts::IMMEDIATE_MASK as VALUE) != 0;
         let test = (value & !(crate::Qnil as VALUE)) != 0;
 
         is_immediate || !test
-    }
-
-    #[inline]
-    unsafe fn bignum_negative_p(&self, obj: VALUE) -> bool {
-        crate::rb_big_sign(obj) == 0
     }
 
     #[inline]

--- a/crates/rb-sys/src/stable_api/ruby_3_1.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_1.rs
@@ -98,11 +98,6 @@ impl StableApiDefinition for Definition {
     }
 
     #[inline]
-    unsafe fn bignum_positive_p(&self, obj: VALUE) -> bool {
-        crate::rb_big_sign(obj) == 1
-    }
-
-    #[inline]
     unsafe fn bignum_negative_p(&self, obj: VALUE) -> bool {
         crate::rb_big_sign(obj) == 0
     }

--- a/crates/rb-sys/src/stable_api/ruby_3_1.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_1.rs
@@ -98,6 +98,16 @@ impl StableApiDefinition for Definition {
     }
 
     #[inline]
+    unsafe fn bignum_positive_p(&self, obj: VALUE) -> bool {
+        crate::rb_big_sign(obj) == 1
+    }
+
+    #[inline]
+    unsafe fn bignum_negative_p(&self, obj: VALUE) -> bool {
+        crate::rb_big_sign(obj) == 0
+    }
+
+    #[inline]
     unsafe fn builtin_type(&self, obj: VALUE) -> crate::ruby_value_type {
         let rbasic = obj as *const crate::RBasic;
         let ret: u32 = ((*rbasic).flags & crate::ruby_value_type::RUBY_T_MASK as VALUE) as _;

--- a/crates/rb-sys/src/stable_api/ruby_3_1.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_1.rs
@@ -90,16 +90,18 @@ impl StableApiDefinition for Definition {
     }
 
     #[inline]
+    unsafe fn bignum_positive_p(&self, obj: VALUE) -> bool {
+        let rbasic = obj as *const crate::RBasic;
+
+        ((*rbasic).flags & crate::ruby_fl_type::RUBY_FL_USER1 as VALUE) != 0
+    }
+
+    #[inline]
     fn special_const_p(&self, value: VALUE) -> bool {
         let is_immediate = value & (crate::special_consts::IMMEDIATE_MASK as VALUE) != 0;
         let test = (value & !(crate::Qnil as VALUE)) != 0;
 
         is_immediate || !test
-    }
-
-    #[inline]
-    unsafe fn bignum_negative_p(&self, obj: VALUE) -> bool {
-        crate::rb_big_sign(obj) == 0
     }
 
     #[inline]

--- a/crates/rb-sys/src/stable_api/ruby_3_2.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_2.rs
@@ -92,11 +92,6 @@ impl StableApiDefinition for Definition {
     }
 
     #[inline]
-    unsafe fn bignum_positive_p(&self, obj: VALUE) -> bool {
-        crate::rb_big_sign(obj) == 1
-    }
-
-    #[inline]
     unsafe fn bignum_negative_p(&self, obj: VALUE) -> bool {
         crate::rb_big_sign(obj) == 0
     }

--- a/crates/rb-sys/src/stable_api/ruby_3_2.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_2.rs
@@ -84,16 +84,18 @@ impl StableApiDefinition for Definition {
     }
 
     #[inline]
+    unsafe fn bignum_positive_p(&self, obj: VALUE) -> bool {
+        let rbasic = obj as *const crate::RBasic;
+
+        ((*rbasic).flags & crate::ruby_fl_type::RUBY_FL_USER1 as VALUE) != 0
+    }
+
+    #[inline]
     fn special_const_p(&self, value: VALUE) -> bool {
         let is_immediate = (value) & (crate::special_consts::IMMEDIATE_MASK as VALUE) != 0;
         let test = (value & !(crate::Qnil as VALUE)) != 0;
 
         is_immediate || !test
-    }
-
-    #[inline]
-    unsafe fn bignum_negative_p(&self, obj: VALUE) -> bool {
-        crate::rb_big_sign(obj) == 0
     }
 
     #[inline]

--- a/crates/rb-sys/src/stable_api/ruby_3_2.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_2.rs
@@ -92,6 +92,16 @@ impl StableApiDefinition for Definition {
     }
 
     #[inline]
+    unsafe fn bignum_positive_p(&self, obj: VALUE) -> bool {
+        crate::rb_big_sign(obj) == 1
+    }
+
+    #[inline]
+    unsafe fn bignum_negative_p(&self, obj: VALUE) -> bool {
+        crate::rb_big_sign(obj) == 0
+    }
+
+    #[inline]
     unsafe fn builtin_type(&self, obj: VALUE) -> crate::ruby_value_type {
         let rbasic = obj as *const crate::RBasic;
         let ret: u32 = ((*rbasic).flags & crate::ruby_value_type::RUBY_T_MASK as VALUE) as _;

--- a/crates/rb-sys/src/stable_api/ruby_3_3.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_3.rs
@@ -85,6 +85,16 @@ impl StableApiDefinition for Definition {
     }
 
     #[inline]
+    unsafe fn bignum_positive_p(&self, obj: VALUE) -> bool {
+        crate::rb_big_sign(obj) == 1
+    }
+
+    #[inline]
+    unsafe fn bignum_negative_p(&self, obj: VALUE) -> bool {
+        crate::rb_big_sign(obj) == 0
+    }
+
+    #[inline]
     unsafe fn builtin_type(&self, obj: VALUE) -> crate::ruby_value_type {
         let rbasic = obj as *const crate::RBasic;
         let ret: u32 = ((*rbasic).flags & crate::ruby_value_type::RUBY_T_MASK as VALUE) as _;

--- a/crates/rb-sys/src/stable_api/ruby_3_3.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_3.rs
@@ -77,18 +77,18 @@ impl StableApiDefinition for Definition {
     }
 
     #[inline]
+    unsafe fn bignum_positive_p(&self, obj: VALUE) -> bool {
+        let rbasic = obj as *const crate::RBasic;
+
+        ((*rbasic).flags & crate::ruby_fl_type::RUBY_FL_USER1 as VALUE) != 0
+    }
+
+    #[inline]
     fn special_const_p(&self, value: VALUE) -> bool {
         let is_immediate = (value) & (crate::special_consts::IMMEDIATE_MASK as VALUE) != 0;
         let test = (value & !(crate::Qnil as VALUE)) != 0;
 
         is_immediate || !test
-    }
-
-    #[inline]
-    unsafe fn bignum_positive_p(&self, obj: VALUE) -> bool {
-        let rbasic = obj as *const crate::RBasic;
-
-        ((*rbasic).flags & crate::ruby_fl_type::RUBY_FL_USER1 as VALUE) != 0
     }
 
     #[inline]

--- a/crates/rb-sys/src/stable_api/ruby_3_3.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_3.rs
@@ -1,7 +1,7 @@
 use super::StableApiDefinition;
 use crate::{
     internal::{RArray, RString},
-    value_type, VALUE,
+    value_type, RBasic, VALUE,
 };
 use std::os::raw::{c_char, c_long};
 
@@ -86,12 +86,16 @@ impl StableApiDefinition for Definition {
 
     #[inline]
     unsafe fn bignum_positive_p(&self, obj: VALUE) -> bool {
-        crate::rb_big_sign(obj) == 1
+        let rbasic = obj as *const crate::RBasic;
+
+        ((*rbasic).flags & crate::ruby_fl_type::RUBY_FL_USER1 as VALUE) != 0
     }
 
     #[inline]
     unsafe fn bignum_negative_p(&self, obj: VALUE) -> bool {
-        crate::rb_big_sign(obj) == 0
+        let rbasic = obj as *const crate::RBasic;
+
+        ((*rbasic).flags & crate::ruby_fl_type::RUBY_FL_USER1 as VALUE) == 0
     }
 
     #[inline]

--- a/crates/rb-sys/src/stable_api/ruby_3_3.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_3.rs
@@ -1,7 +1,7 @@
 use super::StableApiDefinition;
 use crate::{
     internal::{RArray, RString},
-    value_type, RBasic, VALUE,
+    value_type, VALUE,
 };
 use std::os::raw::{c_char, c_long};
 
@@ -89,13 +89,6 @@ impl StableApiDefinition for Definition {
         let rbasic = obj as *const crate::RBasic;
 
         ((*rbasic).flags & crate::ruby_fl_type::RUBY_FL_USER1 as VALUE) != 0
-    }
-
-    #[inline]
-    unsafe fn bignum_negative_p(&self, obj: VALUE) -> bool {
-        let rbasic = obj as *const crate::RBasic;
-
-        ((*rbasic).flags & crate::ruby_fl_type::RUBY_FL_USER1 as VALUE) == 0
     }
 
     #[inline]

--- a/crates/rb-sys/src/stable_api/ruby_3_4.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_4.rs
@@ -85,6 +85,16 @@ impl StableApiDefinition for Definition {
     }
 
     #[inline]
+    unsafe fn bignum_positive_p(&self, obj: VALUE) -> bool {
+        crate::rb_big_sign(obj) == 1
+    }
+
+    #[inline]
+    unsafe fn bignum_negative_p(&self, obj: VALUE) -> bool {
+        crate::rb_big_sign(obj) == 0
+    }
+
+    #[inline]
     unsafe fn builtin_type(&self, obj: VALUE) -> crate::ruby_value_type {
         let rbasic = obj as *const crate::RBasic;
         let ret: u32 = ((*rbasic).flags & crate::ruby_value_type::RUBY_T_MASK as VALUE) as _;

--- a/crates/rb-sys/src/stable_api/ruby_3_4.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_4.rs
@@ -86,7 +86,9 @@ impl StableApiDefinition for Definition {
 
     #[inline]
     unsafe fn bignum_positive_p(&self, obj: VALUE) -> bool {
-        crate::rb_big_sign(obj) == 1
+        let rbasic = obj as *const crate::RBasic;
+
+        ((*rbasic).flags & crate::ruby_fl_type::RUBY_FL_USER1 as VALUE) != 0
     }
 
     #[inline]

--- a/crates/rb-sys/src/stable_api/ruby_3_4.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_4.rs
@@ -90,11 +90,6 @@ impl StableApiDefinition for Definition {
     }
 
     #[inline]
-    unsafe fn bignum_negative_p(&self, obj: VALUE) -> bool {
-        crate::rb_big_sign(obj) == 0
-    }
-
-    #[inline]
     unsafe fn builtin_type(&self, obj: VALUE) -> crate::ruby_value_type {
         let rbasic = obj as *const crate::RBasic;
         let ret: u32 = ((*rbasic).flags & crate::ruby_value_type::RUBY_T_MASK as VALUE) as _;


### PR DESCRIPTION
Closes https://github.com/oxidize-rb/rb-sys/issues/451

For the Rust implementation I choose a similar approach than CRuby.