### PR TITLE
perf(stable-api): inline encoding_get for MRI stable versions

### DIFF
--- a/crates/rb-sys/src/stable_api/ruby_2_7.rs
+++ b/crates/rb-sys/src/stable_api/ruby_2_7.rs
@@ -527,9 +527,21 @@ impl StableApiDefinition for Definition {
 
     #[inline]
     unsafe fn encoding_get(&self, obj: VALUE) -> std::os::raw::c_int {
-        // Delegate to the exported rb_enc_get_index, which handles both the
-        // inline-encoded and out-of-line (ivar) cases correctly, and is stable
-        // across Ruby versions where the inline-bit offset varies.
-        crate::rb_enc_get_index(obj)
+        // Fast path: encoding index is stored inline in the flags when
+        // < RUBY_ENCODING_INLINE_MAX (0x7f). Only fall back to the libruby
+        // function for out-of-line encodings (rare in practice).
+        // Matches CRuby's `ENCODING_GET` inline function semantics.
+        let rbasic = obj as *const crate::RBasic;
+        let flags = (*rbasic).flags;
+        let shift = crate::ruby_encoding_consts::RUBY_ENCODING_SHIFT as u32;
+        let inline_max =
+            crate::ruby_encoding_consts::RUBY_ENCODING_INLINE_MAX as std::os::raw::c_int;
+        let mask = crate::ruby_encoding_consts::RUBY_ENCODING_MASK as VALUE;
+        let inline_idx = ((flags & mask) >> shift) as std::os::raw::c_int;
+        if inline_idx == inline_max {
+            crate::rb_enc_get_index(obj)
+        } else {
+            inline_idx
+        }
     }
 }

--- a/crates/rb-sys/src/stable_api/ruby_3_0.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_0.rs
@@ -530,9 +530,21 @@ impl StableApiDefinition for Definition {
 
     #[inline]
     unsafe fn encoding_get(&self, obj: VALUE) -> std::os::raw::c_int {
-        // Delegate to the exported rb_enc_get_index, which handles both the
-        // inline-encoded and out-of-line (ivar) cases correctly, and is stable
-        // across Ruby versions where the inline-bit offset varies.
-        crate::rb_enc_get_index(obj)
+        // Fast path: encoding index is stored inline in the flags when
+        // < RUBY_ENCODING_INLINE_MAX (0x7f). Only fall back to the libruby
+        // function for out-of-line encodings (rare in practice).
+        // Matches CRuby's `ENCODING_GET` inline function semantics.
+        let rbasic = obj as *const crate::RBasic;
+        let flags = (*rbasic).flags;
+        let shift = crate::ruby_encoding_consts::RUBY_ENCODING_SHIFT as u32;
+        let inline_max =
+            crate::ruby_encoding_consts::RUBY_ENCODING_INLINE_MAX as std::os::raw::c_int;
+        let mask = crate::ruby_encoding_consts::RUBY_ENCODING_MASK as VALUE;
+        let inline_idx = ((flags & mask) >> shift) as std::os::raw::c_int;
+        if inline_idx == inline_max {
+            crate::rb_enc_get_index(obj)
+        } else {
+            inline_idx
+        }
     }
 }

--- a/crates/rb-sys/src/stable_api/ruby_3_1.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_1.rs
@@ -523,9 +523,21 @@ impl StableApiDefinition for Definition {
 
     #[inline]
     unsafe fn encoding_get(&self, obj: VALUE) -> std::os::raw::c_int {
-        // Delegate to the exported rb_enc_get_index, which handles both the
-        // inline-encoded and out-of-line (ivar) cases correctly, and is stable
-        // across Ruby versions where the inline-bit offset varies.
-        crate::rb_enc_get_index(obj)
+        // Fast path: encoding index is stored inline in the flags when
+        // < RUBY_ENCODING_INLINE_MAX (0x7f). Only fall back to the libruby
+        // function for out-of-line encodings (rare in practice).
+        // Matches CRuby's `ENCODING_GET` inline function semantics.
+        let rbasic = obj as *const crate::RBasic;
+        let flags = (*rbasic).flags;
+        let shift = crate::ruby_encoding_consts::RUBY_ENCODING_SHIFT as u32;
+        let inline_max =
+            crate::ruby_encoding_consts::RUBY_ENCODING_INLINE_MAX as std::os::raw::c_int;
+        let mask = crate::ruby_encoding_consts::RUBY_ENCODING_MASK as VALUE;
+        let inline_idx = ((flags & mask) >> shift) as std::os::raw::c_int;
+        if inline_idx == inline_max {
+            crate::rb_enc_get_index(obj)
+        } else {
+            inline_idx
+        }
     }
 }

--- a/crates/rb-sys/src/stable_api/ruby_3_2.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_2.rs
@@ -521,9 +521,21 @@ impl StableApiDefinition for Definition {
 
     #[inline]
     unsafe fn encoding_get(&self, obj: VALUE) -> std::os::raw::c_int {
-        // Delegate to the exported rb_enc_get_index, which handles both the
-        // inline-encoded and out-of-line (ivar) cases correctly, and is stable
-        // across Ruby versions where the inline-bit offset varies.
-        crate::rb_enc_get_index(obj)
+        // Fast path: encoding index is stored inline in the flags when
+        // < RUBY_ENCODING_INLINE_MAX (0x7f). Only fall back to the libruby
+        // function for out-of-line encodings (rare in practice).
+        // Matches CRuby's `ENCODING_GET` inline function semantics.
+        let rbasic = obj as *const crate::RBasic;
+        let flags = (*rbasic).flags;
+        let shift = crate::ruby_encoding_consts::RUBY_ENCODING_SHIFT as u32;
+        let inline_max =
+            crate::ruby_encoding_consts::RUBY_ENCODING_INLINE_MAX as std::os::raw::c_int;
+        let mask = crate::ruby_encoding_consts::RUBY_ENCODING_MASK as VALUE;
+        let inline_idx = ((flags & mask) >> shift) as std::os::raw::c_int;
+        if inline_idx == inline_max {
+            crate::rb_enc_get_index(obj)
+        } else {
+            inline_idx
+        }
     }
 }

--- a/crates/rb-sys/src/stable_api/ruby_3_3.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_3.rs
@@ -533,9 +533,21 @@ impl StableApiDefinition for Definition {
 
     #[inline]
     unsafe fn encoding_get(&self, obj: VALUE) -> std::os::raw::c_int {
-        // Delegate to the exported rb_enc_get_index, which handles both the
-        // inline-encoded and out-of-line (ivar) cases correctly, and is stable
-        // across Ruby versions where the inline-bit offset varies.
-        crate::rb_enc_get_index(obj)
+        // Fast path: encoding index is stored inline in the flags when
+        // < RUBY_ENCODING_INLINE_MAX (0x7f). Only fall back to the libruby
+        // function for out-of-line encodings (rare in practice).
+        // Matches CRuby's `ENCODING_GET` inline function semantics.
+        let rbasic = obj as *const crate::RBasic;
+        let flags = (*rbasic).flags;
+        let shift = crate::ruby_encoding_consts::RUBY_ENCODING_SHIFT as u32;
+        let inline_max =
+            crate::ruby_encoding_consts::RUBY_ENCODING_INLINE_MAX as std::os::raw::c_int;
+        let mask = crate::ruby_encoding_consts::RUBY_ENCODING_MASK as VALUE;
+        let inline_idx = ((flags & mask) >> shift) as std::os::raw::c_int;
+        if inline_idx == inline_max {
+            crate::rb_enc_get_index(obj)
+        } else {
+            inline_idx
+        }
     }
 }

--- a/crates/rb-sys/src/stable_api/ruby_3_4.rs
+++ b/crates/rb-sys/src/stable_api/ruby_3_4.rs
@@ -545,9 +545,21 @@ impl StableApiDefinition for Definition {
 
     #[inline(always)]
     unsafe fn encoding_get(&self, obj: VALUE) -> std::os::raw::c_int {
-        // Delegate to the exported rb_enc_get_index, which handles both the
-        // inline-encoded and out-of-line (ivar) cases correctly, and is stable
-        // across Ruby versions where the inline-bit offset varies.
-        crate::rb_enc_get_index(obj)
+        // Fast path: encoding index is stored inline in the flags when
+        // < RUBY_ENCODING_INLINE_MAX (0x7f). Only fall back to the libruby
+        // function for out-of-line encodings (rare in practice).
+        // Matches CRuby's `ENCODING_GET` inline function semantics.
+        let rbasic = obj as *const crate::RBasic;
+        let flags = (*rbasic).flags;
+        let shift = crate::ruby_encoding_consts::RUBY_ENCODING_SHIFT as u32;
+        let inline_max =
+            crate::ruby_encoding_consts::RUBY_ENCODING_INLINE_MAX as std::os::raw::c_int;
+        let mask = crate::ruby_encoding_consts::RUBY_ENCODING_MASK as VALUE;
+        let inline_idx = ((flags & mask) >> shift) as std::os::raw::c_int;
+        if inline_idx == inline_max {
+            crate::rb_enc_get_index(obj)
+        } else {
+            inline_idx
+        }
     }
 }

--- a/crates/rb-sys/src/stable_api/ruby_4_0.rs
+++ b/crates/rb-sys/src/stable_api/ruby_4_0.rs
@@ -541,9 +541,21 @@ impl StableApiDefinition for Definition {
 
     #[inline(always)]
     unsafe fn encoding_get(&self, obj: VALUE) -> std::os::raw::c_int {
-        // Delegate to the exported rb_enc_get_index, which handles both the
-        // inline-encoded and out-of-line (ivar) cases correctly, and is stable
-        // across Ruby versions where the inline-bit offset varies.
-        crate::rb_enc_get_index(obj)
+        // Fast path: encoding index is stored inline in the flags when
+        // < RUBY_ENCODING_INLINE_MAX (0x7f). Only fall back to the libruby
+        // function for out-of-line encodings (rare in practice).
+        // Matches CRuby's `ENCODING_GET` inline function semantics.
+        let rbasic = obj as *const crate::RBasic;
+        let flags = (*rbasic).flags;
+        let shift = crate::ruby_encoding_consts::RUBY_ENCODING_SHIFT as u32;
+        let inline_max =
+            crate::ruby_encoding_consts::RUBY_ENCODING_INLINE_MAX as std::os::raw::c_int;
+        let mask = crate::ruby_encoding_consts::RUBY_ENCODING_MASK as VALUE;
+        let inline_idx = ((flags & mask) >> shift) as std::os::raw::c_int;
+        if inline_idx == inline_max {
+            crate::rb_enc_get_index(obj)
+        } else {
+            inline_idx
+        }
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #681. The initial implementation of `encoding_get` delegates to the exported `rb_enc_get_index` function on all calls — but for the vast majority of objects (any encoding with index < 0x7f, which covers ASCII, UTF-8, US-ASCII, and all commonly used encodings), the encoding index is stored **inline in `RBasic.flags`** and can be read with no function call.

This PR restores the fast path: read the index directly from flags, and only fall back to `rb_enc_get_index` when the inline slot reads as `RUBY_ENCODING_INLINE_MAX (0x7f)`, which is the sentinel that CRuby uses to signal \"look at the ivar instead.\"

Semantics are unchanged — parity-tested against the compiled C shim.

## Changes

- `crates/rb-sys/src/stable_api/ruby_{2_7,3_0,3_1,3_2,3_3,3_4,4_0}.rs` — inline flag read + sentinel fallback.
- No changes to `compiled.c`/`compiled.rs`: C side already uses `ENCODING_GET` macro when defined, and TruffleRuby keeps its `rb_enc_get_index` fallback (no `RBasic.flags` exposed).

## Test plan

- [x] Parity tests pass locally (`test_encoding_get_ascii_string`, `test_encoding_get_utf8_string`)
- [ ] CI green across all Ruby versions + TruffleRuby

🤖 Generated with [Claude Code](https://claude.com/claude-code)