### PR TITLE
Implemented GC methods for `StableApiDefinition` for TruffleRuby support.

### DIFF
--- a/crates/rb-sys-tests/src/stable_api_test.rs
+++ b/crates/rb-sys-tests/src/stable_api_test.rs
@@ -405,6 +405,39 @@ parity_test! (
     }
 );
 
+#[rb_sys_test_helpers::ruby_test]
+fn test_rb_gc_writebarrier() {
+    use rb_sys::stable_api;
+    let old = ruby_eval!("String.new") as VALUE;
+    let young = ruby_eval!("42") as VALUE;
+    assert_ne!(stable_api::get_default().version(), (0, 0));
+    #[allow(unused)]
+    let rust_result = unsafe { stable_api::get_default().gc_writebarrier(old, young) };
+    #[allow(unused_unsafe)]
+    let compiled_c_result = unsafe { stable_api::get_compiled().gc_writebarrier(old, young) };
+    assert_eq!(
+        compiled_c_result, rust_result,
+        "compiled_c was {:?}, rust was {:?}",
+        compiled_c_result, rust_result
+    );
+}
+
+#[rb_sys_test_helpers::ruby_test]
+fn test_rb_gc_writebarrier_unprotect() {
+    use rb_sys::stable_api;
+    let obj = ruby_eval!("String.new") as VALUE;
+    assert_ne!(stable_api::get_default().version(), (0, 0));
+    #[allow(unused)]
+    let rust_result = unsafe { stable_api::get_default().gc_writebarrier_unprotect(obj) };
+    #[allow(unused_unsafe)]
+    let compiled_c_result = unsafe { stable_api::get_compiled().gc_writebarrier_unprotect(obj) };
+    assert_eq!(
+        compiled_c_result, rust_result,
+        "compiled_c was {:?}, rust was {:?}",
+        compiled_c_result, rust_result
+    );
+}
+
 parity_test! (
     name: test_rb_static_sym_p_for_static_sym,
     func: static_sym_p,

--- a/crates/rb-sys-tests/src/stable_api_test.rs
+++ b/crates/rb-sys-tests/src/stable_api_test.rs
@@ -390,6 +390,22 @@ parity_test! (
 );
 
 parity_test! (
+    name: test_rb_gc_adjust_memory_usage,
+    func: gc_adjust_memory_usage,
+    data_factory: {
+        64isize
+    }
+);
+
+parity_test! (
+    name: test_rb_gc_adjust_memory_usage_negative,
+    func: gc_adjust_memory_usage,
+    data_factory: {
+        -64isize
+    }
+);
+
+parity_test! (
     name: test_rb_static_sym_p_for_static_sym,
     func: static_sym_p,
     data_factory: {

--- a/crates/rb-sys-tests/src/stable_api_test.rs
+++ b/crates/rb-sys-tests/src/stable_api_test.rs
@@ -554,6 +554,22 @@ parity_test! (
 );
 
 parity_test! (
+    name: test_rb_gc_adjust_memory_usage,
+    func: gc_adjust_memory_usage,
+    data_factory: {
+        64isize
+    }
+);
+
+parity_test! (
+    name: test_rb_gc_adjust_memory_usage_negative,
+    func: gc_adjust_memory_usage,
+    data_factory: {
+        -64isize
+    }
+);
+
+parity_test! (
     name: test_rb_static_sym_p_for_static_sym,
     func: static_sym_p,
     data_factory: {

--- a/crates/rb-sys-tests/src/stable_api_test.rs
+++ b/crates/rb-sys-tests/src/stable_api_test.rs
@@ -569,6 +569,39 @@ parity_test! (
     }
 );
 
+#[rb_sys_test_helpers::ruby_test]
+fn test_rb_gc_writebarrier() {
+    use rb_sys::stable_api;
+    let old = ruby_eval!("String.new") as VALUE;
+    let young = ruby_eval!("42") as VALUE;
+    assert_ne!(stable_api::get_default().version(), (0, 0));
+    #[allow(unused)]
+    let rust_result = unsafe { stable_api::get_default().gc_writebarrier(old, young) };
+    #[allow(unused_unsafe)]
+    let compiled_c_result = unsafe { stable_api::get_compiled().gc_writebarrier(old, young) };
+    assert_eq!(
+        compiled_c_result, rust_result,
+        "compiled_c was {:?}, rust was {:?}",
+        compiled_c_result, rust_result
+    );
+}
+
+#[rb_sys_test_helpers::ruby_test]
+fn test_rb_gc_writebarrier_unprotect() {
+    use rb_sys::stable_api;
+    let obj = ruby_eval!("String.new") as VALUE;
+    assert_ne!(stable_api::get_default().version(), (0, 0));
+    #[allow(unused)]
+    let rust_result = unsafe { stable_api::get_default().gc_writebarrier_unprotect(obj) };
+    #[allow(unused_unsafe)]
+    let compiled_c_result = unsafe { stable_api::get_compiled().gc_writebarrier_unprotect(obj) };
+    assert_eq!(
+        compiled_c_result, rust_result,
+        "compiled_c was {:?}, rust was {:?}",
+        compiled_c_result, rust_result
+    );
+}
+
 parity_test! (
     name: test_rb_static_sym_p_for_static_sym,
     func: static_sym_p,

--- a/crates/rb-sys/src/stable_api.rs
+++ b/crates/rb-sys/src/stable_api.rs
@@ -112,6 +112,10 @@ pub trait StableApiDefinition {
     /// Checks if the given object is a so-called Fixnum.
     fn fixnum_p(&self, obj: VALUE) -> bool;
 
+    /// Informs that there are external memory usages, so the GC can run more
+    /// often than it otherwise would if it was unaware of such allocations.
+    fn gc_adjust_memory_usage(&self, diff: isize);
+
     /// Checks if the given object is a dynamic symbol.
     ///
     /// # Safety

--- a/crates/rb-sys/src/stable_api.rs
+++ b/crates/rb-sys/src/stable_api.rs
@@ -116,6 +116,13 @@ pub trait StableApiDefinition {
     /// often than it otherwise would if it was unaware of such allocations.
     fn gc_adjust_memory_usage(&self, diff: isize);
 
+    /// Informs the GC that `young` is a new reference to `old`, allowing the
+    /// the old object to participate in generational GC.
+    fn gc_writebarrier(&self, old: VALUE, young: VALUE);
+
+    /// Opts out of generational GC and write barrier protection.
+    fn gc_writebarrier_unprotect(&self, obj: VALUE);
+
     /// Checks if the given object is a dynamic symbol.
     ///
     /// # Safety

--- a/crates/rb-sys/src/stable_api.rs
+++ b/crates/rb-sys/src/stable_api.rs
@@ -141,6 +141,10 @@ pub trait StableApiDefinition {
     /// Checks if the given object is a so-called Fixnum.
     fn fixnum_p(&self, obj: VALUE) -> bool;
 
+    /// Informs that there are external memory usages, so the GC can run more
+    /// often than it otherwise would if it was unaware of such allocations.
+    fn gc_adjust_memory_usage(&self, diff: isize);
+
     /// Checks if the given object is a dynamic symbol.
     ///
     /// # Safety

--- a/crates/rb-sys/src/stable_api.rs
+++ b/crates/rb-sys/src/stable_api.rs
@@ -145,6 +145,13 @@ pub trait StableApiDefinition {
     /// often than it otherwise would if it was unaware of such allocations.
     fn gc_adjust_memory_usage(&self, diff: isize);
 
+    /// Informs the GC that `young` is a new reference to `old`, allowing the
+    /// the old object to participate in generational GC.
+    fn gc_writebarrier(&self, old: VALUE, young: VALUE);
+
+    /// Opts out of generational GC and write barrier protection.
+    fn gc_writebarrier_unprotect(&self, obj: VALUE);
+
     /// Checks if the given object is a dynamic symbol.
     ///
     /// # Safety

--- a/crates/rb-sys/src/stable_api/compiled.c
+++ b/crates/rb-sys/src/stable_api/compiled.c
@@ -61,6 +61,11 @@ impl_fixnum_p(VALUE obj) {
   return FIXNUM_P(obj);
 }
 
+void
+impl_gc_adjust_memory_usage(size_t diff) {
+  return rb_gc_adjust_memory_usage(diff);
+}
+
 int
 impl_static_sym_p(VALUE obj) {
   return STATIC_SYM_P(obj);

--- a/crates/rb-sys/src/stable_api/compiled.c
+++ b/crates/rb-sys/src/stable_api/compiled.c
@@ -63,7 +63,17 @@ impl_fixnum_p(VALUE obj) {
 
 void
 impl_gc_adjust_memory_usage(size_t diff) {
-  return rb_gc_adjust_memory_usage(diff);
+  rb_gc_adjust_memory_usage(diff);
+}
+
+void
+impl_gc_writebarrier(VALUE old, VALUE young) {
+  rb_gc_writebarrier(old, young);
+}
+
+void
+impl_gc_writebarrier_unprotect(VALUE obj) {
+  rb_gc_writebarrier_unprotect(obj);
 }
 
 int

--- a/crates/rb-sys/src/stable_api/compiled.c
+++ b/crates/rb-sys/src/stable_api/compiled.c
@@ -101,6 +101,16 @@ void impl_gc_adjust_memory_usage(ssize_t diff)
   rb_gc_adjust_memory_usage(diff);
 }
 
+void impl_gc_writebarrier(VALUE old, VALUE young)
+{
+  rb_gc_writebarrier(old, young);
+}
+
+void impl_gc_writebarrier_unprotect(VALUE obj)
+{
+  rb_gc_writebarrier_unprotect(obj);
+}
+
 int impl_static_sym_p(VALUE obj)
 {
   return STATIC_SYM_P(obj);

--- a/crates/rb-sys/src/stable_api/compiled.c
+++ b/crates/rb-sys/src/stable_api/compiled.c
@@ -96,6 +96,11 @@ int impl_fixnum_p(VALUE obj)
   return FIXNUM_P(obj);
 }
 
+void impl_gc_adjust_memory_usage(ssize_t diff)
+{
+  rb_gc_adjust_memory_usage(diff);
+}
+
 int impl_static_sym_p(VALUE obj)
 {
   return STATIC_SYM_P(obj);

--- a/crates/rb-sys/src/stable_api/compiled.rs
+++ b/crates/rb-sys/src/stable_api/compiled.rs
@@ -47,6 +47,12 @@ extern "C" {
     #[link_name = "impl_gc_adjust_memory_usage"]
     fn impl_gc_adjust_memory_usage(diff: isize);
 
+    #[link_name = "impl_gc_writebarrier"]
+    fn impl_gc_writebarrier(old: VALUE, young: VALUE);
+
+    #[link_name = "impl_gc_writebarrier_unprotect"]
+    fn impl_gc_writebarrier_unprotect(obj: VALUE);
+
     #[link_name = "impl_static_sym_p"]
     fn impl_static_sym_p(obj: VALUE) -> bool;
 
@@ -152,6 +158,16 @@ impl StableApiDefinition for Definition {
     #[inline]
     fn gc_adjust_memory_usage(&self, diff: isize) {
         unsafe { impl_gc_adjust_memory_usage(diff) }
+    }
+
+    #[inline]
+    fn gc_writebarrier(&self, old: VALUE, young: VALUE) {
+        unsafe { impl_gc_writebarrier(old, young) }
+    }
+
+    #[inline]
+    fn gc_writebarrier_unprotect(&self, obj: VALUE) {
+        unsafe { impl_gc_writebarrier_unprotect(obj) }
     }
 
     #[inline]

--- a/crates/rb-sys/src/stable_api/compiled.rs
+++ b/crates/rb-sys/src/stable_api/compiled.rs
@@ -44,6 +44,9 @@ extern "C" {
     #[link_name = "impl_fixnum_p"]
     fn impl_fixnum_p(obj: VALUE) -> bool;
 
+    #[link_name = "impl_gc_adjust_memory_usage"]
+    fn impl_gc_adjust_memory_usage(diff: isize);
+
     #[link_name = "impl_static_sym_p"]
     fn impl_static_sym_p(obj: VALUE) -> bool;
 
@@ -144,6 +147,11 @@ impl StableApiDefinition for Definition {
     #[inline]
     fn fixnum_p(&self, obj: VALUE) -> bool {
         unsafe { impl_fixnum_p(obj) }
+    }
+
+    #[inline]
+    fn gc_adjust_memory_usage(&self, diff: isize) {
+        unsafe { impl_gc_adjust_memory_usage(diff) }
     }
 
     #[inline]

--- a/crates/rb-sys/src/stable_api/compiled.rs
+++ b/crates/rb-sys/src/stable_api/compiled.rs
@@ -54,6 +54,12 @@ extern "C" {
     #[link_name = "impl_gc_adjust_memory_usage"]
     fn impl_gc_adjust_memory_usage(diff: isize);
 
+    #[link_name = "impl_gc_writebarrier"]
+    fn impl_gc_writebarrier(old: VALUE, young: VALUE);
+
+    #[link_name = "impl_gc_writebarrier_unprotect"]
+    fn impl_gc_writebarrier_unprotect(obj: VALUE);
+
     #[link_name = "impl_static_sym_p"]
     fn impl_static_sym_p(obj: VALUE) -> bool;
 
@@ -254,6 +260,16 @@ impl StableApiDefinition for Definition {
     #[inline]
     fn gc_adjust_memory_usage(&self, diff: isize) {
         unsafe { impl_gc_adjust_memory_usage(diff) }
+    }
+
+    #[inline]
+    fn gc_writebarrier(&self, old: VALUE, young: VALUE) {
+        unsafe { impl_gc_writebarrier(old, young) }
+    }
+
+    #[inline]
+    fn gc_writebarrier_unprotect(&self, obj: VALUE) {
+        unsafe { impl_gc_writebarrier_unprotect(obj) }
     }
 
     #[inline]

--- a/crates/rb-sys/src/stable_api/compiled.rs
+++ b/crates/rb-sys/src/stable_api/compiled.rs
@@ -51,6 +51,9 @@ extern "C" {
     #[link_name = "impl_fixnum_p"]
     fn impl_fixnum_p(obj: VALUE) -> bool;
 
+    #[link_name = "impl_gc_adjust_memory_usage"]
+    fn impl_gc_adjust_memory_usage(diff: isize);
+
     #[link_name = "impl_static_sym_p"]
     fn impl_static_sym_p(obj: VALUE) -> bool;
 
@@ -246,6 +249,11 @@ impl StableApiDefinition for Definition {
     #[inline]
     fn fixnum_p(&self, obj: VALUE) -> bool {
         unsafe { impl_fixnum_p(obj) }
+    }
+
+    #[inline]
+    fn gc_adjust_memory_usage(&self, diff: isize) {
+        unsafe { impl_gc_adjust_memory_usage(diff) }
     }
 
     #[inline]

--- a/crates/rb-sys/src/stable_api/ruby_2_6.rs
+++ b/crates/rb-sys/src/stable_api/ruby_2_6.rs
@@ -143,6 +143,11 @@ impl StableApiDefinition for Definition {
     }
 
     #[inline]
+    fn gc_adjust_memory_usage(&self, diff: isize) {
+        unsafe { crate::rb_gc_adjust_memory_usage(diff as _) };
+    }
+
+    #[inline]
     fn static_sym_p(&self, obj: VALUE) -> bool {
         let mask = !(VALUE::MAX << crate::ruby_special_consts::RUBY_SPECIAL_SHIFT as VALUE);
         (obj & mask) == crate::ruby_special_consts::RUBY_SYMBOL_FLAG as VALUE

--- a/crates/rb-sys/src/stable_api/ruby_2_6.rs
+++ b/crates/rb-sys/src/stable_api/ruby_2_6.rs
@@ -148,6 +148,16 @@ impl StableApiDefinition for Definition {
     }
 
     #[inline]
+    fn gc_writebarrier(&self, old: VALUE, young: VALUE) {
+        unsafe { crate::rb_gc_writebarrier(old, young) }
+    }
+
+    #[inline]
+    fn gc_writebarrier_unprotect(&self, obj: VALUE) {
+        unsafe { crate::rb_gc_writebarrier_unprotect(obj) }
+    }
+
+    #[inline]
     fn static_sym_p(&self, obj: VALUE) -> bool {
         let mask = !(VALUE::MAX << crate::ruby_special_consts::RUBY_SPECIAL_SHIFT as VALUE);
         (obj & mask) == crate::ruby_special_consts::RUBY_SYMBOL_FLAG as VALUE

--- a/crates/rb-sys/src/stable_api/ruby_2_7.rs
+++ b/crates/rb-sys/src/stable_api/ruby_2_7.rs
@@ -143,6 +143,11 @@ impl StableApiDefinition for Definition {
     }
 
     #[inline]
+    fn gc_adjust_memory_usage(&self, diff: isize) {
+        unsafe { crate::rb_gc_adjust_memory_usage(diff as _) };
+    }
+
+    #[inline]
     fn static_sym_p(&self, obj: VALUE) -> bool {
         let mask = !(VALUE::MAX << crate::ruby_special_consts::RUBY_SPECIAL_SHIFT as VALUE);
         (obj & mask) == crate::ruby_special_consts::RUBY_SYMBOL_FLAG as VALUE

--- a/crates/rb-sys/src/stable_api/ruby_2_7.rs
+++ b/crates/rb-sys/src/stable_api/ruby_2_7.rs
@@ -148,6 +148,16 @@ impl StableApiDefinition for Definition {
     }
 
     #[inline]
+    fn gc_writebarrier(&self, old: VALUE, young: VALUE) {
+        unsafe { crate::rb_gc_writebarrier(old, young) }
+    }
+
+    #[inline]
+    fn gc_writebarrier_unprotect(&self, obj: VALUE) {
+        unsafe { crate::rb_gc_writebarrier_unprotect(obj) }
+    }
+
+    #[inline]
     fn static_sym_p(&self, obj: VALUE) -> bool {
         let mask = !(VALUE::MAX << crate::ruby_special_consts::RUBY_SPECIAL_SHIFT as VALUE);
         (obj & mask) == crate::ruby_special_consts::RUBY_SYMBOL_FLAG as VALUE

--- a/crates/rb-sys/src/stable_api/ruby_2_7.rs
+++ b/crates/rb-sys/src/stable_api/ruby_2_7.rs
@@ -161,6 +161,16 @@ impl StableApiDefinition for Definition {
         unsafe { crate::rb_gc_adjust_memory_usage(diff as _) };
     }
 
+    #[inline(always)]
+    fn gc_writebarrier(&self, old: VALUE, young: VALUE) {
+        unsafe { crate::rb_gc_writebarrier(old, young) }
+    }
+
+    #[inline(always)]
+    fn gc_writebarrier_unprotect(&self, obj: VALUE) {
+        unsafe { crate::rb_gc_writebarrier_unprotect(obj) }
+    }
+
     #[inline]
     fn static_sym_p(&self, obj: VALUE) -> bool {
         let mask = !(VALUE::MAX << crate::ruby_special_consts::RUBY_SPECIAL_SHIFT as VALUE);

--- a/crates/rb-sys/src/stable_api/ruby_2_7.rs
+++ b/crates/rb-sys/src/stable_api/ruby_2_7.rs
@@ -156,6 +156,11 @@ impl StableApiDefinition for Definition {
         (obj & crate::FIXNUM_FLAG as VALUE) != 0
     }
 
+    #[inline(always)]
+    fn gc_adjust_memory_usage(&self, diff: isize) {
+        unsafe { crate::rb_gc_adjust_memory_usage(diff as _) };
+    }
+
     #[inline]
     fn static_sym_p(&self, obj: VALUE) -> bool {
         let mask = !(VALUE::MAX << crate::ruby_special_consts::RUBY_SPECIAL_SHIFT as VALUE);

--- a/crates/rb-sys/src/stable_api/ruby_3_0.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_0.rs
@@ -156,6 +156,16 @@ impl StableApiDefinition for Definition {
     }
 
     #[inline]
+    fn gc_writebarrier(&self, old: VALUE, young: VALUE) {
+        unsafe { crate::rb_gc_writebarrier(old, young) }
+    }
+
+    #[inline]
+    fn gc_writebarrier_unprotect(&self, obj: VALUE) {
+        unsafe { crate::rb_gc_writebarrier_unprotect(obj) }
+    }
+
+    #[inline]
     fn static_sym_p(&self, obj: VALUE) -> bool {
         let mask = !(VALUE::MAX << crate::ruby_special_consts::RUBY_SPECIAL_SHIFT as VALUE);
         (obj & mask) == crate::ruby_special_consts::RUBY_SYMBOL_FLAG as VALUE

--- a/crates/rb-sys/src/stable_api/ruby_3_0.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_0.rs
@@ -151,6 +151,11 @@ impl StableApiDefinition for Definition {
     }
 
     #[inline]
+    fn gc_adjust_memory_usage(&self, diff: isize) {
+        unsafe { crate::rb_gc_adjust_memory_usage(diff as _) };
+    }
+
+    #[inline]
     fn static_sym_p(&self, obj: VALUE) -> bool {
         let mask = !(VALUE::MAX << crate::ruby_special_consts::RUBY_SPECIAL_SHIFT as VALUE);
         (obj & mask) == crate::ruby_special_consts::RUBY_SYMBOL_FLAG as VALUE

--- a/crates/rb-sys/src/stable_api/ruby_3_0.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_0.rs
@@ -164,6 +164,11 @@ impl StableApiDefinition for Definition {
         (obj & crate::FIXNUM_FLAG as VALUE) != 0
     }
 
+    #[inline(always)]
+    fn gc_adjust_memory_usage(&self, diff: isize) {
+        unsafe { crate::rb_gc_adjust_memory_usage(diff as _) };
+    }
+
     #[inline]
     fn static_sym_p(&self, obj: VALUE) -> bool {
         let mask = !(VALUE::MAX << crate::ruby_special_consts::RUBY_SPECIAL_SHIFT as VALUE);

--- a/crates/rb-sys/src/stable_api/ruby_3_0.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_0.rs
@@ -169,6 +169,16 @@ impl StableApiDefinition for Definition {
         unsafe { crate::rb_gc_adjust_memory_usage(diff as _) };
     }
 
+    #[inline(always)]
+    fn gc_writebarrier(&self, old: VALUE, young: VALUE) {
+        unsafe { crate::rb_gc_writebarrier(old, young) }
+    }
+
+    #[inline(always)]
+    fn gc_writebarrier_unprotect(&self, obj: VALUE) {
+        unsafe { crate::rb_gc_writebarrier_unprotect(obj) }
+    }
+
     #[inline]
     fn static_sym_p(&self, obj: VALUE) -> bool {
         let mask = !(VALUE::MAX << crate::ruby_special_consts::RUBY_SPECIAL_SHIFT as VALUE);

--- a/crates/rb-sys/src/stable_api/ruby_3_1.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_1.rs
@@ -144,6 +144,11 @@ impl StableApiDefinition for Definition {
     }
 
     #[inline]
+    fn gc_adjust_memory_usage(&self, diff: isize) {
+        unsafe { crate::rb_gc_adjust_memory_usage(diff as _) };
+    }
+
+    #[inline]
     fn static_sym_p(&self, obj: VALUE) -> bool {
         let mask = !(VALUE::MAX << crate::ruby_special_consts::RUBY_SPECIAL_SHIFT as VALUE);
         (obj & mask) == crate::ruby_special_consts::RUBY_SYMBOL_FLAG as VALUE

--- a/crates/rb-sys/src/stable_api/ruby_3_1.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_1.rs
@@ -149,6 +149,16 @@ impl StableApiDefinition for Definition {
     }
 
     #[inline]
+    fn gc_writebarrier(&self, old: VALUE, young: VALUE) {
+        unsafe { crate::rb_gc_writebarrier(old, young) }
+    }
+
+    #[inline]
+    fn gc_writebarrier_unprotect(&self, obj: VALUE) {
+        unsafe { crate::rb_gc_writebarrier_unprotect(obj) }
+    }
+
+    #[inline]
     fn static_sym_p(&self, obj: VALUE) -> bool {
         let mask = !(VALUE::MAX << crate::ruby_special_consts::RUBY_SPECIAL_SHIFT as VALUE);
         (obj & mask) == crate::ruby_special_consts::RUBY_SYMBOL_FLAG as VALUE

--- a/crates/rb-sys/src/stable_api/ruby_3_1.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_1.rs
@@ -162,6 +162,16 @@ impl StableApiDefinition for Definition {
         unsafe { crate::rb_gc_adjust_memory_usage(diff as _) };
     }
 
+    #[inline(always)]
+    fn gc_writebarrier(&self, old: VALUE, young: VALUE) {
+        unsafe { crate::rb_gc_writebarrier(old, young) }
+    }
+
+    #[inline(always)]
+    fn gc_writebarrier_unprotect(&self, obj: VALUE) {
+        unsafe { crate::rb_gc_writebarrier_unprotect(obj) }
+    }
+
     #[inline]
     fn static_sym_p(&self, obj: VALUE) -> bool {
         let mask = !(VALUE::MAX << crate::ruby_special_consts::RUBY_SPECIAL_SHIFT as VALUE);

--- a/crates/rb-sys/src/stable_api/ruby_3_1.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_1.rs
@@ -157,6 +157,11 @@ impl StableApiDefinition for Definition {
         (obj & crate::FIXNUM_FLAG as VALUE) != 0
     }
 
+    #[inline(always)]
+    fn gc_adjust_memory_usage(&self, diff: isize) {
+        unsafe { crate::rb_gc_adjust_memory_usage(diff as _) };
+    }
+
     #[inline]
     fn static_sym_p(&self, obj: VALUE) -> bool {
         let mask = !(VALUE::MAX << crate::ruby_special_consts::RUBY_SPECIAL_SHIFT as VALUE);

--- a/crates/rb-sys/src/stable_api/ruby_3_2.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_2.rs
@@ -138,6 +138,11 @@ impl StableApiDefinition for Definition {
     }
 
     #[inline]
+    fn gc_adjust_memory_usage(&self, diff: isize) {
+        unsafe { crate::rb_gc_adjust_memory_usage(diff as _) };
+    }
+
+    #[inline]
     fn static_sym_p(&self, obj: VALUE) -> bool {
         let mask = !(VALUE::MAX << crate::ruby_special_consts::RUBY_SPECIAL_SHIFT as VALUE);
         (obj & mask) == crate::ruby_special_consts::RUBY_SYMBOL_FLAG as VALUE

--- a/crates/rb-sys/src/stable_api/ruby_3_2.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_2.rs
@@ -143,6 +143,16 @@ impl StableApiDefinition for Definition {
     }
 
     #[inline]
+    fn gc_writebarrier(&self, old: VALUE, young: VALUE) {
+        unsafe { crate::rb_gc_writebarrier(old, young) }
+    }
+
+    #[inline]
+    fn gc_writebarrier_unprotect(&self, obj: VALUE) {
+        unsafe { crate::rb_gc_writebarrier_unprotect(obj) }
+    }
+
+    #[inline]
     fn static_sym_p(&self, obj: VALUE) -> bool {
         let mask = !(VALUE::MAX << crate::ruby_special_consts::RUBY_SPECIAL_SHIFT as VALUE);
         (obj & mask) == crate::ruby_special_consts::RUBY_SYMBOL_FLAG as VALUE

--- a/crates/rb-sys/src/stable_api/ruby_3_2.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_2.rs
@@ -151,6 +151,11 @@ impl StableApiDefinition for Definition {
         (obj & crate::FIXNUM_FLAG as VALUE) != 0
     }
 
+    #[inline(always)]
+    fn gc_adjust_memory_usage(&self, diff: isize) {
+        unsafe { crate::rb_gc_adjust_memory_usage(diff as _) };
+    }
+
     #[inline]
     fn static_sym_p(&self, obj: VALUE) -> bool {
         let mask = !(VALUE::MAX << crate::ruby_special_consts::RUBY_SPECIAL_SHIFT as VALUE);

--- a/crates/rb-sys/src/stable_api/ruby_3_2.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_2.rs
@@ -156,6 +156,16 @@ impl StableApiDefinition for Definition {
         unsafe { crate::rb_gc_adjust_memory_usage(diff as _) };
     }
 
+    #[inline(always)]
+    fn gc_writebarrier(&self, old: VALUE, young: VALUE) {
+        unsafe { crate::rb_gc_writebarrier(old, young) }
+    }
+
+    #[inline(always)]
+    fn gc_writebarrier_unprotect(&self, obj: VALUE) {
+        unsafe { crate::rb_gc_writebarrier_unprotect(obj) }
+    }
+
     #[inline]
     fn static_sym_p(&self, obj: VALUE) -> bool {
         let mask = !(VALUE::MAX << crate::ruby_special_consts::RUBY_SPECIAL_SHIFT as VALUE);

--- a/crates/rb-sys/src/stable_api/ruby_3_3.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_3.rs
@@ -131,6 +131,11 @@ impl StableApiDefinition for Definition {
     }
 
     #[inline]
+    fn gc_adjust_memory_usage(&self, diff: isize) {
+        unsafe { crate::rb_gc_adjust_memory_usage(diff as _) };
+    }
+
+    #[inline]
     fn static_sym_p(&self, obj: VALUE) -> bool {
         let mask = !(VALUE::MAX << crate::ruby_special_consts::RUBY_SPECIAL_SHIFT as VALUE);
         (obj & mask) == crate::ruby_special_consts::RUBY_SYMBOL_FLAG as VALUE

--- a/crates/rb-sys/src/stable_api/ruby_3_3.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_3.rs
@@ -136,6 +136,16 @@ impl StableApiDefinition for Definition {
     }
 
     #[inline]
+    fn gc_writebarrier(&self, old: VALUE, young: VALUE) {
+        unsafe { crate::rb_gc_writebarrier(old, young) }
+    }
+
+    #[inline]
+    fn gc_writebarrier_unprotect(&self, obj: VALUE) {
+        unsafe { crate::rb_gc_writebarrier_unprotect(obj) }
+    }
+
+    #[inline]
     fn static_sym_p(&self, obj: VALUE) -> bool {
         let mask = !(VALUE::MAX << crate::ruby_special_consts::RUBY_SPECIAL_SHIFT as VALUE);
         (obj & mask) == crate::ruby_special_consts::RUBY_SYMBOL_FLAG as VALUE

--- a/crates/rb-sys/src/stable_api/ruby_3_3.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_3.rs
@@ -144,6 +144,11 @@ impl StableApiDefinition for Definition {
         (obj & crate::FIXNUM_FLAG as VALUE) != 0
     }
 
+    #[inline(always)]
+    fn gc_adjust_memory_usage(&self, diff: isize) {
+        unsafe { crate::rb_gc_adjust_memory_usage(diff as _) };
+    }
+
     #[inline]
     fn static_sym_p(&self, obj: VALUE) -> bool {
         let mask = !(VALUE::MAX << crate::ruby_special_consts::RUBY_SPECIAL_SHIFT as VALUE);

--- a/crates/rb-sys/src/stable_api/ruby_3_3.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_3.rs
@@ -149,6 +149,16 @@ impl StableApiDefinition for Definition {
         unsafe { crate::rb_gc_adjust_memory_usage(diff as _) };
     }
 
+    #[inline(always)]
+    fn gc_writebarrier(&self, old: VALUE, young: VALUE) {
+        unsafe { crate::rb_gc_writebarrier(old, young) }
+    }
+
+    #[inline(always)]
+    fn gc_writebarrier_unprotect(&self, obj: VALUE) {
+        unsafe { crate::rb_gc_writebarrier_unprotect(obj) }
+    }
+
     #[inline]
     fn static_sym_p(&self, obj: VALUE) -> bool {
         let mask = !(VALUE::MAX << crate::ruby_special_consts::RUBY_SPECIAL_SHIFT as VALUE);

--- a/crates/rb-sys/src/stable_api/ruby_3_4.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_4.rs
@@ -131,6 +131,21 @@ impl StableApiDefinition for Definition {
     }
 
     #[inline]
+    fn gc_adjust_memory_usage(&self, diff: isize) {
+        unsafe { crate::rb_gc_adjust_memory_usage(diff as _) };
+    }
+
+    #[inline]
+    fn gc_writebarrier(&self, old: VALUE, young: VALUE) {
+        unsafe { crate::rb_gc_writebarrier(old, young) }
+    }
+
+    #[inline]
+    fn gc_writebarrier_unprotect(&self, obj: VALUE) {
+        unsafe { crate::rb_gc_writebarrier_unprotect(obj) }
+    }
+
+    #[inline]
     fn static_sym_p(&self, obj: VALUE) -> bool {
         let mask = !(VALUE::MAX << crate::ruby_special_consts::RUBY_SPECIAL_SHIFT as VALUE);
         (obj & mask) == crate::ruby_special_consts::RUBY_SYMBOL_FLAG as VALUE
@@ -244,11 +259,6 @@ impl StableApiDefinition for Definition {
         } else {
             self.builtin_type(obj) == value_type::RUBY_T_BIGNUM
         }
-    }
-
-    #[inline]
-    fn gc_adjust_memory_usage(&self, diff: isize) {
-        unsafe { crate::rb_gc_adjust_memory_usage(diff as _) };
     }
 
     #[inline]

--- a/crates/rb-sys/src/stable_api/ruby_3_4.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_4.rs
@@ -247,6 +247,11 @@ impl StableApiDefinition for Definition {
     }
 
     #[inline]
+    fn gc_adjust_memory_usage(&self, diff: isize) {
+        unsafe { crate::rb_gc_adjust_memory_usage(diff as _) };
+    }
+
+    #[inline]
     unsafe fn rstring_interned_p(&self, obj: VALUE) -> bool {
         assert!(self.type_p(obj, value_type::RUBY_T_STRING));
 

--- a/crates/rb-sys/src/stable_api/ruby_3_4.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_4.rs
@@ -271,6 +271,11 @@ impl StableApiDefinition for Definition {
     }
 
     #[inline(always)]
+    fn gc_adjust_memory_usage(&self, diff: isize) {
+        unsafe { crate::rb_gc_adjust_memory_usage(diff as _) };
+    }
+
+    #[inline(always)]
     unsafe fn rstring_interned_p(&self, obj: VALUE) -> bool {
         debug_ruby_assert_type!(
             obj,

--- a/crates/rb-sys/src/stable_api/ruby_3_4.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_4.rs
@@ -151,6 +151,21 @@ impl StableApiDefinition for Definition {
     }
 
     #[inline(always)]
+    fn gc_adjust_memory_usage(&self, diff: isize) {
+        unsafe { crate::rb_gc_adjust_memory_usage(diff as _) };
+    }
+
+    #[inline(always)]
+    fn gc_writebarrier(&self, old: VALUE, young: VALUE) {
+        unsafe { crate::rb_gc_writebarrier(old, young) }
+    }
+
+    #[inline(always)]
+    fn gc_writebarrier_unprotect(&self, obj: VALUE) {
+        unsafe { crate::rb_gc_writebarrier_unprotect(obj) }
+    }
+
+    #[inline(always)]
     fn static_sym_p(&self, obj: VALUE) -> bool {
         const SPECIAL_MASK: VALUE =
             !(VALUE::MAX << crate::ruby_special_consts::RUBY_SPECIAL_SHIFT as VALUE);
@@ -268,11 +283,6 @@ impl StableApiDefinition for Definition {
         } else {
             self.fixnum_p(obj)
         }
-    }
-
-    #[inline(always)]
-    fn gc_adjust_memory_usage(&self, diff: isize) {
-        unsafe { crate::rb_gc_adjust_memory_usage(diff as _) };
     }
 
     #[inline(always)]

--- a/crates/rb-sys/src/stable_api/ruby_4_0.rs
+++ b/crates/rb-sys/src/stable_api/ruby_4_0.rs
@@ -271,6 +271,11 @@ impl StableApiDefinition for Definition {
     }
 
     #[inline(always)]
+    fn gc_adjust_memory_usage(&self, diff: isize) {
+        unsafe { crate::rb_gc_adjust_memory_usage(diff as _) };
+    }
+
+    #[inline(always)]
     unsafe fn rstring_interned_p(&self, obj: VALUE) -> bool {
         debug_ruby_assert_type!(
             obj,

--- a/crates/rb-sys/src/stable_api/ruby_4_0.rs
+++ b/crates/rb-sys/src/stable_api/ruby_4_0.rs
@@ -151,6 +151,21 @@ impl StableApiDefinition for Definition {
     }
 
     #[inline(always)]
+    fn gc_adjust_memory_usage(&self, diff: isize) {
+        unsafe { crate::rb_gc_adjust_memory_usage(diff as _) };
+    }
+
+    #[inline(always)]
+    fn gc_writebarrier(&self, old: VALUE, young: VALUE) {
+        unsafe { crate::rb_gc_writebarrier(old, young) }
+    }
+
+    #[inline(always)]
+    fn gc_writebarrier_unprotect(&self, obj: VALUE) {
+        unsafe { crate::rb_gc_writebarrier_unprotect(obj) }
+    }
+
+    #[inline(always)]
     fn static_sym_p(&self, obj: VALUE) -> bool {
         const SPECIAL_MASK: VALUE =
             !(VALUE::MAX << crate::ruby_special_consts::RUBY_SPECIAL_SHIFT as VALUE);
@@ -268,11 +283,6 @@ impl StableApiDefinition for Definition {
         } else {
             self.fixnum_p(obj)
         }
-    }
-
-    #[inline(always)]
-    fn gc_adjust_memory_usage(&self, diff: isize) {
-        unsafe { crate::rb_gc_adjust_memory_usage(diff as _) };
     }
 
     #[inline(always)]


### PR DESCRIPTION
Solves https://github.com/oxidize-rb/rb-sys/issues/447

Implemented:

- `StableApiDefinition::gc_adjust_memory_usage`.
- `StableApiDefinition::gc_writebarrier`.
- `StableApiDefinition::gc_writebarrier_unprotect`.

Note:

I have to tweak the testing macros so it would allow multiple arguments for the data_builder, in the meanwhile I just expanded the macro and tweaked it manually.