### PR TITLE
Remove `json` from runtime dependencies

### DIFF
--- a/gem/rb_sys.gemspec
+++ b/gem/rb_sys.gemspec
@@ -27,8 +27,6 @@ Gem::Specification.new do |spec|
     spec.signing_key = File.expand_path("~/.ssh/gem-private_key.pem") if $0.end_with?("gem")
   end
 
-  spec.add_dependency("json", ">= 2")
-
   # Needed for `RakeCompilerDock.cross_rubies`
   spec.add_dependency("rake-compiler-dock", "1.11.0")
 


### PR DESCRIPTION
The json gem is bundled as a default gem since Ruby 1.9, so there is no need to declare it as an explicit runtime dependency.

Removing it avoids unnecessary native compilation of the `json` gem on every `rb_sys` install.