### PR TITLE
Fix ExtensionTask custom ext_dir handling

### DIFF
--- a/gem/lib/rb_sys/extensiontask.rb
+++ b/gem/lib/rb_sys/extensiontask.rb
@@ -61,7 +61,7 @@ module RbSys
     end
 
     def extconf
-      File.join(cargo_metadata.manifest_directory, "extconf.rb")
+      File.join(ext_dir, "extconf.rb")
     end
 
     def binary(_platf)
@@ -104,7 +104,7 @@ module RbSys
     def define_env_tasks
       task "rb_sys:env:default" do
         ENV["RB_SYS_CARGO_TARGET_DIR"] ||= target_directory
-        ENV["RB_SYS_CARGO_MANIFEST_DIR"] ||= cargo_metadata.manifest_directory
+        ENV["RB_SYS_CARGO_MANIFEST_DIR"] ||= File.expand_path(ext_dir)
         ENV["RB_SYS_CARGO_PROFILE"] ||= "release"
       end
 

--- a/gem/test/test_extensiontask.rb
+++ b/gem/test/test_extensiontask.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "rb_sys/extensiontask"
+
+class TestExtensionTask < Minitest::Test
+  def setup
+    Rake::Task.clear
+    @original_manifest_dir = ENV.delete("RB_SYS_CARGO_MANIFEST_DIR")
+    @original_target_dir = ENV.delete("RB_SYS_CARGO_TARGET_DIR")
+    @original_profile = ENV.delete("RB_SYS_CARGO_PROFILE")
+  end
+
+  def teardown
+    ENV["RB_SYS_CARGO_MANIFEST_DIR"] = @original_manifest_dir
+    ENV["RB_SYS_CARGO_TARGET_DIR"] = @original_target_dir
+    ENV["RB_SYS_CARGO_PROFILE"] = @original_profile
+    Rake::Task.clear
+  end
+
+  def test_custom_ext_dir_is_used_for_extconf_and_cargo_manifest
+    metadata = Struct.new(:manifest_directory, :target_directory)
+      .new("ext/my_gem", "target")
+
+    RbSys::Cargo::Metadata.stub(:new_or_inferred, metadata) do
+      extension = RbSys::ExtensionTask.new("my_gem") do |ext|
+        ext.ext_dir = "bindings/ruby"
+      end
+
+      assert_equal "bindings/ruby/extconf.rb", extension.extconf
+
+      Rake::Task["rb_sys:env:default"].invoke
+      assert_equal File.expand_path("bindings/ruby"), ENV["RB_SYS_CARGO_MANIFEST_DIR"]
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- resolve `extconf.rb` from the configured `ext_dir`
- export the configured directory as an absolute Cargo manifest directory so it remains valid from rake-compiler's temporary build directory
- add regression coverage for both paths

## Validation

- `./script/run bundle exec rake test:gem` (54 runs, 91 assertions)
- `./script/run bundle exec standardrb gem/lib/rb_sys/extensiontask.rb gem/test/test_extensiontask.rb`
- `./script/run git diff --check`

Fixes #525