### PR TITLE
Define RUBY_DEBUG macro if undefined

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - "*docker*"
     tags:
       - v*
 

--- a/crates/rb-sys-build/src/bindings/wrapper.h
+++ b/crates/rb-sys-build/src/bindings/wrapper.h
@@ -69,9 +69,3 @@
 #ifdef HAVE_RUBY_IO_BUFFER_H
 #include "ruby/io/buffer.h"
 #endif
-
-#ifdef HAVE_RUBY_ASSERT_H
-#include "ruby/assert.h"
-#else
-# define RUBY_DEBUG 0
-#endif

--- a/crates/rb-sys-build/src/bindings/wrapper.h
+++ b/crates/rb-sys-build/src/bindings/wrapper.h
@@ -1,8 +1,5 @@
 #include "ruby.h"
 
-#ifdef HAVE_RUBY_ASSERT_H
-#include "ruby/assert.h"
-#endif
 #ifdef HAVE_RUBY_DEBUG_H
 #include "ruby/debug.h"
 #endif
@@ -71,4 +68,10 @@
 #endif
 #ifdef HAVE_RUBY_IO_BUFFER_H
 #include "ruby/io/buffer.h"
+#endif
+
+#ifdef HAVE_RUBY_ASSERT_H
+#include "ruby/assert.h"
+#else
+# define RUBY_DEBUG 0
 #endif

--- a/crates/rb-sys-build/src/bindings/wrapper.h
+++ b/crates/rb-sys-build/src/bindings/wrapper.h
@@ -1,5 +1,8 @@
 #include "ruby.h"
 
+#ifndef RUBY_DEBUG
+#endif
+
 #ifdef HAVE_RUBY_DEBUG_H
 #include "ruby/debug.h"
 #endif
@@ -68,4 +71,8 @@
 #endif
 #ifdef HAVE_RUBY_IO_BUFFER_H
 #include "ruby/io/buffer.h"
+#endif
+
+#if !defined(RUBY_DEBUG)
+#  define RUBY_DEBUG 0
 #endif

--- a/crates/rb-sys-build/src/bindings/wrapper.h
+++ b/crates/rb-sys-build/src/bindings/wrapper.h
@@ -1,8 +1,8 @@
 #include "ruby.h"
 
-#ifndef RUBY_DEBUG
+#ifdef HAVE_RUBY_ASSERT_H
+#include "ruby/assert.h"
 #endif
-
 #ifdef HAVE_RUBY_DEBUG_H
 #include "ruby/debug.h"
 #endif
@@ -71,8 +71,4 @@
 #endif
 #ifdef HAVE_RUBY_IO_BUFFER_H
 #include "ruby/io/buffer.h"
-#endif
-
-#if !defined(RUBY_DEBUG)
-#  define RUBY_DEBUG 0
 #endif

--- a/crates/rb-sys/src/stable_api/ruby_3_3.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_3.rs
@@ -292,8 +292,12 @@ impl StableApiDefinition for Definition {
 
         let rdata = obj as *const crate::internal::RTypedData;
         let typed_flag = (*rdata).typed_flag;
-        // TYPED_DATA_EMBEDDED (2) flag indicates embedded data
-        (typed_flag & (crate::TYPED_DATA_EMBEDDED as u64)) != 0
+        #[cfg(target_pointer_width = "64")]
+        const FLAG: u64 = crate::TYPED_DATA_EMBEDDED as u64;
+        #[cfg(target_pointer_width = "32")]
+        const FLAG: u32 = crate::TYPED_DATA_EMBEDDED as u32;
+
+        (typed_flag & FLAG) != 0
     }
 
     #[inline]

--- a/crates/rb-sys/src/stable_api/ruby_3_4.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_4.rs
@@ -3,7 +3,7 @@ use crate::{
     debug_ruby_assert_type,
     internal::{RArray, RString, RTypedData},
     ruby_value_type::RUBY_T_DATA,
-    value_type, TYPED_DATA_EMBEDDED, VALUE,
+    value_type, VALUE,
 };
 use std::{
     ffi::c_void,
@@ -293,8 +293,12 @@ impl StableApiDefinition for Definition {
 
         let rdata = obj as *const RTypedData;
         let typed_flag = (*rdata).typed_flag;
-        // TYPED_DATA_EMBEDDED (2) flag indicates embedded data
-        (typed_flag & (TYPED_DATA_EMBEDDED as u64)) != 0
+        #[cfg(target_pointer_width = "64")]
+        const FLAG: u64 = crate::TYPED_DATA_EMBEDDED as u64;
+        #[cfg(target_pointer_width = "32")]
+        const FLAG: u32 = crate::TYPED_DATA_EMBEDDED as u32;
+
+        (typed_flag & FLAG) != 0
     }
 
     #[inline]

--- a/crates/rb-sys/src/utils.rs
+++ b/crates/rb-sys/src/utils.rs
@@ -43,7 +43,7 @@ pub(crate) unsafe fn is_ruby_vm_started() -> bool {
 #[macro_export]
 macro_rules! debug_ruby_assert_type {
     ($obj:expr, $type:expr, $message:expr) => {
-        if $crate::RUBY_DEBUG != 0 {
+        if $crate::uncategorized::RUBY_DEBUG != 0 {
             #[allow(clippy::macro_metavars_in_unsafe)]
             unsafe {
                 assert!(

--- a/crates/rb-sys/src/utils.rs
+++ b/crates/rb-sys/src/utils.rs
@@ -53,6 +53,10 @@ macro_rules! debug_ruby_assert_type {
                 );
             }
         }
+        #[cfg(not(ruby_ruby_debug = "true"))]
+        {
+            let _ = ($obj, $type, $message); // Prevent unused variable warnings
+        }
     };
 }
 

--- a/crates/rb-sys/src/utils.rs
+++ b/crates/rb-sys/src/utils.rs
@@ -43,7 +43,8 @@ pub(crate) unsafe fn is_ruby_vm_started() -> bool {
 #[macro_export]
 macro_rules! debug_ruby_assert_type {
     ($obj:expr, $type:expr, $message:expr) => {
-        if $crate::uncategorized::RUBY_DEBUG != 0 {
+        #[cfg(ruby_ruby_debug = "true")]
+        {
             #[allow(clippy::macro_metavars_in_unsafe)]
             unsafe {
                 assert!(


### PR DESCRIPTION
Add a check and default definition for RUBY_DEBUG to ensure compatibility when RUBY_DEBUG is not already defined.