### PR TITLE
Refactor doctest workflow and unify jobs

### DIFF
--- a/.github/workflows/doctest.yml
+++ b/.github/workflows/doctest.yml
@@ -2,7 +2,7 @@ name: Documentation Tests
 
 on:
   push:
-    branches: [main]
+    branches: [main, doctest-stabilize]
     paths:
       - "docsite/docs/**/*.mdx"
       - "docsite/docs/**/*.md"

--- a/.github/workflows/doctest.yml
+++ b/.github/workflows/doctest.yml
@@ -4,83 +4,45 @@ on:
   push:
     branches: [main]
     paths:
-      - 'docsite/docs/**/*.mdx'
-      - 'docsite/docs/**/*.md'
-      - '.github/workflows/doctest.yml'
+      - "docsite/docs/**/*.mdx"
+      - "docsite/docs/**/*.md"
+      - ".github/workflows/doctest.yml"
   pull_request:
     paths:
-      - 'docsite/docs/**/*.mdx'
-      - 'docsite/docs/**/*.md'
-      - '.github/workflows/doctest.yml'
+      - "docsite/docs/**/*.mdx"
+      - "docsite/docs/**/*.md"
+      - ".github/workflows/doctest.yml"
 
 jobs:
   doctest:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        ruby: ['3.1', '3.2', '3.3']
-    
     steps:
-    - uses: actions/checkout@v4
-    
-    - name: Setup Ruby and Rust
-      uses: oxidize-rb/setup-ruby-and-rust@v1
-      with:
-        ruby-version: ${{ matrix.ruby }}
-        bundler-cache: true
-        rustup-toolchain: stable
-        rustup-components: clippy
-    
-    - name: Install dependencies
-      run: bundle install
-    
-    - name: Run doctests with clippy
-      run: bundle exec rake doctest:run
-    
-    - name: Test documentation builds
-      run: |
-        cd docsite
-        npm install
-        npm run build
+      - uses: actions/checkout@v4
 
-  link-check:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '18'
-    
-    - name: Install dependencies
-      run: |
-        cd docsite
-        npm install
-    
-    - name: Check for broken links
-      run: |
-        cd docsite
-        # Install markdown-link-check
-        npm install -g markdown-link-check
-        
-        # Check all markdown files
-        find docs -name "*.md" -o -name "*.mdx" | xargs -I {} markdown-link-check {} || true
-    
-    - name: Build documentation
-      run: |
-        cd docsite
-        npm run build
+      - name: Setup Ruby and Rust
+        uses: oxidize-rb/actions/setup-ruby-and-rust@v1
+        with:
+          ruby-version: "3.4"
+          bundler-cache: true
+          rustup-toolchain: stable
+          rustup-components: clippy
 
-  vale-prose:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    
-    - name: Vale Linting
-      uses: errata-ai/vale-action@v2
-      with:
-        files: docsite/docs
-        fail_on_error: false
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Run doctests
+        run: bundle exec rake doctest:run
+
+      - name: Build docs
+        run: bundle exec rake docsite:build
+
+      - name: Check for broken links
+        run: |
+          cd docsite
+          # Install markdown-link-check
+          npm install -g markdown-link-check
+
+          # Check all markdown files
+          find docs -name "*.md" -o -name "*.mdx" | xargs -I {} markdown-link-check {} || true

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'npm'
+          cache: "npm"
           cache-dependency-path: docsite/package-lock.json
 
       - name: Install dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
     "crates/rb-sys-build",
     "crates/rb-sys-env",
     "crates/rb-sys-test-helpers",
-    "crates/rb-sys-test-helpers-macros", "tmp/doctest",
+    "crates/rb-sys-test-helpers-macros",
 ]
 exclude = [
     "examples/rust_reverse/ext/rust_reverse",

--- a/docsite/DOCUMENTATION_OUTLINE.md
+++ b/docsite/DOCUMENTATION_OUTLINE.md
@@ -3,38 +3,46 @@
 ## Documentation Structure
 
 ### 1. Introduction (index page)
+
 - **Why Ruby + Rust?** - Clear benefits with real-world examples
 - **Success Stories** - Highlighting production gems using rb-sys
 - **Quick Demo** - Visual example showing Ruby calling Rust
 - **Documentation Roadmap** - Guide readers to the right section
 
 ### 2. Getting Started
+
 #### 2.1 Installation
+
 - Prerequisites check script
 - Platform-specific installation guides (macOS, Linux, Windows)
 - Docker option for quick experimentation
 - Troubleshooting common installation issues
 
 #### 2.2 Quick Start (15-minute goal)
+
 - Create your first Ruby gem with Rust
 - Step-by-step with visual progress indicators
 - Working example: String processing utility
 - Interactive verification steps
 
 #### 2.3 Core Concepts
+
 - Ruby's C API basics (simplified)
 - How rb-sys bridges Ruby and Rust
 - Magnus vs rb-sys (when to use each)
 - Memory ownership fundamentals
 
 ### 3. Building Extensions
+
 #### 3.1 Project Setup
+
 - Gem structure best practices
 - Cargo.toml configuration
 - extconf.rb patterns
 - Development workflow
 
 #### 3.2 Basic Patterns
+
 - Functions and methods
 - Working with strings
 - Numbers and basic types
@@ -42,6 +50,7 @@
 - Error handling
 
 #### 3.3 Advanced Patterns
+
 - Classes and modules
 - Instance variables
 - Callbacks and blocks
@@ -49,89 +58,110 @@
 - Threading and GVL
 
 ### 4. Memory Management Deep Dive
+
 #### 4.1 Understanding Ruby's GC
+
 - Mark and sweep basics
 - When and how to mark
 - Common pitfalls
 
 #### 4.2 Safe Rust Patterns
+
 - TypedData and DataTypeFunctions
 - RefCell and interior mutability
 - Avoiding memory leaks
 - Performance considerations
 
 ### 5. Real-World Patterns
+
 #### 5.1 String Processing
+
 - Efficient string handling
 - Encoding management
 - Zero-copy techniques
 - Buffer management
 
 #### 5.2 Data Structures
+
 - Wrapping Rust structs
 - Collections and iterators
 - Custom data types
 
 #### 5.3 Performance Optimization
+
 - Profiling techniques
 - GVL release strategies
 - Memory allocation patterns
 - Benchmarking
 
 ### 6. Testing and Debugging
+
 #### 6.1 Testing Strategies
+
 - Unit testing in Rust
 - Integration testing with Ruby
 - Memory leak detection
 - CI setup
 
 #### 6.2 Debugging Techniques
+
 - Common error messages
 - Using debuggers
 - Logging best practices
 - Crash investigation
 
 ### 7. Deployment
+
 #### 7.1 Building and Packaging
+
 - Release builds
 - Platform-specific gems
 - Source gems
 - Binary distribution
 
 #### 7.2 Cross-Compilation
+
 - rb-sys-dock usage
 - GitHub Actions setup
 - Platform matrix
 - Troubleshooting
 
 ### 8. API Reference
+
 #### 8.1 rb-sys Features
+
 - Feature flags
 - API stability
 - Version compatibility
 
 #### 8.2 Common APIs
+
 - Magnus API reference
 - rb-sys low-level APIs
 - Helper macros
 
 #### 8.3 Build Configuration
+
 - Environment variables
 - Cargo features
 - Compilation options
 
 ### 9. Migration Guide
+
 #### 9.1 From C Extensions
+
 - Mapping C patterns to Rust
 - Common conversions
 - Performance comparison
 
 #### 9.2 From Pure Ruby
+
 - Identifying bottlenecks
 - Incremental migration
 - Maintaining compatibility
 
 ### 10. Cookbook
+
 - Common recipes with full examples
 - Error handling patterns
 - Memory management patterns
@@ -139,12 +169,14 @@
 - Integration patterns
 
 ### 11. FAQ
+
 - Common questions
 - Troubleshooting guide
 - Performance myths
 - Security considerations
 
 ### 12. Contributing
+
 - Code of Conduct
 - Development setup
 - Testing guidelines
@@ -152,6 +184,7 @@
 - Release process
 
 ### 13. Glossary
+
 - Ruby + Rust terminology
 - Common acronyms
 - Technical terms

--- a/docsite/docs/api-reference/test-helpers.mdx
+++ b/docsite/docs/api-reference/test-helpers.mdx
@@ -57,13 +57,12 @@ mod tests {
         unsafe {
             let obj = rb_cObject;
             // Use a literal C string for tests
-            let name_ptr = b"test\0".as_ptr() as *const i8;
-            let value = rb_str_new_cstr(name_ptr);
+            let value = rb_str_new_cstr(c"test".as_ptr());
 
-            rb_iv_set(obj, b"@name\0".as_ptr() as *const _, value);
+            rb_iv_set(obj, c"@name".as_ptr() as *const _, value);
 
-            let result = rb_funcall(obj, rb_intern(b"instance_variable_get\0".as_ptr() as *const _), 1,
-                                    rb_str_new_cstr(b"@name\0".as_ptr() as *const _));
+            let result = rb_funcall(obj, rb_intern(c"instance_variable_get".as_ptr()), 1,
+                                    rb_str_new_cstr(c"@name".as_ptr()));
 
             assert_eq!(value, result);
         }

--- a/docsite/docs/basic-patterns.mdx
+++ b/docsite/docs/basic-patterns.mdx
@@ -178,7 +178,7 @@ Handle different encodings properly:
 ```rust
 use magnus::{RString, Error, Ruby};
 
-fn ensure_utf8(ruby: &Ruby, input: RString) -> Result<RString, Error> {
+fn ensure_utf8(_ruby: &Ruby, input: RString) -> Result<RString, Error> {
     // For this example, we'll assume the string is already in the correct encoding
     // In production code, you would use rb-sys directly for encoding operations
     Ok(input)
@@ -337,7 +337,7 @@ fn double_values(array: RArray) -> Result<RArray, Error> {
 ### Advanced Array Patterns
 
 ```rust
-use magnus::{RArray, Value, Error, RString, exception, TryConvert};
+use magnus::{RArray, Error, RString, exception, TryConvert};
 
 // Filter arrays
 fn select_strings(array: RArray) -> Result<RArray, Error> {

--- a/docsite/docs/classes-and-modules.mdx
+++ b/docsite/docs/classes-and-modules.mdx
@@ -251,7 +251,7 @@ For Ruby objects that need interior mutability:
 <LanguageCallout language="rust" title="Interior Mutability with RefCell">
 ```rust
 use std::cell::RefCell;
-use magnus::{function, method, prelude::*, Error, Ruby};
+use magnus::{Error};
 
 struct Counter {
     count: usize,
@@ -496,7 +496,7 @@ fn make_comparable(ruby: &Ruby) -> Result<RModule, Error> {
     }, 1))?;
 
     // Define methods that depend on <=>
-    module.define_method("==", method!(|ruby: &Ruby, rb_self: Value, other: Value| -> Result<bool, Error> {
+    module.define_method("==", method!(|_ruby: &Ruby, rb_self: Value, other: Value| -> Result<bool, Error> {
         let result: Value = rb_self.funcall("<=>", (other,))?;
         if result.is_nil() {
             Ok(false)
@@ -506,7 +506,7 @@ fn make_comparable(ruby: &Ruby) -> Result<RModule, Error> {
         }
     }, 1))?;
 
-    module.define_method(">", method!(|ruby: &Ruby, rb_self: Value, other: Value| -> Result<bool, Error> {
+    module.define_method(">", method!(|_ruby: &Ruby, rb_self: Value, other: Value| -> Result<bool, Error> {
         let result: Value = rb_self.funcall("<=>", (other,))?;
         if result.is_nil() {
             Ok(false)
@@ -516,7 +516,7 @@ fn make_comparable(ruby: &Ruby) -> Result<RModule, Error> {
         }
     }, 1))?;
 
-    module.define_method("<", method!(|ruby: &Ruby, rb_self: Value, other: Value| -> Result<bool, Error> {
+    module.define_method("<", method!(|_ruby: &Ruby, rb_self: Value, other: Value| -> Result<bool, Error> {
         let result: Value = rb_self.funcall("<=>", (other,))?;
         if result.is_nil() {
             Ok(false)

--- a/docsite/docs/cookbook.mdx
+++ b/docsite/docs/cookbook.mdx
@@ -66,7 +66,7 @@ fn batch_replace(text: String, patterns: Vec<(String, String)>) -> Result<String
 ### Parallel Array Processing
 
 ```rust
-use magnus::{RArray, Value, Error, TryConvert};
+use magnus::{RArray, Error, TryConvert};
 use rayon::prelude::*;
 use rb_sys::rb_thread_call_without_gvl;
 use std::os::raw::c_void;
@@ -287,7 +287,7 @@ fn sha256_raw(input: RString) -> Result<RString, Error> {
 ### Connection Pool Pattern
 
 ```rust
-use magnus::{class, Error, Ruby};
+use magnus::{Error};
 use std::sync::{Arc, Mutex};
 use once_cell::sync::Lazy;
 
@@ -341,7 +341,7 @@ impl DatabasePool {
 ### Simple URL Operations
 
 ```rust
-use magnus::{RString, RHash, Error};
+use magnus::{RHash, Error};
 use url::Url;
 
 fn parse_url_components(url_string: String) -> Result<RHash, Error> {
@@ -488,7 +488,7 @@ impl ThreadSafeCounter {
 ### Ruby-Style Enumerator
 
 ```rust
-use magnus::{class, block::Proc, RArray, Value, Error};
+use magnus::{block::Proc, RArray, Value, Error};
 
 #[magnus::wrap(class = "RangeIterator", free_immediately)]
 struct RangeIterator {

--- a/docsite/docs/core-concepts.mdx
+++ b/docsite/docs/core-concepts.mdx
@@ -318,7 +318,6 @@ rb-sys handles platform differences automatically:
 
 ```rust
 // rb-sys handles platform differences
-use rb_sys::VALUE;
 use magnus::RString;
 
 // Same code works on all platforms

--- a/docsite/docs/cross-platform.mdx
+++ b/docsite/docs/cross-platform.mdx
@@ -166,9 +166,6 @@ Cargo.toml supports platform-specific dependencies:
 [dependencies]
 # Common dependencies...
 
-[target.'cfg(target_os = "linux")'.dependencies]
-jemallocator = { version = "0.5", features = ["disable_initial_exec_tls"] }
-
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["winbase"] }
 
@@ -176,18 +173,6 @@ winapi = { version = "0.3", features = ["winbase"] }
 core-foundation = "0.9"
 ```
 
-### Example: System-specific Memory Allocation
-
-```rust
-#[cfg(target_os = "linux")]
-use jemallocator::Jemalloc;
-
-#[cfg(target_os = "linux")]
-#[global_allocator]
-static GLOBAL: Jemalloc = Jemalloc;
-
-// Rest of your code...
-```
 
 ## Using build.rs for Platform Detection
 
@@ -218,6 +203,7 @@ fn main() {
 Then in your code:
 
 ```rust
+// Note: These features would need to be defined in your Cargo.toml
 #[cfg(feature = "windows_specific")]
 fn platform_init() {
     // Windows initialization code

--- a/docsite/docs/development-approaches.mdx
+++ b/docsite/docs/development-approaches.mdx
@@ -53,13 +53,13 @@ unsafe extern "C" fn reverse(_: VALUE, s: VALUE) -> VALUE {
     let c_str = rb_string_value_cstr(&mut s_copy);
     let rust_str = match std::ffi::CStr::from_ptr(c_str).to_str() {
         Ok(s) => s,
-        Err(_) => return rb_str_new_cstr(b"\0".as_ptr() as *const i8),
+        Err(_) => return rb_str_new_cstr(c"".as_ptr()),
     };
     let reversed = rust_str.chars().rev().collect::<String>();
 
     let c_string = match CString::new(reversed) {
         Ok(s) => s,
-        Err(_) => return rb_str_new_cstr(b"\0".as_ptr() as *const i8),
+        Err(_) => return rb_str_new_cstr(c"".as_ptr()),
     };
     rb_str_new_cstr(c_string.as_ptr())
 }
@@ -346,7 +346,7 @@ unsafe extern "C" fn low_level(_: rb_sys::VALUE) -> rb_sys::VALUE {
     // Direct rb-sys implementation
     let c_string = match std::ffi::CString::new("Low level") {
         Ok(s) => s,
-        Err(_) => return rb_sys::rb_str_new_cstr(b"\0".as_ptr() as *const i8),
+        Err(_) => return rb_sys::rb_str_new_cstr(c"".as_ptr()),
     };
     rb_sys::rb_str_new_cstr(c_string.as_ptr())
 }

--- a/docsite/docs/faq.mdx
+++ b/docsite/docs/faq.mdx
@@ -131,12 +131,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 // In your code
-#[cfg(ruby_version = "3.0")]
+// rb-sys-env automatically sets Ruby version cfg flags
+#[cfg(ruby_gte_3_0)]
 fn ruby3_only_feature() {
     // Ruby 3.0+ only code
 }
 
-#[cfg(not(ruby_version = "3.0"))]
+#[cfg(not(ruby_gte_3_0))]
 fn ruby2_compat() {
     // Ruby 2.x compatible code
 }

--- a/docsite/docs/memory-management.mdx
+++ b/docsite/docs/memory-management.mdx
@@ -146,7 +146,7 @@ impl Person {
     }
 
     fn friend(&self) -> Option<Obj<Person>> {
-        self.0.borrow().friend.clone()
+        self.0.borrow().friend
     }
 }
 
@@ -512,15 +512,14 @@ fn efficient_string(ruby: &Ruby, data: &[u8]) -> RString {
 }
 
 // ALSO GOOD: Creating from string slice when UTF-8 is confirmed
-fn from_str(ruby: &Ruby, s: &str) -> RString {
+fn from_str(_ruby: &Ruby, s: &str) -> RString {
     RString::new(s)
 }
 
 // ALSO GOOD: Creating binary string with capacity then filling
-fn build_string(ruby: &Ruby, size: usize) -> RString {
-    let mut string = RString::with_capacity(size);
-    // Fill the string directly...
-    string
+fn build_string(_ruby: &Ruby, size: usize) -> RString {
+    // In a real implementation, you would fill the string here
+    RString::with_capacity(size)
 }
 ```
 

--- a/docsite/docs/project-setup.mdx
+++ b/docsite/docs/project-setup.mdx
@@ -191,6 +191,7 @@ rb-sys-env = "0.1"
 // ext/url_parser/src/lib.rs
 use magnus::{function, method, prelude::*, Error, Ruby};
 use url::Url;
+use std::fmt;
 
 // Simple URL wrapper class
 #[magnus::wrap(class = "UrlParser::URL")]
@@ -227,8 +228,14 @@ impl UrlWrapper {
     }
 
     // String representation of the URL
-    fn to_string(&self) -> String {
+    fn to_string_ruby(&self) -> String {
         self.inner.to_string()
+    }
+}
+
+impl fmt::Display for UrlWrapper {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.inner)
     }
 }
 
@@ -255,7 +262,7 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
     class.define_method("host", method!(UrlWrapper::host, 0))?;
     class.define_method("path", method!(UrlWrapper::path, 0))?;
     class.define_method("query", method!(UrlWrapper::query, 0))?;
-    class.define_method("to_s", method!(UrlWrapper::to_string, 0))?;
+    class.define_method("to_s", method!(UrlWrapper::to_string_ruby, 0))?;
 
     Ok(())
 }

--- a/docsite/docs/quick-start.mdx
+++ b/docsite/docs/quick-start.mdx
@@ -82,9 +82,11 @@ fn levenshtein_distance(s1: String, s2: String) -> usize {
     let len2 = s2.chars().count();
     let mut matrix = vec![vec![0; len2 + 1]; len1 + 1];
     
-    for i in 0..=len1 {
-        matrix[i][0] = i;
+    // Initialize first column
+    for (i, row) in matrix.iter_mut().enumerate() {
+        row[0] = i;
     }
+    // Initialize first row
     for j in 0..=len2 {
         matrix[0][j] = j;
     }

--- a/rakelib/doctest.rake
+++ b/rakelib/doctest.rake
@@ -1,8 +1,7 @@
 # rakelib/doctest.rake
 
-require 'rake'
-require 'fileutils'
-require 'open3'
+require "rake"
+require "fileutils"
 
 namespace :doctest do
   desc "Run documentation code examples tests"
@@ -13,14 +12,7 @@ namespace :doctest do
     FileUtils.mkdir_p(src_dir)
     puts "--- Created temporary directory for doctests at #{test_dir} ---"
 
-    # Set Ruby environment variables for the build process
-    # ruby_root = ENV['RUBY_ROOT'] || '/Users/ianks/.rubies/ruby-3.4.1'
-    # ruby_version = ENV['RUBY_VERSION'] || '3.4.1'
-    # ENV['RUBY_ROOT'] ||= ruby_root
-    # ENV['RUBY_VERSION'] ||= ruby_version
-    # ENV['PATH'] = "#{ruby_root}/bin:#{ENV['PATH']}"
-
-    files_to_check = ENV['FILE'] ? [ENV['FILE']] : Dir.glob("docsite/docs/**/*.{mdx,md}")
+    files_to_check = ENV["FILE"] ? [ENV["FILE"]] : Dir.glob("docsite/docs/**/*.{mdx,md}")
     rust_files = []
 
     # --- Rust Doctests ---
@@ -44,15 +36,15 @@ namespace :doctest do
       next if rust_code_blocks.empty?
 
       puts "Processing Rust in #{file}"
-      example_to_run = ENV['EXAMPLE'] ? ENV['EXAMPLE'].to_i - 1 : nil
+      example_to_run = ENV["EXAMPLE"] ? ENV["EXAMPLE"].to_i - 1 : nil
 
       rust_code_blocks.each_with_index do |rust_code, index|
         next if example_to_run && index != example_to_run
-        slug = file.gsub(/[^a-zA-Z0-9_]/, '_')
+        slug = file.gsub(/[^a-zA-Z0-9_]/, "_")
         rust_file_name = "#{slug}_#{index}.rs"
         rust_files << rust_file_name
         # Remove #[magnus::init] to avoid symbol conflicts in doctests
-        cleaned_code = rust_code.gsub(/^#\[magnus::init\]\s*\n/, '')
+        cleaned_code = rust_code.gsub(/^#\[magnus::init\]\s*\n/, "")
         File.write(File.join(src_dir, rust_file_name), cleaned_code)
       end
     end
@@ -65,106 +57,93 @@ namespace :doctest do
         file_content = File.read(File.join(src_dir, file))
         if file_content.include?("rb_sys_test_helpers")
           # Put test helpers in a test module
-          %Q(#[cfg(test)]\n#[path="#{file}"] mod #{module_name};)
+          %(#[cfg(test)]\n#[path="#{file}"] mod #{module_name};)
         else
-          %Q(#[path="#{file}"] mod #{module_name};)
+          %(#[path="#{file}"] mod #{module_name};)
         end
       end.join("\n")
       File.write(File.join(src_dir, "lib.rs"), lib_rs_content)
 
       cargo_toml_content = <<~EOF
-[package]
-name = "doctests"
-version = "0.1.0"
-edition = "2021"
-
-[workspace]
-
-[dependencies]
-magnus = { version = "0.6", features = ["rb-sys"] }
-rb-sys = "0.9"
-unicode-segmentation = "1.10"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-regex = "1.5"
-rayon = "1.5"
-csv = "1.1"
-sha2 = "0.10"
-hex = "0.4"
-image = "0.24"
-once_cell = "1.17"
-log = "0.4"
-env_logger = "0.9"
-criterion = "0.5"
-url = "2.5"
-lz4_flex = "0.11"
-
-[build-dependencies]
-rb-sys-env = { path = "../../crates/rb-sys-env" }
-
-[dev-dependencies]
-rb-sys-test-helpers = { path = "../../crates/rb-sys-test-helpers" }
-proptest = "1.0"
-
-[patch.crates-io]
-rb-sys = { path = "../../crates/rb-sys" }
+        [package]
+        name = "doctests"
+        version = "0.1.0"
+        edition = "2021"
+        
+        [workspace]
+        
+        [dependencies]
+        magnus = { version = "0.6", features = ["rb-sys"] }
+        rb-sys = "0.9"
+        unicode-segmentation = "1.10"
+        serde = { version = "1.0", features = ["derive"] }
+        serde_json = "1.0"
+        regex = "1.5"
+        rayon = "1.5"
+        csv = "1.1"
+        sha2 = "0.10"
+        hex = "0.4"
+        image = "0.24"
+        once_cell = "1.17"
+        log = "0.4"
+        env_logger = "0.9"
+        criterion = "0.5"
+        url = "2.5"
+        lz4_flex = "0.11"
+        
+        [build-dependencies]
+        rb-sys-env = { path = "../../crates/rb-sys-env" }
+        
+        [dev-dependencies]
+        rb-sys-test-helpers = { path = "../../crates/rb-sys-test-helpers" }
+        proptest = "1.0"
+        
+        [patch.crates-io]
+        rb-sys = { path = "../../crates/rb-sys" }
       EOF
       File.write(File.join(test_dir, "Cargo.toml"), cargo_toml_content)
-      
+
       # Create build.rs to handle macOS framework linking
       build_rs_content = <<~EOF
-use std::env;
-
-fn main() {
-    let target = env::var("TARGET").unwrap();
-    
-    // Link SystemConfiguration framework on macOS for reqwest
-    if target.contains("apple") {
-        println!("cargo:rustc-link-lib=framework=SystemConfiguration");
-        println!("cargo:rustc-link-lib=framework=CoreFoundation");
-        println!("cargo:rustc-link-lib=framework=Security");
-    }
-    
-    // Use rb-sys-env to set up Ruby linking
-    rb_sys_env::activate().unwrap();
-}
+        use std::env;
+        
+        fn main() -> Result<(), Box<dyn std::error::Error>> {
+            let target = env::var("TARGET")?;
+            
+            // Link SystemConfiguration framework on macOS for reqwest
+            if target.contains("apple") {
+                println!("cargo:rustc-link-lib=framework=SystemConfiguration");
+                println!("cargo:rustc-link-lib=framework=CoreFoundation");
+                println!("cargo:rustc-link-lib=framework=Security");
+            }
+            
+            // Use rb-sys-env to set up Ruby linking
+            rb_sys_env::activate()?;
+            Ok(())
+        }
       EOF
       File.write(File.join(test_dir, "build.rs"), build_rs_content)
 
       Dir.chdir(test_dir) do
-        _stdout, stderr, status = Open3.capture3("cargo", "check", "--all-targets")
+        sh("cargo", "check", "--all-targets")
+        puts "✅ All Rust examples compiled successfully."
 
-        if status.success?
-          puts "✅ All Rust examples compiled successfully."
-          
-          # Run clippy to check for lints
-          puts "--- Running clippy on Rust examples ---"
-          # For doctests, we allow warnings since many functions/variables are unused in examples
-          # We also allow some clippy lints that are too strict for documentation
-          _stdout, stderr, status = Open3.capture3("cargo", "clippy", "--all-targets", "--", 
-            "-A", "dead_code",
-            "-A", "unused_variables", 
-            "-A", "unused_imports",
-            "-A", "unused_mut",
-            "-A", "clippy::needless_range_loop",
-            "-A", "clippy::redundant_field_names",
-            "-A", "clippy::manual_c_str_literals",
-            "-W", "clippy::unwrap_used",
-            "-W", "clippy::expect_used"
-          )
-          
-          if status.success?
-            puts "✅ All Rust examples pass clippy checks."
-          else
-            puts "❌ Clippy found issues:"
-            puts stderr
-            exit 1
-          end
-        else
-          puts "❌ Rust compilation failed:"
-          puts stderr
-          exit 1
-        end
+        # Run clippy to check for lints
+        puts "--- Running clippy on Rust examples ---"
+
+        # For doctests, we allow warnings since many functions/variables are unused in examples
+        # We also allow some clippy lints that are too strict for documentation
+        sh("cargo", "clippy", "--all-targets", "--",
+          "-A", "dead_code",
+          "-A", "unused_variables",
+          "-A", "unused_imports",
+          "-A", "unused_mut",
+          "-A", "clippy::needless_range_loop",
+          "-A", "clippy::redundant_field_names",
+          "-A", "clippy::manual_c_str_literals",
+          "-D", "clippy::unwrap_used",
+          "-D", "clippy::expect_used")
+        puts "✅ All Rust examples pass clippy checks."
       end
     end
 
@@ -189,7 +168,7 @@ fn main() {
       next if ruby_code_blocks.empty?
 
       puts "Processing Ruby in #{file}"
-      example_to_run = ENV['EXAMPLE'] ? ENV['EXAMPLE'].to_i - 1 : nil
+      example_to_run = ENV["EXAMPLE"] ? ENV["EXAMPLE"].to_i - 1 : nil
 
       ruby_code_blocks.each_with_index do |ruby_code, index|
         next if example_to_run && index != example_to_run
@@ -198,16 +177,7 @@ fn main() {
         temp_ruby_file = File.join(test_dir, "temp_ruby_#{index}.rb")
         File.write(temp_ruby_file, ruby_code)
 
-        _stdout, stderr, status = Open3.capture3("ruby", "-c", temp_ruby_file)
-
-        if status.success?
-          puts "✅"
-        else
-          puts "❌"
-          puts "Ruby in #{file} (example ##{index + 1}) has syntax errors:"
-          puts stderr
-          exit 1
-        end
+        sh("ruby", "-c", temp_ruby_file)
       end
     end
 

--- a/rakelib/doctest.rake
+++ b/rakelib/doctest.rake
@@ -131,16 +131,10 @@ namespace :doctest do
         # Run clippy to check for lints
         puts "--- Running clippy on Rust examples ---"
 
-        # For doctests, we allow warnings since many functions/variables are unused in examples
-        # We also allow some clippy lints that are too strict for documentation
+        # Run clippy with strict checks
         sh("cargo", "clippy", "--all-targets", "--",
           "-A", "dead_code",
-          "-A", "unused_variables",
-          "-A", "unused_imports",
-          "-A", "unused_mut",
-          "-A", "clippy::needless_range_loop",
           "-A", "clippy::redundant_field_names",
-          "-A", "clippy::manual_c_str_literals",
           "-D", "clippy::unwrap_used",
           "-D", "clippy::expect_used")
         puts "✅ All Rust examples pass clippy checks."


### PR DESCRIPTION
Simplify the doctest GitHub Actions workflow by removing job matrix and separate jobs. Update Ruby version to 3.4 and Node.js to 20.
Combine doctests, doc build, and link checks into a single job for streamlined execution.