### PR TITLE
Fix parallel make race condition with gemclean

### DIFF
--- a/gem/lib/rb_sys/mkmf.rb
+++ b/gem/lib/rb_sys/mkmf.rb
@@ -141,11 +141,11 @@ module RbSys
         \t$(Q) $(MAKEDIRS) $(RUBYARCHDIR)
         \t$(INSTALL_PROG) $(DLLIB) $(RUBYARCHDIR)
 
-        gemclean:
+        gemclean: install-so
         \t$(ECHO) Cleaning gem artifacts
         \t-$(Q)$(RM_RF) $(RUBYGEMS_CLEAN_DIRS) 2> /dev/null || true
 
-        install: #{builder.clean_after_install ? "install-so gemclean" : "install-so"}
+        install: #{builder.clean_after_install ? "gemclean" : "install-so"}
 
         all: #{$extout ? "install" : "$(DLLIB)"}
       MAKE


### PR DESCRIPTION
Ruby 3.4 includes RubyGems that sets MAKEFLAGS=-j by default, enabling parallel make execution. This caused a race condition where `install-so` (which runs cargo) and `gemclean` (which deletes target/) could run simultaneously, causing cargo to fail when writing to files that gemclean just deleted.

Fix by making gemclean explicitly depend on install-so, ensuring proper ordering regardless of parallel execution.