### PR TITLE
Handle panic when parsing literal

### DIFF
--- a/crates/rb-sys-build/src/bindings.rs
+++ b/crates/rb-sys-build/src/bindings.rs
@@ -241,7 +241,7 @@ impl<'a> ConfValue<'a> {
             Expr::Lit(ExprLit {
                 lit: Lit::Int(ref lit),
                 ..
-            }) => lit.base10_parse::<u8>().unwrap() != 0,
+            }) => lit.base10_parse::<u8>().unwrap_or(1) != 0,
             Expr::Lit(ExprLit {
                 lit: Lit::Bool(ref lit),
                 ..


### PR DESCRIPTION
I've noticed an error about a literal not fitting in a type in a build of mine. The error message is from [here](https://github.com/bytecodealliance/wasmtime-rb/actions/runs/15398850435/job/43326304223?pr=458#step:5:4860) and looks like:
>   thread 'main' panicked at C:\Users\runneradmin\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\rb-sys-build-0.9.115\src\bindings.rs:244:44:
>  called `Result::unwrap()` on an `Err` value: Error("number too large to fit in target type")

Defaulting to `1` seems sane given we want to coerce a value to a boolean.