### PR TITLE
Correct optional arguments to nilable arguments

### DIFF
--- a/docsite/docs/basic-patterns.mdx
+++ b/docsite/docs/basic-patterns.mdx
@@ -168,16 +168,16 @@ fn might_fail(should_fail: bool) -> Result<(), MyError> {
 }
 ```
 
-## Optional Arguments & Blocks
+## Nilable Arguments & Blocks
 
-### Optional Arguments
+### Nilable Arguments
 
-Use `Option<T>` for optional arguments. For keyword arguments, accept an `RHash`.
+Use `Option<T>` for nilable arguments. For keyword arguments, accept an `RHash`.
 
 ```rust
 use magnus::{RHash, Error, TryConvert};
 
-// `greeting` will be `None` if the argument is omitted or `nil`.
+// `greeting` will be `None` if the argument is `nil`.
 fn greet(name: String, greeting: Option<String>) -> String {
     format!("{}, {}!", greeting.unwrap_or_else(|| "Hello".to_string()), name)
 }


### PR DESCRIPTION
It seems that `Option<T>` does not allow omitting arguments. It's still possible to pass `nil` in Ruby.

Later, it would be nice to include an explanation of [scan_args](https://docs.rs/magnus/latest/magnus/scan_args/fn.scan_args.html)￼.