### PR TITLE
Bump rake-compiler-dock images to v1.8.0 with Ruby patch versions

### DIFF
--- a/docker/Dockerfile.aarch64-linux
+++ b/docker/Dockerfile.aarch64-linux
@@ -1,6 +1,6 @@
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.7.0-mri-aarch64-linux
+FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.8.0-mri-aarch64-linux
 
-ENV RUBY_CC_VERSION="3.4.0:3.3.5:3.2.0:3.1.0:3.0.0:2.7.0:2.6.0" \
+ENV RUBY_CC_VERSION="3.4.1:3.3.5:3.2.6:3.1.6:3.0.7:2.7.8:2.6.10" \
     RUBY_TARGET="aarch64-linux" \
     RUST_TARGET="aarch64-unknown-linux-gnu" \
     RUSTUP_DEFAULT_TOOLCHAIN="stable" \

--- a/docker/Dockerfile.aarch64-linux-musl
+++ b/docker/Dockerfile.aarch64-linux-musl
@@ -1,6 +1,6 @@
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.7.0-mri-aarch64-linux-musl
+FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.8.0-mri-aarch64-linux-musl
 
-ENV RUBY_CC_VERSION="3.4.0:3.3.5:3.2.0:3.1.0:3.0.0:2.7.0:2.6.0" \
+ENV RUBY_CC_VERSION="3.4.1:3.3.5:3.2.6:3.1.6:3.0.7:2.7.8:2.6.10" \
     RUBY_TARGET="aarch64-linux-musl" \
     RUST_TARGET="aarch64-unknown-linux-musl" \
     RUSTUP_DEFAULT_TOOLCHAIN="stable" \

--- a/docker/Dockerfile.arm-linux
+++ b/docker/Dockerfile.arm-linux
@@ -1,6 +1,6 @@
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.7.0-mri-arm-linux
+FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.8.0-mri-arm-linux
 
-ENV RUBY_CC_VERSION="3.4.0:3.3.5:3.2.0:3.1.0:3.0.0:2.7.0:2.6.0" \
+ENV RUBY_CC_VERSION="3.4.1:3.3.5:3.2.6:3.1.6:3.0.7:2.7.8:2.6.10" \
     RUBY_TARGET="arm-linux" \
     RUST_TARGET="arm-unknown-linux-gnueabihf" \
     RUSTUP_DEFAULT_TOOLCHAIN="stable" \

--- a/docker/Dockerfile.arm64-darwin
+++ b/docker/Dockerfile.arm64-darwin
@@ -1,6 +1,6 @@
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.7.0-mri-arm64-darwin
+FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.8.0-mri-arm64-darwin
 
-ENV RUBY_CC_VERSION="3.4.0:3.3.5:3.2.0:3.1.0:3.0.0:2.7.0:2.6.0" \
+ENV RUBY_CC_VERSION="3.4.1:3.3.5:3.2.6:3.1.6:3.0.7:2.7.8:2.6.10" \
     RUBY_TARGET="arm64-darwin" \
     RUST_TARGET="aarch64-apple-darwin" \
     RUSTUP_DEFAULT_TOOLCHAIN="stable" \

--- a/docker/Dockerfile.x64-mingw-ucrt
+++ b/docker/Dockerfile.x64-mingw-ucrt
@@ -1,6 +1,6 @@
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.7.0-mri-x64-mingw-ucrt
+FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.8.0-mri-x64-mingw-ucrt
 
-ENV RUBY_CC_VERSION="3.4.0:3.3.5:3.2.0:3.1.0:3.0.0:2.7.0:2.6.0" \
+ENV RUBY_CC_VERSION="3.4.1:3.3.5:3.2.6:3.1.6:3.0.7:2.7.8:2.6.10" \
     RUBY_TARGET="x64-mingw-ucrt" \
     RUST_TARGET="x86_64-pc-windows-gnu" \
     RUSTUP_DEFAULT_TOOLCHAIN="stable" \

--- a/docker/Dockerfile.x64-mingw32
+++ b/docker/Dockerfile.x64-mingw32
@@ -1,6 +1,6 @@
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.7.0-mri-x64-mingw32
+FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.8.0-mri-x64-mingw32
 
-ENV RUBY_CC_VERSION="3.4.0:3.3.5:3.2.0:3.1.0:3.0.0:2.7.0:2.6.0" \
+ENV RUBY_CC_VERSION="3.4.1:3.3.5:3.2.6:3.1.6:3.0.7:2.7.8:2.6.10" \
     RUBY_TARGET="x64-mingw32" \
     RUST_TARGET="x86_64-pc-windows-gnu" \
     RUSTUP_DEFAULT_TOOLCHAIN="stable" \

--- a/docker/Dockerfile.x86-linux
+++ b/docker/Dockerfile.x86-linux
@@ -1,6 +1,6 @@
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.7.0-mri-x86-linux
+FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.8.0-mri-x86-linux
 
-ENV RUBY_CC_VERSION="3.4.0:3.3.5:3.2.0:3.1.0:3.0.0:2.7.0:2.6.0" \
+ENV RUBY_CC_VERSION="3.4.1:3.3.5:3.2.6:3.1.6:3.0.7:2.7.8:2.6.10" \
     RUBY_TARGET="x86-linux" \
     RUST_TARGET="i686-unknown-linux-gnu" \
     RUSTUP_DEFAULT_TOOLCHAIN="stable" \

--- a/docker/Dockerfile.x86-mingw32
+++ b/docker/Dockerfile.x86-mingw32
@@ -1,10 +1,10 @@
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.7.0-mri-x86-mingw32
+FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.8.0-mri-x86-mingw32
 
 ARG LLVM_MINGW_VERSION=20231128 \
     LLVM_MINGW_SHA256=2d532648bfd202bfe5edfa8b7f6c55970f65639779f34115a9a8bfa6f7d87f0b \
     LLVM_MINGW_LIBCLANG_VERSION=14.0.0
 
-ENV RUBY_CC_VERSION="3.4.0:3.3.5:3.2.0:3.1.0:3.0.0:2.7.0:2.6.0" \
+ENV RUBY_CC_VERSION="3.4.1:3.3.5:3.2.6:3.1.6:3.0.7:2.7.8:2.6.10" \
     RUBY_TARGET="x86-mingw32" \
     RUST_TARGET="i686-pc-windows-gnu" \
     RUSTUP_DEFAULT_TOOLCHAIN="stable" \

--- a/docker/Dockerfile.x86_64-darwin
+++ b/docker/Dockerfile.x86_64-darwin
@@ -1,6 +1,6 @@
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.7.0-mri-x86_64-darwin
+FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.8.0-mri-x86_64-darwin
 
-ENV RUBY_CC_VERSION="3.4.0:3.3.5:3.2.0:3.1.0:3.0.0:2.7.0:2.6.0" \
+ENV RUBY_CC_VERSION="3.4.1:3.3.5:3.2.6:3.1.6:3.0.7:2.7.8:2.6.10" \
     RUBY_TARGET="x86_64-darwin" \
     RUST_TARGET="x86_64-apple-darwin" \
     RUSTUP_DEFAULT_TOOLCHAIN="stable" \

--- a/docker/Dockerfile.x86_64-linux
+++ b/docker/Dockerfile.x86_64-linux
@@ -1,6 +1,6 @@
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.7.0-mri-x86_64-linux
+FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.8.0-mri-x86_64-linux
 
-ENV RUBY_CC_VERSION="3.4.0:3.3.5:3.2.0:3.1.0:3.0.0:2.7.0:2.6.0" \
+ENV RUBY_CC_VERSION="3.4.1:3.3.5:3.2.6:3.1.6:3.0.7:2.7.8:2.6.10" \
     RUBY_TARGET="x86_64-linux" \
     RUST_TARGET="x86_64-unknown-linux-gnu" \
     RUSTUP_DEFAULT_TOOLCHAIN="stable" \

--- a/docker/Dockerfile.x86_64-linux-musl
+++ b/docker/Dockerfile.x86_64-linux-musl
@@ -1,6 +1,6 @@
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.7.0-mri-x86_64-linux-musl
+FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.8.0-mri-x86_64-linux-musl
 
-ENV RUBY_CC_VERSION="3.4.0:3.3.5:3.2.0:3.1.0:3.0.0:2.7.0:2.6.0" \
+ENV RUBY_CC_VERSION="3.4.1:3.3.5:3.2.6:3.1.6:3.0.7:2.7.8:2.6.10" \
     RUBY_TARGET="x86_64-linux-musl" \
     RUST_TARGET="x86_64-unknown-linux-musl" \
     RUSTUP_DEFAULT_TOOLCHAIN="stable" \


### PR DESCRIPTION
This reflects the changes made in https://github.com/rake-compiler/rake-compiler-dock/pull/135.

While this requires packages to update their `RUBY_CC_VERSION` to use Ruby patches across the board, this is already needed for Ruby 3.3.5. This change at least makes this consistent.

See https://github.com/rake-compiler/rake-compiler-dock/releases/tag/v1.8.0.