### PR TITLE
Allow RUBY_TARGET to be inherited from sudo

### DIFF
--- a/docker/setup/rb-sys-dock.sh
+++ b/docker/setup/rb-sys-dock.sh
@@ -3,7 +3,7 @@
 set -e
 
 setup_sudoers() {
-  echo "Defaults        env_keep += \"BUNDLE_PATH RB_SYS_CARGO_TARGET_DIR RAKEOPT\"" >> /etc/sudoers.d/rb-sys-dock
+  echo "Defaults        env_keep += \"BUNDLE_PATH RB_SYS_CARGO_TARGET_DIR RAKEOPT RUBY_TARGET\"" >> /etc/sudoers.d/rb-sys-dock
 }
 
 main() {


### PR DESCRIPTION
Previously RUBY_TARGET was never passed along because `sudo -u` was run. Add this variable to the sudoers file to preserve this varaible.