### PR TITLE
fix: Ignored `target` defined via cargo config file

### DIFF
--- a/gem/lib/rb_sys/cargo/config.rb
+++ b/gem/lib/rb_sys/cargo/config.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module RbSys
+  module Cargo
+    # Reads Cargo configuration files to extract build settings.
+    module Config
+      class << self
+        # Returns the build target from Cargo configuration files.
+        # Searches from start_dir up to root, then checks CARGO_HOME.
+        #
+        # @param start_dir [String] the directory to start searching from
+        # @return [String, nil] the target triple, or nil if not configured
+        def build_target(start_dir: Dir.pwd)
+          find_in_hierarchy(start_dir) || find_in_home
+        end
+
+        private
+
+        def find_in_hierarchy(dir)
+          dir = File.expand_path(dir)
+          while (parent = File.dirname(dir)) != dir
+            target = read_build_target(File.join(dir, ".cargo"))
+            return target if target
+            dir = parent
+          end
+          nil
+        end
+
+        def find_in_home
+          cargo_home = ENV["CARGO_HOME"] || File.join(Dir.home, ".cargo")
+          read_build_target(cargo_home)
+        rescue ArgumentError
+          # Dir.home can raise if HOME is not set
+          nil
+        end
+
+        def read_build_target(cargo_dir)
+          # Version without `.toml` is for cargo < 1.39
+          %w[config.toml config].each do |name|
+            path = File.join(cargo_dir, name)
+            next unless File.exist?(path)
+            target = parse_build_target(File.read(path))
+            return target if target
+          rescue Errno::EACCES, Errno::ENOENT
+            next
+          end
+          nil
+        end
+
+        def parse_build_target(content)
+          # That is a hacky way to avoid pulling a proper toml parser as a dependency
+          current_section = nil
+          content.each_line do |line|
+            line = line.sub(/#.*/, "").strip
+            next if line.empty?
+
+            if line =~ /^\["?([^\]"]+)"?\]/
+              current_section = $1.strip
+            elsif current_section.nil? && line =~ /^"?build"?\."?target"?\s*=\s*["']([^"']+)["']/
+              return $1
+            elsif current_section.nil? && line =~ /^"?build"?\s*=\s*\{[^}]*"?target"?\s*=\s*["']([^"']+)["']/
+              return $1
+            elsif current_section == "build" && line =~ /^"?target"?\s*=\s*["']([^"']+)["']/
+              return $1
+            end
+          end
+          nil
+        end
+      end
+    end
+  end
+end

--- a/gem/lib/rb_sys/cargo_builder.rb
+++ b/gem/lib/rb_sys/cargo_builder.rb
@@ -1,6 +1,7 @@
 require "rubygems/ext"
 require "rubygems/ext/builder"
 require_relative "cargo_builder/link_flag_converter"
+require_relative "cargo/config"
 
 module RbSys
   # A class to build a Ruby gem Cargo. Extracted from `rubygems` gem, with some modifications.
@@ -21,7 +22,7 @@ module RbSys
       @profile = ENV.fetch("RB_SYS_CARGO_PROFILE", :release).to_sym
       @env = {}
       @features = []
-      @target = ENV["CARGO_BUILD_TARGET"] || ENV["RUST_TARGET"]
+      @target = ENV["CARGO_BUILD_TARGET"] || ENV["RUST_TARGET"] || Cargo::Config.build_target
       @extra_rustc_args = []
       @extra_cargo_args = []
       @dry_run = true

--- a/gem/test/test_cargo_config.rb
+++ b/gem/test/test_cargo_config.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "minitest/mock"
+require "fileutils"
+require "rb_sys/cargo/config"
+
+class TestCargoConfig < Minitest::Test
+  def test_parse_section_style
+    assert_equal "aarch64-apple-darwin", parse("[build]\ntarget = \"aarch64-apple-darwin\"")
+  end
+
+  def test_parse_dotted_key_style
+    assert_equal "x86_64-unknown-linux-gnu", parse("build.target = \"x86_64-unknown-linux-gnu\"")
+  end
+
+  def test_parse_with_comment
+    assert_equal "aarch64-apple-darwin", parse("[build]\ntarget = \"aarch64-apple-darwin\" # M1")
+  end
+
+  def test_parse_ignores_wrong_section
+    assert_nil parse("[target.x86_64-unknown-linux-gnu]\ntarget = \"wrong\"")
+  end
+
+  def test_parse_single_quoted_string
+    assert_equal "aarch64-apple-darwin", parse("[build]\ntarget = 'aarch64-apple-darwin'")
+  end
+
+  def test_parse_inline_table
+    assert_equal "x86_64-unknown-linux-gnu", parse("build = { target = \"x86_64-unknown-linux-gnu\" }")
+  end
+
+  def test_parse_inline_table_target_not_first
+    assert_equal "aarch64-apple-darwin", parse("build = { jobs = 4, target = \"aarch64-apple-darwin\" }")
+  end
+
+  def test_parse_section_header_with_comment
+    assert_equal "x86_64", parse("[build] # build settings\ntarget = \"x86_64\"")
+  end
+
+  def test_parse_section_header_with_whitespace
+    assert_equal "x86_64", parse("[ build ]\ntarget = \"x86_64\"")
+  end
+
+  def test_parse_quoted_section_name
+    assert_equal "x86_64", parse("[\"build\"]\ntarget = \"x86_64\"")
+  end
+
+  def test_parse_quoted_key
+    assert_equal "x86_64", parse("[build]\n\"target\" = \"x86_64\"")
+  end
+
+  def test_finds_config_in_ancestor
+    with_tmpdir do |dir|
+      child = File.join(dir, "a", "b")
+      FileUtils.mkdir_p(child)
+      write_config(dir, "from-ancestor")
+      assert_equal "from-ancestor", isolated_build_target(child)
+    end
+  end
+
+  def test_closer_config_wins
+    with_tmpdir do |dir|
+      child = File.join(dir, "child")
+      FileUtils.mkdir_p(child)
+      write_config(dir, "parent")
+      write_config(child, "child")
+      assert_equal "child", isolated_build_target(child)
+    end
+  end
+
+  def test_config_toml_preferred_over_config
+    with_tmpdir do |dir|
+      cargo_dir = File.join(dir, ".cargo")
+      FileUtils.mkdir_p(cargo_dir)
+      File.write(File.join(cargo_dir, "config.toml"), "[build]\ntarget = \"toml\"")
+      File.write(File.join(cargo_dir, "config"), "[build]\ntarget = \"legacy\"")
+      assert_equal "toml", isolated_build_target(dir)
+    end
+  end
+
+  def test_checks_cargo_home_env
+    with_tmpdir do |dir|
+      write_config(dir, "from-cargo-home")
+      ENV["CARGO_HOME"] = File.join(dir, ".cargo")
+      RbSys::Cargo::Config.stub(:find_in_hierarchy, nil) do
+        Dir.mktmpdir do |empty_dir|
+          assert_equal "from-cargo-home", RbSys::Cargo::Config.build_target(start_dir: empty_dir)
+        end
+      end
+    ensure
+      ENV.delete("CARGO_HOME")
+    end
+  end
+
+  private
+
+  def parse(content)
+    RbSys::Cargo::Config.send(:parse_build_target, content)
+  end
+
+  def write_config(dir, target)
+    cargo_dir = File.join(dir, ".cargo")
+    FileUtils.mkdir_p(cargo_dir)
+    File.write(File.join(cargo_dir, "config.toml"), "[build]\ntarget = \"#{target}\"")
+  end
+
+  def with_tmpdir
+    Dir.mktmpdir { |dir| yield dir }
+  end
+
+  def isolated_build_target(start_dir)
+    RbSys::Cargo::Config.stub(:find_in_home, nil) do
+      RbSys::Cargo::Config.build_target(start_dir: start_dir)
+    end
+  end
+end


### PR DESCRIPTION
Fixes #568 

Besides these tests, I've checked it with the `rust_reverse` example by adding `examples/rust_reverse/ext/rust_reverse/.cargo/config.toml`:

```
[build]
target = "x86_64-unknown-linux-gnu"
```

and building it.

I am very sorry for parsing toml with regexes :( Let me know if it would be better to pull the proper parser as a dependency (as per my understanding, no external dependencies is one of the goals?) - I also saw that the package name is parsed with a regex already (as a fallback). As of now, `cargo config` is unstable :(

P.S. I think that if a benchmark is defined first in `Cargo.toml`, then the name inference would take that instead of the package name