### PR TITLE
Avoid PATH-resolved echo in generated Makefiles

### DIFF
--- a/gem/lib/rb_sys/mkmf.rb
+++ b/gem/lib/rb_sys/mkmf.rb
@@ -161,6 +161,11 @@ module RbSys
       base_makefile = dummy_makefile(__dir__).join("\n")
       base_makefile.gsub!("all install static install-so install-rb", "all static install-rb")
       base_makefile.gsub!(/^srcdir = .*$/, "srcdir = #{cargo_dir}")
+      unless $nmake
+        base_makefile.gsub!(/^ECHO = \$\(ECHO1:0=@ echo\)$/,
+          "ECHO = $(ECHO1:0=@ /bin/echo)")
+      end
+
       base_makefile
     end
 

--- a/gem/test/test_mkmf_echo.rb
+++ b/gem/test/test_mkmf_echo.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "mkmf"
+require "rb_sys/mkmf"
+require "tmpdir"
+
+class MkmfEchoTest < Minitest::Test
+  def test_generated_makefile_uses_absolute_echo_command
+    skip "requires a POSIX echo executable" if win_target?
+
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        create_rust_makefile("example")
+
+        makefile = File.read("Makefile")
+
+        assert_includes makefile, "ECHO = $(ECHO1:0=@ /bin/echo)"
+        refute_includes makefile, "ECHO = $(ECHO1:0=@ echo)"
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Ruby's `mkmf` generates an `ECHO` command that invokes `echo` through `PATH`:

```make
ECHO = $(ECHO1:0=@ echo)
```

Under some Bundler environments, a RubyGems executable named `echo` may appear earlier in `PATH` than the operating system's `echo`, causing native extension builds to invoke the wrong executable.

This change replaces the PATH-resolved command in rb-sys-generated POSIX Makefiles with an absolute path:

```make
ECHO = $(ECHO1:0=@ /bin/echo)
```

The replacement is applied only for POSIX Makefiles (`unless $nmake`), so native Windows builds are unaffected.

## Background

I originally encountered this while building the `kino` gem, where the generated Makefile invoked the RubyGems `echo` executable instead of the operating system's `echo`, resulting in incorrect build output.

The issue was originally addressed downstream in `kino`:

https://github.com/yaroslav/kino/pull/4

Since `rb-sys` is responsible for generating the Makefile, it seemed more appropriate to apply the workaround here so downstream gems do not each need to patch their generated Makefiles independently.

## Tests

- Added a regression test verifying that generated POSIX Makefiles contain:

  ```make
  ECHO = $(ECHO1:0=@ /bin/echo)
  ```

- The regression test is skipped on Windows.

- Verified with:

  - `bundle exec rake test`
  - `bundle exec rubocop gem/lib/rb_sys/mkmf.rb gem/test/test_mkmf_echo.rb`
 
## Notes

This addresses the issue within `rb-sys`-generated Makefiles. The underlying `ECHO` definition originates from Ruby's `mkmf` and is now being addressed upstream in [ruby/ruby#17975](https://github.com/ruby/ruby/pull/17975)

If the upstream fix is merged and becomes part of the minimum Ruby version supported by `rb-sys`, this workaround may eventually become unnecessary.