### PR TITLE
Make it possible to override RUBY_TARGET

### DIFF
--- a/docker/Dockerfile.aarch64-linux
+++ b/docker/Dockerfile.aarch64-linux
@@ -1,7 +1,7 @@
 # Ensure this version matches the rack-compiler-version in Gemfile
 FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.9.1-mri-aarch64-linux
 
-ENV RUBY_TARGET="aarch64-linux-gnu" \
+ENV RUBY_TARGET="aarch64-linux" \
     RUST_TARGET="aarch64-unknown-linux-gnu" \
     RUSTUP_DEFAULT_TOOLCHAIN="stable" \
     PKG_CONFIG_ALLOW_CROSS="1" \

--- a/docker/Dockerfile.arm-linux
+++ b/docker/Dockerfile.arm-linux
@@ -1,7 +1,7 @@
 # Ensure this version matches the rack-compiler-version in Gemfile
 FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.9.1-mri-arm-linux
 
-ENV RUBY_TARGET="arm-linux-gnu" \
+ENV RUBY_TARGET="arm-linux" \
     RUST_TARGET="arm-unknown-linux-gnueabihf" \
     RUSTUP_DEFAULT_TOOLCHAIN="stable" \
     PKG_CONFIG_ALLOW_CROSS="1" \

--- a/docker/Dockerfile.x86-linux
+++ b/docker/Dockerfile.x86-linux
@@ -1,7 +1,7 @@
 # Ensure this version matches the rack-compiler-version in Gemfile
 FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.9.1-mri-x86-linux
 
-ENV RUBY_TARGET="x86-linux-gnu" \
+ENV RUBY_TARGET="x86-linux" \
     RUST_TARGET="i686-unknown-linux-gnu" \
     RUSTUP_DEFAULT_TOOLCHAIN="stable" \
     PKG_CONFIG_ALLOW_CROSS="1" \

--- a/docker/Dockerfile.x86_64-linux
+++ b/docker/Dockerfile.x86_64-linux
@@ -1,7 +1,7 @@
 # Ensure this version matches the rack-compiler-version in Gemfile
 FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.9.1-mri-x86_64-linux
 
-ENV RUBY_TARGET="x86_64-linux-gnu" \
+ENV RUBY_TARGET="x86_64-linux" \
     RUST_TARGET="x86_64-unknown-linux-gnu" \
     RUSTUP_DEFAULT_TOOLCHAIN="stable" \
     PKG_CONFIG_ALLOW_CROSS="1" \

--- a/docker/setup/rubybashrc.sh
+++ b/docker/setup/rubybashrc.sh
@@ -52,7 +52,6 @@ main() {
   echo "export PATH=\"/usr/local/cargo/bin:\$PATH\"" >> "$OUTFILE"
   echo "export RUSTUP_HOME=\"$RUSTUP_HOME\"" >> "$OUTFILE"
   echo "export CARGO_HOME=\"$CARGO_HOME\"" >> "$OUTFILE"
-  echo "export RUBY_TARGET=\"$RUBY_TARGET\"" >> "$OUTFILE"
   echo "export RCD_PLATFORM=\"$RUBY_TARGET\"" >> "$OUTFILE"
   echo "export RUST_TARGET=\"$RUST_TARGET\"" >> "$OUTFILE"
   echo "export RUSTUP_DEFAULT_TOOLCHAIN=\"$RUSTUP_DEFAULT_TOOLCHAIN\"" >> "$OUTFILE"

--- a/gem/exe/rb-sys-dock
+++ b/gem/exe/rb-sys-dock
@@ -391,6 +391,7 @@ def rcd(input_args)
       -e RB_SYS_DOCK_TMPDIR="/tmp/rb-sys-dock" \
       -e RB_SYS_CARGO_TARGET_DIR=#{tmp_target_dir.inspect} \
       -e RUBY_CC_VERSION="#{ruby_versions}" \
+      -e RUBY_TARGET="#{OPTIONS.fetch(:platform)}" \
       -e RAKEOPT \
       -e TERM \
       -w #{working_directory} \


### PR DESCRIPTION
This reverts #511 because the CI test expected that `rb-sys-dock --platform x86_64-linux --directory . --build` produces a gem with a suffix of `-x86_64-linux.gem`.

This change drops the hard-coded `RUBY_TARGET` from the bash script so the value can be derived from the `ENV` setting. With this change, this is now possible:

1. `rb-sys-dock --platform x86_64-linux --directory . --build` produces a gem with a filename `-x86_64-linux-gnu.gem`.
1. `rb-sys-dock --platform x86_64-linux-gnu --directory . --build` produces a gem with a filename `-x86_64-linux-gnu.gem`.
