### PR TITLE
Fix PackageNotFoundError name in msg

### DIFF
--- a/gem/lib/rb_sys/error.rb
+++ b/gem/lib/rb_sys/error.rb
@@ -8,8 +8,8 @@ module RbSys
   class PackageNotFoundError < Error
     def initialize(name)
       msg = <<~MSG.chomp.tr("\n", " ")
-        Could not find Cargo package metadata for #{@name.inspect}. Please
-        check that #{@name.inspect} matches the crate name in your
+        Could not find Cargo package metadata for #{name.inspect}. Please
+        check that #{name.inspect} matches the crate name in your
         Cargo.toml."
       MSG
 


### PR DESCRIPTION
Simple:

    s/@name/name/

It used to always say

    [...] Could not find Cargo package metadata for metadata for nil. Please [...]

... obviously.