### PR TITLE
Fix build on NetBSD

### DIFF
--- a/crates/rb-sys-build/src/bindings.rs
+++ b/crates/rb-sys-build/src/bindings.rs
@@ -139,6 +139,7 @@ fn default_bindgen(clang_args: Vec<String>) -> bindgen::Builder {
         .layout_tests(cfg!(feature = "bindgen-layout-tests"))
         .blocklist_item("^__darwin_pthread.*")
         .blocklist_item("^_opaque_pthread.*")
+        .blocklist_item("^__pthread_.*")
         .blocklist_item("^pthread_.*")
         .blocklist_item("^rb_native.*")
         .opaque_type("^__sFILE$")


### PR DESCRIPTION
NetBSD defines some symbols starting with "__pthread_" that are not captured by "^pthread_.*".