### PR TITLE
Fix target-dir rewrite for dashed paths

### DIFF
--- a/gem/lib/rb_sys/mkmf.rb
+++ b/gem/lib/rb_sys/mkmf.rb
@@ -217,7 +217,7 @@ module RbSys
       cargo_command.gsub!(/--profile [\w-]+/, "$(RB_SYS_CARGO_PROFILE_FLAG)")
       cargo_command.gsub!(%r{--features \S+}, "--features $(RB_SYS_CARGO_FEATURES)")
       cargo_command.gsub!(%r{--target \S+}, "--target $(CARGO_BUILD_TARGET)")
-      cargo_command.gsub!(/--target-dir (?:(?!--).)+/, "--target-dir $(RB_SYS_CARGO_TARGET_DIR) ")
+      cargo_command.gsub!(/--target-dir (?:\\.|[^[:space:]])+/, "--target-dir $(RB_SYS_CARGO_TARGET_DIR)")
       cargo_command
     end
 

--- a/gem/test/test_rb_sys.rb
+++ b/gem/test/test_rb_sys.rb
@@ -19,6 +19,24 @@ class TestRbSys < Minitest::Test
     assert_match(/\$\(CARGO\) rustc/, makefile.read)
   end
 
+  def test_target_dir_rewrite_handles_double_hyphens_in_path
+    makefile = create_makefile(prefix: "rb_sys_test--worktree")
+    cargo_command = cargo_command_line(makefile)
+
+    assert_includes(cargo_command, "--target-dir $(RB_SYS_CARGO_TARGET_DIR)")
+    assert_includes(cargo_command, "--lib $(RB_SYS_CARGO_PROFILE_FLAG)")
+    refute_includes(cargo_command, "--worktree")
+  end
+
+  def test_target_dir_rewrite_handles_spaces_in_path
+    makefile = create_makefile(prefix: "rb_sys space_marker")
+    cargo_command = cargo_command_line(makefile)
+
+    assert_includes(cargo_command, "--target-dir $(RB_SYS_CARGO_TARGET_DIR)")
+    assert_includes(cargo_command, "--lib $(RB_SYS_CARGO_PROFILE_FLAG)")
+    refute_includes(cargo_command, "space_marker")
+  end
+
   def test_invokes_custom_env
     skip("Skipping for mswin") if win_target?
 
@@ -124,15 +142,19 @@ class TestRbSys < Minitest::Test
 
   private
 
-  def create_makefile(&blk)
+  def create_makefile(prefix: "rb_sys_test", &blk)
     require "mkmf"
     require "rb_sys/mkmf"
-    cargo_dir = Dir.mktmpdir("rb_sys_test")
+    cargo_dir = Dir.mktmpdir(prefix)
 
     Dir.chdir(cargo_dir) do
       create_rust_makefile("foo_ext", &blk)
       Pathname.new(File.join(cargo_dir, "Makefile"))
     end
+  end
+
+  def cargo_command_line(makefile)
+    makefile.read.lines.find { |line| line.include?("$(CARGO) rustc") }
   end
 
   def create_makefile_with_cargo_config(config_content, &blk)


### PR DESCRIPTION
The generated Makefile rewrites Cargo's concrete `--target-dir` path to `$(RB_SYS_CARGO_TARGET_DIR)`. The previous regex stopped when it saw any `--` in the already shell-joined path, which left the rest of the path as a bogus Cargo option.

This caused directories like `~/trees/michaelherold--fix-bug-in-foo/` to fail to compile as it would split the double-dash from the path, leaving a non-existent directory.

This change matches the target directory as a shell word instead, so paths containing `--` or spaces are fully replaced.