### PR TITLE
Append -gnu to RUBY_TARGET for GNU Linux builds

### DIFF
--- a/docker/Dockerfile.aarch64-linux
+++ b/docker/Dockerfile.aarch64-linux
@@ -1,7 +1,7 @@
 # Ensure this version matches the rack-compiler-version in Gemfile
 FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.9.1-mri-aarch64-linux
 
-ENV RUBY_TARGET="aarch64-linux" \
+ENV RUBY_TARGET="aarch64-linux-gnu" \
     RUST_TARGET="aarch64-unknown-linux-gnu" \
     RUSTUP_DEFAULT_TOOLCHAIN="stable" \
     PKG_CONFIG_ALLOW_CROSS="1" \

--- a/docker/Dockerfile.arm-linux
+++ b/docker/Dockerfile.arm-linux
@@ -1,7 +1,7 @@
 # Ensure this version matches the rack-compiler-version in Gemfile
 FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.9.1-mri-arm-linux
 
-ENV RUBY_TARGET="arm-linux" \
+ENV RUBY_TARGET="arm-linux-gnu" \
     RUST_TARGET="arm-unknown-linux-gnueabihf" \
     RUSTUP_DEFAULT_TOOLCHAIN="stable" \
     PKG_CONFIG_ALLOW_CROSS="1" \

--- a/docker/Dockerfile.x86-linux
+++ b/docker/Dockerfile.x86-linux
@@ -1,7 +1,7 @@
 # Ensure this version matches the rack-compiler-version in Gemfile
 FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.9.1-mri-x86-linux
 
-ENV RUBY_TARGET="x86-linux" \
+ENV RUBY_TARGET="x86-linux-gnu" \
     RUST_TARGET="i686-unknown-linux-gnu" \
     RUSTUP_DEFAULT_TOOLCHAIN="stable" \
     PKG_CONFIG_ALLOW_CROSS="1" \

--- a/docker/Dockerfile.x86_64-linux
+++ b/docker/Dockerfile.x86_64-linux
@@ -1,7 +1,7 @@
 # Ensure this version matches the rack-compiler-version in Gemfile
 FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.9.1-mri-x86_64-linux
 
-ENV RUBY_TARGET="x86_64-linux" \
+ENV RUBY_TARGET="x86_64-linux-gnu" \
     RUST_TARGET="x86_64-unknown-linux-gnu" \
     RUSTUP_DEFAULT_TOOLCHAIN="stable" \
     PKG_CONFIG_ALLOW_CROSS="1" \


### PR DESCRIPTION
rake-compiler-dock images now make a distinction between GNU and musl builds. Add a `-gnu` extension to `RUBY_TARGET` to make it possible to run:

```
rb-sys-dock --platform x86_64-linux-gnu --directory . --build
```

Closes https://github.com/oxidize-rb/rb-sys/issues/510