### PR TITLE
WIP: Implementing RStruct methods for `StableApiDefinition` in order to support TruffleRuby

### DIFF
--- a/crates/rb-sys-build/src/bindings/stable_api.rs
+++ b/crates/rb-sys-build/src/bindings/stable_api.rs
@@ -4,7 +4,7 @@ use quote::ToTokens;
 
 use crate::RbConfig;
 
-const OPAQUE_STRUCTS: [&str; 2] = ["RString", "RArray"];
+const OPAQUE_STRUCTS: [&str; 3] = ["RString", "RArray", "RStruct"];
 
 const OPAQUE_STRUCTS_RUBY_3_3: [&str; 3] = [
     "rb_matchext_struct",

--- a/crates/rb-sys-build/src/bindings/wrapper.h
+++ b/crates/rb-sys-build/src/bindings/wrapper.h
@@ -69,3 +69,19 @@
 #ifdef HAVE_RUBY_IO_BUFFER_H
 #include "ruby/io/buffer.h"
 #endif
+
+struct RStruct {
+  struct RBasic basic;
+  union {
+    struct {
+      long len;
+      const VALUE *ptr;
+    } heap;
+    /* This is a length 1 array because:
+     *   1. GCC has a bug that does not optimize C flexible array members
+     *      (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=102452)
+     *   2. Zero length arrays are not supported by all compilers
+     */
+    const VALUE ary[1];
+  } as;
+};

--- a/crates/rb-sys-tests/src/stable_api_test.rs
+++ b/crates/rb-sys-tests/src/stable_api_test.rs
@@ -1,3 +1,5 @@
+use std::ffi::{CStr, CString};
+
 use rb_sys::{StableApiDefinition, VALUE};
 use rb_sys_test_helpers::rstring as gen_rstring;
 
@@ -654,4 +656,13 @@ parity_test!(
     data_factory: {
         std::time::Duration::from_millis(100)
     }
+);
+
+parity_test!(
+    name: test_rb_rstruct_len,
+    func: rstruct_len,
+    data_factory: {
+        ruby_eval!("Person = Struct.new(:name, :age); Person.new('Matz', 59)")
+    },
+    expected: 2
 );

--- a/crates/rb-sys/src/stable_api.rs
+++ b/crates/rb-sys/src/stable_api.rs
@@ -13,6 +13,7 @@
 
 use crate::VALUE;
 use std::{
+    ffi::{c_int, CStr},
     os::raw::{c_char, c_long},
     ptr::NonNull,
     time::Duration,
@@ -175,6 +176,36 @@ pub trait StableApiDefinition {
 
     /// Blocks the current thread until the given duration has passed.
     fn thread_sleep(&self, duration: Duration);
+
+    /// Defines a struct type with the given name and members.
+    ///
+    /// # Example
+    ///
+    fn rstruct_define(&self, name: &CStr, members: &[&CStr]) -> VALUE;
+
+    /// Accesses an indexed member of the struct.
+    ///
+    /// # Safety
+    /// This function is unsafe because it dereferences a raw pointer to get
+    /// access to underlying struct data. The caller must ensure that the
+    /// `VALUE` is a valid pointer to a struct.
+    unsafe fn rstruct_get(&self, st: VALUE, idx: c_int) -> VALUE;
+
+    /// Sets an indexed member of the struct.
+    ///
+    /// # Safety
+    /// This function is unsafe because it dereferences a raw pointer to get
+    /// access to underlying struct data. The caller must ensure that the
+    /// `VALUE` is a valid pointer to a struct.
+    unsafe fn rstruct_set(&self, st: VALUE, idx: c_int, value: VALUE);
+
+    /// Returns the number of struct members.
+    ///
+    /// # Safety
+    /// This function is unsafe because it dereferences a raw pointer to get
+    /// access to underlying struct data. The caller must ensure that the
+    /// `VALUE` is a valid pointer to an RStruct.
+    unsafe fn rstruct_len(&self, obj: VALUE) -> c_long;
 }
 
 #[cfg(stable_api_enable_compiled_mod)]

--- a/crates/rb-sys/src/stable_api/compiled.c
+++ b/crates/rb-sys/src/stable_api/compiled.c
@@ -121,3 +121,23 @@ impl_thread_sleep(struct timeval time) {
   rb_thread_wait_for(time);
 }
 
+long
+impl_rstruct_len(VALUE st) {
+  return RSTRUCT_LEN(st);
+}
+
+VALUE
+impl_rstruct_define(char* name, ...) {
+  return rb_struct_define(name, NULL);
+}
+
+VALUE
+impl_rstruct_get(VALUE st, int idx) {
+  return Qnil;
+}
+
+VALUE
+impl_rstruct_set(VALUE st, int idx, VALUE value) {
+  return Qnil;
+}
+

--- a/crates/rb-sys/src/stable_api/compiled.rs
+++ b/crates/rb-sys/src/stable_api/compiled.rs
@@ -1,6 +1,7 @@
 use super::StableApiDefinition;
 use crate::{ruby_value_type, timeval, VALUE};
 use std::{
+    ffi::{c_int, CStr},
     os::raw::{c_char, c_long},
     ptr::NonNull,
     time::Duration,
@@ -79,6 +80,18 @@ extern "C" {
 
     #[link_name = "impl_thread_sleep"]
     fn impl_thread_sleep(interval: timeval);
+
+    #[link_name = "impl_rstruct_define"]
+    fn impl_rstruct_define(name: &CStr, members: Vec<*const c_char>) -> VALUE;
+
+    #[link_name = "impl_rstruct_get"]
+    fn impl_rstruct_get(st: VALUE, idx: c_int) -> VALUE;
+
+    #[link_name = "impl_rstruct_set"]
+    fn impl_rstruct_set(st: VALUE, idx: c_int, value: VALUE);
+
+    #[link_name = "impl_rstruct_len"]
+    fn impl_rstruct_len(obj: VALUE) -> c_long;
 }
 
 pub struct Definition;
@@ -112,6 +125,7 @@ impl StableApiDefinition for Definition {
         NonNull::<VALUE>::new(impl_rbasic_class(obj) as _)
     }
 
+    #[inline]
     unsafe fn frozen_p(&self, obj: VALUE) -> bool {
         impl_frozen_p(obj)
     }
@@ -212,5 +226,30 @@ impl StableApiDefinition for Definition {
         };
 
         unsafe { impl_thread_sleep(time) }
+    }
+
+    #[inline]
+    fn rstruct_define(&self, name: &CStr, members: &[&CStr]) -> VALUE {
+        let mut members: Vec<*const c_char> = members
+            .iter()
+            .map(|m| m.as_ptr() as *const c_char)
+            .collect();
+        members.push(std::ptr::null());
+        unsafe { impl_rstruct_define(name, members) }
+    }
+
+    #[inline]
+    unsafe fn rstruct_get(&self, st: VALUE, idx: c_int) -> VALUE {
+        impl_rstruct_get(st, idx)
+    }
+
+    #[inline]
+    unsafe fn rstruct_set(&self, st: VALUE, idx: c_int, value: VALUE) {
+        impl_rstruct_set(st, idx, value)
+    }
+
+    #[inline]
+    unsafe fn rstruct_len(&self, st: VALUE) -> c_long {
+        impl_rstruct_len(st)
     }
 }


### PR DESCRIPTION
Closes https://github.com/oxidize-rb/rb-sys/issues/448


Implementing RStruct methods for `StableApiDefinition` in order to support TruffleRuby.
