### PR TITLE
Set `--pid=host` in rb-sys-dock

### DIFF
--- a/gem/exe/rb-sys-dock
+++ b/gem/exe/rb-sys-dock
@@ -367,7 +367,7 @@ def rcd(input_args)
   wrapper_command << "sigfw" unless interactive?(input_args)
   wrapper_command << "runas"
 
-  docker_options = []
+  docker_options = ["--pid=host"]
   docker_options << "--tty" if interactive?(input_args)
 
   cmd = <<~SH


### PR DESCRIPTION
The cross-gem action for wasmtime-rb gets killed by something, and I can't quite find out why (see https://github.com/bytecodealliance/wasmtime-rb/issues/418#issuecomment-2587802496). But it looks like setting `--pid=host` fixes it, soo... why not?

The cross-gem action for wasmtime-rb succeeded (well, mostly -- the failure is unrelated) with that patch applied: https://github.com/jbourassa/wasmtime-rb/actions/runs/12754208869/

Locally, oxi-test built successfully with Docker on my M2 mac:

```
~/src/rb-sys/gem/exe/rb-sys-dock --platform x86_64-linux --directory . --ruby-versions 3.3,3.4 --build
```

Fixes https://github.com/oxidize-rb/actions/issues/27