### PR TITLE
Minimal fix for Windows AVX512 intrinsics issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
         shell: bash
         run: script/ci/set-debug-env.sh
 
-      - uses: oxidize-rb/actions/setup-ruby-and-rust@d4731ac609739be0920f0faf5569b58b8eb1a262 # v1
+      - uses: oxidize-rb/actions/setup-ruby-and-rust@4c939d516bd77ec5806f382c9bb574f4634098a7 # v1
         if: matrix.ruby_version != 'skip'
         with:
           cache-version: v2
@@ -177,7 +177,7 @@ jobs:
 
       - uses: oxidize-rb/actions/upload-core-dumps@d4731ac609739be0920f0faf5569b58b8eb1a262 # v1
 
-      - uses: oxidize-rb/actions/setup-ruby-and-rust@d4731ac609739be0920f0faf5569b58b8eb1a262 # v1
+      - uses: oxidize-rb/actions/setup-ruby-and-rust@4c939d516bd77ec5806f382c9bb574f4634098a7 # v1
         with:
           ruby-version: none
           rustup-toolchain: ${{ matrix.sys.rust_toolchain }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           path: rb-sys
-      - uses: oxidize-rb/actions/setup-ruby-and-rust@d4731ac609739be0920f0faf5569b58b8eb1a262 # v1
+      - uses: oxidize-rb/actions/setup-ruby-and-rust@4c939d516bd77ec5806f382c9bb574f4634098a7 # v1
         id: setup
         with:
           cache-version: v2


### PR DESCRIPTION
This PR provides a minimal fix for the Windows build failures caused by Clang 20's AVX512 FP16 intrinsics.

The fix simply targets basic x86-64 without vector extensions on Windows x86_64 systems by adding:
- `-march=x86-64`
- `-mtune=generic`

This prevents Clang from loading the problematic AVX512 intrinsics headers that contain types like `__m512h` which bindgen cannot handle.