### PR TITLE
chore(deps): bump rake-compiler-dock to 1.12.0

### DIFF
--- a/docker/Dockerfile.aarch64-linux
+++ b/docker/Dockerfile.aarch64-linux
@@ -1,5 +1,5 @@
 # Ensure this version matches the rack-compiler-version in Gemfile
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.11.0-mri-aarch64-linux
+FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.12.0-mri-aarch64-linux
 
 ENV RUBY_TARGET="aarch64-linux" \
     RUST_TARGET="aarch64-unknown-linux-gnu" \

--- a/docker/Dockerfile.aarch64-linux-musl
+++ b/docker/Dockerfile.aarch64-linux-musl
@@ -1,5 +1,5 @@
 # Ensure this version matches the rack-compiler-version in Gemfile
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.11.0-mri-aarch64-linux-musl
+FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.12.0-mri-aarch64-linux-musl
 
 ENV RUBY_TARGET="aarch64-linux-musl" \
     RUST_TARGET="aarch64-unknown-linux-musl" \

--- a/docker/Dockerfile.aarch64-mingw-ucrt
+++ b/docker/Dockerfile.aarch64-mingw-ucrt
@@ -1,5 +1,5 @@
 # Ensure this version matches the rack-compiler-version in Gemfile
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.11.0-mri-aarch64-mingw-ucrt
+FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.12.0-mri-aarch64-mingw-ucrt
 
 ENV RUBY_TARGET="aarch64-mingw-ucrt" \
     RUST_TARGET="aarch64-pc-windows-gnullvm" \

--- a/docker/Dockerfile.arm-linux
+++ b/docker/Dockerfile.arm-linux
@@ -1,5 +1,5 @@
 # Ensure this version matches the rack-compiler-version in Gemfile
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.11.0-mri-arm-linux
+FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.12.0-mri-arm-linux
 
 ENV RUBY_TARGET="arm-linux" \
     RUST_TARGET="arm-unknown-linux-gnueabihf" \

--- a/docker/Dockerfile.arm64-darwin
+++ b/docker/Dockerfile.arm64-darwin
@@ -1,5 +1,5 @@
 # Ensure this version matches the rack-compiler-version in Gemfile
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.11.0-mri-arm64-darwin
+FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.12.0-mri-arm64-darwin
 
 ENV RUBY_TARGET="arm64-darwin" \
     RUST_TARGET="aarch64-apple-darwin" \

--- a/docker/Dockerfile.x64-mingw-ucrt
+++ b/docker/Dockerfile.x64-mingw-ucrt
@@ -1,5 +1,5 @@
 # Ensure this version matches the rack-compiler-version in Gemfile
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.11.0-mri-x64-mingw-ucrt
+FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.12.0-mri-x64-mingw-ucrt
 
 ENV RUBY_TARGET="x64-mingw-ucrt" \
     RUST_TARGET="x86_64-pc-windows-gnu" \

--- a/docker/Dockerfile.x64-mingw32
+++ b/docker/Dockerfile.x64-mingw32
@@ -1,5 +1,5 @@
 # Ensure this version matches the rack-compiler-version in Gemfile
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.11.0-mri-x64-mingw32
+FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.12.0-mri-x64-mingw32
 
 ENV RUBY_TARGET="x64-mingw32" \
     RUST_TARGET="x86_64-pc-windows-gnu" \

--- a/docker/Dockerfile.x86-linux
+++ b/docker/Dockerfile.x86-linux
@@ -1,5 +1,5 @@
 # Ensure this version matches the rack-compiler-version in Gemfile
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.11.0-mri-x86-linux
+FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.12.0-mri-x86-linux
 
 ENV RUBY_TARGET="x86-linux" \
     RUST_TARGET="i686-unknown-linux-gnu" \

--- a/docker/Dockerfile.x86-mingw32
+++ b/docker/Dockerfile.x86-mingw32
@@ -1,5 +1,5 @@
 # Ensure this version matches the rack-compiler-version in Gemfile
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.11.0-mri-x86-mingw32
+FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.12.0-mri-x86-mingw32
 
 ARG LLVM_MINGW_VERSION=20231128 \
     LLVM_MINGW_SHA256=2d532648bfd202bfe5edfa8b7f6c55970f65639779f34115a9a8bfa6f7d87f0b \

--- a/docker/Dockerfile.x86_64-darwin
+++ b/docker/Dockerfile.x86_64-darwin
@@ -1,5 +1,5 @@
 # Ensure this version matches the rack-compiler-version in Gemfile
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.11.0-mri-x86_64-darwin
+FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.12.0-mri-x86_64-darwin
 
 ENV RUBY_TARGET="x86_64-darwin" \
     RUST_TARGET="x86_64-apple-darwin" \

--- a/docker/Dockerfile.x86_64-linux
+++ b/docker/Dockerfile.x86_64-linux
@@ -1,5 +1,5 @@
 # Ensure this version matches the rack-compiler-version in Gemfile
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.11.0-mri-x86_64-linux
+FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.12.0-mri-x86_64-linux
 
 ENV RUBY_TARGET="x86_64-linux" \
     RUST_TARGET="x86_64-unknown-linux-gnu" \

--- a/docker/Dockerfile.x86_64-linux-musl
+++ b/docker/Dockerfile.x86_64-linux-musl
@@ -1,5 +1,5 @@
 # Ensure this version matches the rack-compiler-version in Gemfile
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.11.0-mri-x86_64-linux-musl
+FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.12.0-mri-x86_64-linux-musl
 
 ENV RUBY_TARGET="x86_64-linux-musl" \
     RUST_TARGET="x86_64-unknown-linux-musl" \

--- a/gem/rb_sys.gemspec
+++ b/gem/rb_sys.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   end
 
   # Needed for `RakeCompilerDock.cross_rubies`
-  spec.add_dependency("rake-compiler-dock", "1.11.0")
+  spec.add_dependency("rake-compiler-dock", "1.12.0")
 
   spec.metadata["rubygems_mfa_required"] = "true"
 end


### PR DESCRIPTION
Bumps rake-compiler-dock 1.11.0 → 1.12.0 in the gemspec and all 12 per-platform base Dockerfiles.

Upstream release notes:
- Fix `gem install rdoc` permission error
- Fix musl cross-compiler build
- Ruby bumps: 4.0.2, 3.4.9, 3.3.11, 3.2.11 (3.1.7 / 3.0.7 unchanged)

`RUBY_CC_VERSION` is sourced from the base image, so no CI matrix or toolchain changes needed.

## Test plan
- [ ] CI green
- [ ] `docker.yml` rebuilds all `rbsys/rcd:<platform>` images on the new base

🤖 Generated with [Claude Code](https://claude.com/claude-code)