### PR TITLE
Ensure that Cargo metadata is UTF-8 encoded

### DIFF
--- a/gem/lib/rb_sys/cargo/metadata.rb
+++ b/gem/lib/rb_sys/cargo/metadata.rb
@@ -145,6 +145,7 @@ module RbSys
         args = ["metadata", "--format-version", "1"]
         args << "--no-deps" unless @deps
         out, stderr, status = Open3.capture3(cargo, *args)
+        out.force_encoding(Encoding::UTF_8)
         raise "exited with non-zero status (#{status})" unless status.success?
         data = JSON.parse(out)
         raise "metadata must be a Hash" unless data.is_a?(Hash)

--- a/gem/test/test_cargo_metadata.rb
+++ b/gem/test/test_cargo_metadata.rb
@@ -15,6 +15,20 @@ class TestCargoMetadata < Minitest::Test
     end
   end
 
+  def test_cargo_metadata_with_utf_8
+    skip if win_target?
+
+    original_encoding = Encoding.default_external
+    Encoding.default_external = Encoding::US_ASCII
+    in_new_crate("フー") do |dir|
+      metadata = RbSys::Cargo::Metadata.new("フー")
+
+      assert metadata.target_directory.end_with?(File.join(dir, "target"))
+    end
+  ensure
+    Encoding.default_external = original_encoding if original_encoding
+  end
+
   def test_fails_when_cargo_metadata_fails
     skip if win_target?
 


### PR DESCRIPTION
[TOML must be UTF-8](https://toml.io/en/v1.1.0#preliminaries). This PR forces the encoding of Cargo metadata output to UTF-8 via `force_encoding`.

This should be able to resolve #723.