### PR TITLE
Ignore RUBYOPT when loading RbConfig

### DIFF
--- a/crates/rb-sys-build/src/rb_config.rs
+++ b/crates/rb-sys-build/src/rb_config.rs
@@ -80,6 +80,7 @@ impl RbConfig {
                     .arg("-rrbconfig")
                     .arg("-e")
                     .arg("print RbConfig::CONFIG.map {|kv| kv.join(\"\x1F\")}.join(\"\x1E\")")
+                    .env_remove("RUBYOPT")
                     .output()
                     .unwrap_or_else(|e| panic!("ruby not found: {}", e));
                 if !config.status.success() {

--- a/crates/rb-sys-build/tests/fixtures/rubyopt_stdout.rb
+++ b/crates/rb-sys-build/tests/fixtures/rubyopt_stdout.rb
@@ -1,0 +1,1 @@
+puts "RUBYOPT polluted stdout"

--- a/crates/rb-sys-build/tests/rubyopt.rs
+++ b/crates/rb-sys-build/tests/rubyopt.rs
@@ -1,0 +1,17 @@
+use std::{env, path::PathBuf};
+
+use rb_sys_build::RbConfig;
+
+#[test]
+fn current_ignores_rubyopt() {
+    let fixture_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
+    env::set_var("RUBYLIB", fixture_dir);
+    env::set_var("RUBYOPT", "-rrubyopt_stdout");
+
+    let rbconfig = RbConfig::current();
+
+    assert!(rbconfig.get("MAJOR").is_some());
+    assert!(rbconfig
+        .all_keys()
+        .all(|key| !key.contains("RUBYOPT polluted stdout")));
+}


### PR DESCRIPTION
## Summary

- prevent inherited Ruby startup hooks from contaminating the structured `RbConfig` output
- add an integration test whose `RUBYOPT` hook deliberately writes to stdout

## Tests

- `./script/run bundle exec rake test`
- `./script/run cargo test -p rb-sys-build`
- `./script/run cargo fmt --check`
- `./script/run cargo clippy -p rb-sys-build --all-targets` (passes with three pre-existing warnings)
- `./script/run bundle exec standardrb crates/rb-sys-build/tests/fixtures/rubyopt_stdout.rb`

Fixes #747