### PR TITLE
Fix background color for navbar

### DIFF
--- a/docsite/src/css/custom.css
+++ b/docsite/src/css/custom.css
@@ -361,7 +361,7 @@ li {
 }
 
 .navbar {
-  background-color: var(--ifm-background-color);
+  background-color: var(--ifm-navbar-background-color);
   box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.1);
   height: 4rem;
 }


### PR DESCRIPTION
This PR fixes an issue in light mode where text behind a transparent navbar shows through.

## Before

<img width="537" height="139" src="https://github.com/user-attachments/assets/a49fd8ba-3325-4729-bdac-347c6adf0dce" />

## After

<img width="537" height="139" src="https://github.com/user-attachments/assets/a57a3861-c8d7-45a0-b5c3-b271ca1fbf05" />