### PR TITLE
Fix labels assigned to Docker images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -102,7 +102,7 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=sha,format=long
-          labels:
+          labels: |
             org.opencontainers.image.description=Image for building native Rust extensions for Ruby on ${{ env.ruby_platform }}
             org.opencontainers.image.vendor=oxidize-rb
             org.oxidize-rb.ruby.platform=${{ env.ruby_platform }}


### PR DESCRIPTION
I noticed that the `org.opencontainers.image.description` label ends with the text ` org.opencontainers.image.vendor=oxidize-rb org.oxidize-rb.ruby.platform=x64-mingw-ucrt`:

```console
$ podman image inspect docker.io/rbsys/x64-mingw-ucrt:0.9.128 | jq '.[0].Labels'
{
  "org.opencontainers.image.created": "2026-05-04T20:06:43.310Z",
  "org.opencontainers.image.description": "Image for building native Rust extensions for Ruby on x64-mingw-ucrt org.opencontainers.image.vendor=oxidize-rb org.oxidize-rb.ruby.platform=x64-mingw-ucrt",
  "org.opencontainers.image.licenses": "Apache-2.0",
  "org.opencontainers.image.ref.name": "ubuntu",
  "org.opencontainers.image.revision": "94b205cd8425ebdc09d5682f14503b3f3756fa9b",
  "org.opencontainers.image.source": "https://github.com/oxidize-rb/rb-sys",
  "org.opencontainers.image.title": "rb-sys",
  "org.opencontainers.image.url": "https://github.com/oxidize-rb/rb-sys",
  "org.opencontainers.image.version": "0.9.128"
}
```

That was clearly not intentional. It was caused by using the YAML "plain flow scalar" (unquoted string) syntax in the `labels:` key (https://yaml-multiline.info/#flow-scalars-plain), which replaces newlines with spaces. The fix is to use `labels: |` instead (`|` is a _literal_ block style indicator, which ensures that newlines are kept), as can be seen in the README of `docker/metadata-action`: https://github.com/docker/metadata-action/blob/dc802804100637a589fabce1cb79ff13a1411302/README.md#overwrite-labels-and-annotations