### PR TITLE
Add rake-compiler-dock as a dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ gemspec path: "examples/rust_reverse"
 gem "rake", "~> 13.0"
 gem "minitest", "5.15.0"
 gem "rake-compiler", "~> 1.2.5" # Small bug in 1.2.4 that breaks Ruby 2.5
-gem "rake-compiler-dock", "1.9.1" # This should match the versions used in docker/Dockerfile.*
 gem "racc", "~> 1.7"
 gem "base64", "~> 0.2.0"
 gem "yard"

--- a/gem/rb_sys.gemspec
+++ b/gem/rb_sys.gemspec
@@ -28,4 +28,7 @@ Gem::Specification.new do |spec|
   end
 
   spec.metadata["rubygems_mfa_required"] = "true"
+
+  # This should match the versions used in docker/Dockerfile.*
+  spec.add_runtime_dependency("rake-compiler-dock", "~> 1.9")
 end


### PR DESCRIPTION
`gem/exe/rb-sys-dock` needs rake-compiler-dock to load the right Ruby versions, so require it as a dependency.