### PR TITLE
Support target-prefixed install_name_tool for cross-compilation

### DIFF
--- a/gem/lib/rb_sys/mkmf.rb
+++ b/gem/lib/rb_sys/mkmf.rb
@@ -286,9 +286,18 @@ module RbSys
     end
 
     def fixup_libnames
-      return unless find_executable("install_name_tool")
+      # Try to find install_name_tool, checking multiple possible names:
+      # 1. Native macOS install_name_tool
+      # 2. Target-prefixed version from osxcross (e.g., aarch64-apple-darwin-install_name_tool)
+      tool = if find_executable("install_name_tool")
+        "install_name_tool"
+      elsif find_executable("$(CARGO_BUILD_TARGET)-install_name_tool")
+        "$(CARGO_BUILD_TARGET)-install_name_tool"
+      else
+        return
+      end
 
-      '$(Q) install_name_tool -id "" $(DLLIB)'
+      %($(Q) #{tool} -id "" $(DLLIB))
     end
 
     def if_eq_stmt(a, b)


### PR DESCRIPTION
Improves `install_name_tool` detection to support cross-compilation with osxcross.

When cross-compiling for macOS, tools like osxcross prefix binaries with the target triple (e.g., `aarch64-apple-darwin-install_name_tool`). This change checks for both the native and target-prefixed versions of `install_name_tool`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)