### PR TITLE
Fix compile errors with 32-bit platforms

### DIFF
--- a/crates/rb-sys/src/stable_api/ruby_3_3.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_3.rs
@@ -293,7 +293,7 @@ impl StableApiDefinition for Definition {
         let rdata = obj as *const crate::internal::RTypedData;
         let typed_flag = (*rdata).typed_flag;
         // TYPED_DATA_EMBEDDED (2) flag indicates embedded data
-        (typed_flag & (crate::TYPED_DATA_EMBEDDED as u64)) != 0
+        (typed_flag & (crate::TYPED_DATA_EMBEDDED as VALUE)) != 0
     }
 
     #[inline]

--- a/crates/rb-sys/src/stable_api/ruby_3_4.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_4.rs
@@ -294,7 +294,7 @@ impl StableApiDefinition for Definition {
         let rdata = obj as *const RTypedData;
         let typed_flag = (*rdata).typed_flag;
         // TYPED_DATA_EMBEDDED (2) flag indicates embedded data
-        (typed_flag & (TYPED_DATA_EMBEDDED as u64)) != 0
+        (typed_flag & (TYPED_DATA_EMBEDDED as VALUE)) != 0
     }
 
     #[inline]


### PR DESCRIPTION
AFter upgrading to rb-sys v0.9.113, we found that #530 doesn't compile on 32-bit platform because the typed_data is a VALUE type, but it was always casted to a 64-bit value.  Fix this by casting TYPED_DATA_EMBEDDED as a VALUE.

Closes https://github.com/oxidize-rb/rb-sys/issues/534