### PR TITLE
Replace shell `which` calls with pure Ruby executable lookup in `rb-sys-dock`

### DIFF
--- a/docsite/docs/api-reference/rb-sys-features.mdx
+++ b/docsite/docs/api-reference/rb-sys-features.mdx
@@ -26,7 +26,7 @@ The following features can be enabled in your `Cargo.toml`.
 | `stable-api`               | Uses Ruby's C-level stable API if available for your Ruby version.               |         |
 | `bindgen-rbimpls`          | Includes internal Ruby implementation types in the generated bindings.           |         |
 | `bindgen-deprecated-types` | Includes deprecated Ruby functions and types in the bindings.                    |         |
-| `gc-stress`                | Wraps all Ruby C API functions with `rb_gc_start()` calls to smoke out GC bugs. |         |
+| `gc-stress`                | Wraps all Ruby C API functions with `rb_gc_start()` calls to smoke out GC bugs.  |         |
 
 ## Usage Examples
 
@@ -66,6 +66,7 @@ rb-sys = { version = "0.9", features = ["gc-stress"] }
 ```
 
 The following functions are excluded from wrapping to avoid infinite recursion:
+
 - `rb_gc_*` functions (GC internals)
 - `ruby_x*` functions (memory allocators called during GC)
 - Variadic functions (cannot forward varargs in Rust)

--- a/gem/exe/rb-sys-dock
+++ b/gem/exe/rb-sys-dock
@@ -154,17 +154,42 @@ OptionParser.new do |opts|
   end
 end.parse!
 
+def find_executable(name)
+  executable_file = ->(path) {
+    stat = begin
+      File.stat(path)
+    rescue
+      nil
+    end
+    path if stat&.file? && stat.executable?
+  }
+
+  # On Windows, PATHEXT lists the extensions that make a file executable
+  exts = ENV["PATHEXT"]&.split(File::PATH_SEPARATOR)&.map(&:downcase)
+
+  try_path = ->(path) {
+    executable_file.call(path) || exts&.lazy&.filter_map { |ext| executable_file.call(path + ext) }&.first
+  }
+
+  # Handle absolute/explicit paths without a PATH search
+  return try_path.call(name) if File.expand_path(name) == name
+
+  path_dirs = ENV.fetch("PATH", "/usr/local/bin:/usr/bin:/bin").split(File::PATH_SEPARATOR)
+  path_dirs.each do |dir|
+    dir = dir.sub(/\A"(.*)"\z/m, '\1') if /mswin|mingw/i.match?(RbConfig::CONFIG["host_os"])
+    found = try_path.call(File.join(dir, name))
+    return found if found
+  end
+  nil
+end
+
 def default_docker_command
   return @default_docker_command if defined?(@default_docker_command)
 
   @default_docker_command = ENV.fetch("DOCKER") do
-    if !(docker = `which docker`).empty?
-      docker.strip
-    elsif !(podman = `which podman`).empty?
-      podman.strip
-    else
+    find_executable("docker") ||
+      find_executable("podman") ||
       logger.fatal("Could not find docker or podman command, please install one of them")
-    end
   end
 end
 


### PR DESCRIPTION
Previously, `rb-sys-dock` used backtick `which docker` / `which podman` calls to locate the container runtime, which was [triggering a Socket.dev "Shell Access" alert](https://socket.dev/rubygems/package/rb_sys/overview/0.9.126?platform=ruby) on the gem. This replaces them with a pure Ruby `find_executable` helper that walks `$PATH` using `File.stat` -- same semantics, no shell subprocess. Also handles Windows `PATHEXT` extensions and quoted path entries while we're at it.