### PR TITLE
Bump MSRV to 1.71

### DIFF
--- a/crates/rb-sys-build/Cargo.toml
+++ b/crates/rb-sys-build/Cargo.toml
@@ -6,7 +6,7 @@ description = "Build system for rb-sys"
 homepage = "https://github.com/oxidize-rb/rb-sys"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/oxidize-rb/rb-sys"
-rust-version = "1.65"
+rust-version = "1.71"
 
 [lib]
 bench = false

--- a/crates/rb-sys-env/Cargo.toml
+++ b/crates/rb-sys-env/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/oxidize-rb/rb-sys"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/oxidize-rb/rb-sys"
 readme = "readme.md"
-rust-version = "1.65"
+rust-version = "1.71"
 
 [lib]
 bench = false

--- a/crates/rb-sys-test-helpers-macros/Cargo.toml
+++ b/crates/rb-sys-test-helpers-macros/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/oxidize-rb/rb-sys"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/oxidize-rb/rb-sys"
 readme = "readme.md"
-rust-version = "1.65"
+rust-version = "1.71"
 
 [lib]
 proc-macro = true

--- a/crates/rb-sys-test-helpers/Cargo.toml
+++ b/crates/rb-sys-test-helpers/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/oxidize-rb/rb-sys"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/oxidize-rb/rb-sys"
 readme = "readme.md"
-rust-version = "1.65"
+rust-version = "1.71"
 
 [lib]
 bench = false

--- a/crates/rb-sys-tests/Cargo.toml
+++ b/crates/rb-sys-tests/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.9.117"
 edition = "2018"
 autotests = false
 publish = false
-rust-version = "1.65"
+rust-version = "1.71"
 
 [lib]
 bench = false

--- a/crates/rb-sys/Cargo.toml
+++ b/crates/rb-sys/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://github.com/oxidize-rb/rb-sys"
 license = "MIT OR Apache-2.0"
 links = "rb"
 repository = "https://github.com/oxidize-rb/rb-sys"
-rust-version = "1.65"
+rust-version = "1.71"
 
 [build-dependencies]
 rb-sys-build = { version = "0.9.117", path = "../rb-sys-build" }

--- a/data/toolchains.json
+++ b/data/toolchains.json
@@ -1,7 +1,7 @@
 {
   "policy": {
     "minimum-supported-ruby-version": "2.6",
-    "minimum-supported-rust-version": "1.65"
+    "minimum-supported-rust-version": "1.71"
   },
   "toolchains": [
     {

--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,7 @@ covers:
 ## Supported Toolchains
 
 - Ruby: <!-- toolchains .policy.minimum-supported-ruby-version -->2.6<!-- /toolchains -->+
-- Rust: <!-- toolchains .policy.minimum-supported-rust-version -->1.65<!-- /toolchains -->+
+- Rust: <!-- toolchains .policy.minimum-supported-rust-version -->1.71<!-- /toolchains -->+
 
 ## Real-World Examples
 


### PR DESCRIPTION
Updates minimum supported Rust version from 1.65 to 1.71 by following previous examples https://github.com/oxidize-rb/rb-sys/pull/362, https://github.com/oxidize-rb/rb-sys/pull/403.

This resolves CI failures in recent PRs:
https://github.com/oxidize-rb/rb-sys/pull/638

## Changes
- Updated `data/toolchains.json` MSRV policy to 1.71
- Updated `rust-version` in all Cargo.toml files (6 crates)
- Updated readme.md to reflect new MSRV

🤖 Generated with [Claude Code](https://claude.com/claude-code)