### PR TITLE
Update bindgen to 0.71

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,16 +13,14 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.69.4"
+version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
+checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
  "itertools",
- "lazy_static",
- "lazycell",
  "proc-macro2",
  "quote",
  "regex",
@@ -111,12 +109,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
@@ -271,9 +263,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
 
 [[package]]
 name = "rustix"

--- a/crates/rb-sys-build/Cargo.toml
+++ b/crates/rb-sys-build/Cargo.toml
@@ -15,11 +15,11 @@ doctest = false
 [dependencies]
 regex = "1"
 shell-words = "1.1"
-bindgen = { version = "0.69", default-features = false, features = ["runtime"] }
+bindgen = { version = "0.71", default-features = false, features = ["runtime"] }
 syn = { version = "2.0", features = ["parsing", "full", "extra-traits"] }
 quote = "1.0"
 lazy_static = "1.4.0"
-proc-macro2 = "1.0"
+proc-macro2 = "1.0.92"
 
 [features]
 default = []

--- a/crates/rb-sys-build/src/bindings/stable_api.rs
+++ b/crates/rb-sys-build/src/bindings/stable_api.rs
@@ -75,6 +75,21 @@ pub fn categorize_bindings(syntax: &mut syn::File) {
                         }
                     };
                 }
+            } else if let syn::Item::Const(ref mut c) = item {
+                if c.ident == syn::Ident::new("_", c.ident.span()) {
+                    let body = &mut c.expr;
+                    let code = body.clone().to_token_stream().to_string();
+                    let new_code = code.replace("rb_sys__Opaque__", "");
+                    let new_code = syn::parse_str::<syn::Expr>(&new_code).unwrap();
+
+                    *body = syn::parse_quote! {
+                        {
+                            #[allow(unused_imports)]
+                            use crate::internal::*;
+                            #new_code
+                        }
+                    };
+                }
             }
 
             normal_items.push(item.clone());


### PR DESCRIPTION
Bump bindgen to 0.71 in hope to fix compilation on Windows with recent clang. IIUC, latest bindgen should not have that problem.

I ran into 2 issues when bumping the crate:
1. ABI checks that referenced either private fields or out-of-scope structs:
    ```rust
    const _: () = {
        ["Size of RString"][::std::mem::size_of::<RString>() - 40usize];
        ["Alignment of RString"][::std::mem::align_of::<RString>() - 8usize];
        ["Offset of field: RString::basic"][::std::mem::offset_of!(RString, basic) - 0usize];
        ["Offset of field: RString::len"][::std::mem::offset_of!(RString, len) - 16usize];
        ["Offset of field: RString::as_"][::std::mem::offset_of!(RString, as_) - 24usize];
    };
    ```
  
    I fixed it by patching those blocks with a `use crate::internal::*;` and getting rid of the `rb_sys__Opaque__` prefix. Not sure what underlying change made this a problem though.

2. Missing `proc_macro2::Literal::c_string` when testing against magnus. Hence the proc_macro2 bump.

With those changes, magnus tests pass on my machine. Let's see what CI says.