### PR TITLE
✨ feat: add Ruby 4.1 version support for ruby-head compatibility

### DIFF
--- a/crates/rb-sys-env/src/ruby_version.rs
+++ b/crates/rb-sys-env/src/ruby_version.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 const COMPARABLE_RUBY_MAJORS: [u8; 4] = [1, 2, 3, 4];
 
-const COMPARABLE_RUBY_MINORS: [(u8, u8); 11] = [
+const COMPARABLE_RUBY_MINORS: [(u8, u8); 13] = [
     (2, 2),
     (2, 3),
     (2, 4),
@@ -14,6 +14,8 @@ const COMPARABLE_RUBY_MINORS: [(u8, u8); 11] = [
     (3, 2),
     (3, 3),
     (3, 4),
+    (4, 0),
+    (4, 1),
 ];
 
 /// The current Ruby version.

--- a/crates/rb-sys/build/main.rs
+++ b/crates/rb-sys/build/main.rs
@@ -13,7 +13,7 @@ use std::{
 };
 use version::Version;
 
-const SUPPORTED_RUBY_VERSIONS: [Version; 11] = [
+const SUPPORTED_RUBY_VERSIONS: [Version; 12] = [
     Version::new(2, 3),
     Version::new(2, 4),
     Version::new(2, 5),
@@ -25,6 +25,7 @@ const SUPPORTED_RUBY_VERSIONS: [Version; 11] = [
     Version::new(3, 3),
     Version::new(3, 4),
     Version::new(4, 0),
+    Version::new(4, 1),
 ];
 
 fn main() {


### PR DESCRIPTION
# Description

This PR adds Ruby 4.1 to the supported version arrays, enabling version-based cfg flags for Ruby head compatibility.

# Changes

1. **`crates/rb-sys/build/main.rs`**
   - Added `Version::new(4, 1)` to `SUPPORTED_RUBY_VERSIONS` array
   - Updated array size from 11 to 12

2. **`crates/rb-sys-env/src/ruby_version.rs`**
   - Added `(4, 0)` and `(4, 1)` to `COMPARABLE_RUBY_MINORS` array
   - Updated array size from 11 to 13

## New cfg flags available

After this change, the following cfg flags will be available when building with Ruby 4.1:

- `ruby_lt_4_1` / `ruby_lte_4_1` / `ruby_eq_4_1` / `ruby_gte_4_1` / `ruby_gt_4_1`
- `ruby_4_1` / `ruby_4_1_0` (etc.)

# Motivation

Ruby 4.1 (ruby-head) introduces breaking changes in the Ruby C API that require conditional compilation in dependent crates. Specifically, `rb_data_type_struct__bindgen_ty_1` replaced the `reserved` field with `handle_weak_references`.

This change enables crates like `magnus` to properly support both Ruby < 4.1 and Ruby >= 4.1.

# Testing

- [x] Builds successfully with Ruby 4.0.0
- [x] Enables proper cfg flag detection for Ruby 4.1
- [x] Backward compatible with all existing supported Ruby versions

Closes #696