### PR TITLE
Allow forced Rust bootstrap when Cargo is missing

### DIFF
--- a/gem/lib/rb_sys/error.rb
+++ b/gem/lib/rb_sys/error.rb
@@ -32,7 +32,7 @@ module RbSys
           - Make sure `cargo` is installed and in your PATH
       MSG
 
-      if !stderr.empty?
+      if stderr && !stderr.empty?
         indented_stderr = stderr.lines.map { |line| "  #{line}" }.join
         msg << "Stderr from `cargo metadata` was:\n#{indented_stderr}"
       end

--- a/gem/lib/rb_sys/extensiontask.rb
+++ b/gem/lib/rb_sys/extensiontask.rb
@@ -29,8 +29,8 @@ module RbSys
     def init(name = nil, gem_spec = nil)
       super(name, lint_gem_spec(name, gem_spec))
 
-      @orginal_ext_dir = @ext_dir
-      @ext_dir = cargo_metadata.manifest_directory
+      @original_ext_dir = @ext_dir
+      @ext_dir = cargo_manifest_directory
       @source_pattern = nil
       @compiled_pattern = "*.{obj,so,bundle,dSYM}"
       @cross_compile = ENV.key?("RUBY_TARGET")
@@ -86,6 +86,8 @@ module RbSys
     end
 
     def target_directory
+      return fallback_target_directory if @cargo_metadata_unavailable
+
       cargo_metadata.target_directory
     end
 
@@ -128,6 +130,33 @@ module RbSys
     end
 
     private
+
+    def cargo_manifest_directory
+      cargo_metadata.manifest_directory
+    rescue CargoMetadataError
+      raise unless force_install_rust_toolchain?
+
+      # Let the generated Makefile install Cargo before the extension is built.
+      @cargo_metadata_unavailable = true
+      File.expand_path(configured_extension_directory)
+    end
+
+    def configured_extension_directory
+      extension = @gem_spec&.extensions&.find do |path|
+        %w[Cargo.toml extconf.rb].include?(File.basename(path))
+      end
+
+      extension ? File.dirname(extension) : @original_ext_dir
+    end
+
+    def fallback_target_directory
+      File.expand_path(ENV["RB_SYS_CARGO_TARGET_DIR"] || ENV["CARGO_TARGET_DIR"] || "target")
+    end
+
+    def force_install_rust_toolchain?
+      value = ENV["RB_SYS_FORCE_INSTALL_RUST_TOOLCHAIN"]
+      value && value != "false"
+    end
 
     def lint_gem_spec(name, gs)
       gem_spec = case gs

--- a/gem/test/test_extensiontask.rb
+++ b/gem/test/test_extensiontask.rb
@@ -1,21 +1,20 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "fileutils"
 require "rb_sys/extensiontask"
+require "tmpdir"
 
 class TestExtensionTask < Minitest::Test
   def setup
-    Rake::Task.clear
-    @original_manifest_dir = ENV.delete("RB_SYS_CARGO_MANIFEST_DIR")
-    @original_target_dir = ENV.delete("RB_SYS_CARGO_TARGET_DIR")
-    @original_profile = ENV.delete("RB_SYS_CARGO_PROFILE")
+    @original_rake_application = Rake.application
+    @original_env = ENV.to_h
+    Rake.application = Rake::Application.new
   end
 
   def teardown
-    ENV["RB_SYS_CARGO_MANIFEST_DIR"] = @original_manifest_dir
-    ENV["RB_SYS_CARGO_TARGET_DIR"] = @original_target_dir
-    ENV["RB_SYS_CARGO_PROFILE"] = @original_profile
-    Rake::Task.clear
+    Rake.application = @original_rake_application
+    ENV.replace(@original_env)
   end
 
   def test_custom_ext_dir_is_used_for_extconf_and_cargo_manifest
@@ -31,6 +30,57 @@ class TestExtensionTask < Minitest::Test
 
       Rake::Task["rb_sys:env:default"].invoke
       assert_equal File.expand_path("bindings/ruby"), ENV["RB_SYS_CARGO_MANIFEST_DIR"]
+    end
+  end
+
+  def test_force_install_defines_compile_tasks_without_cargo
+    in_new_extension do |dir, spec|
+      ENV["CARGO"] = File.join(dir, "missing-cargo")
+      ENV["RB_SYS_FORCE_INSTALL_RUST_TOOLCHAIN"] = "true"
+
+      extension_task = RbSys::ExtensionTask.new("example-extension", spec)
+
+      assert_equal File.join(dir, "ext/example_extension"), extension_task.ext_dir
+      assert_equal File.join(dir, "target"), extension_task.target_directory
+      assert Rake::Task.task_defined?("compile")
+
+      Rake::Task["rb_sys:env:default"].invoke
+      assert_equal File.join(dir, "ext/example_extension"), ENV["RB_SYS_CARGO_MANIFEST_DIR"]
+      assert_equal File.join(dir, "target"), ENV["RB_SYS_CARGO_TARGET_DIR"]
+    end
+  end
+
+  def test_missing_cargo_still_raises_without_force_install
+    in_new_extension do |dir, spec|
+      ENV["CARGO"] = File.join(dir, "missing-cargo")
+      ENV.delete("RB_SYS_FORCE_INSTALL_RUST_TOOLCHAIN")
+
+      assert_raises(RbSys::CargoMetadataError) do
+        RbSys::ExtensionTask.new("example-extension", spec)
+      end
+    end
+  end
+
+  private
+
+  def in_new_extension
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        extension_dir = "ext/example_extension"
+        FileUtils.mkdir_p(extension_dir)
+        File.write("Cargo.toml", "[workspace]\nmembers = [\"#{extension_dir}\"]\n")
+        File.write(File.join(extension_dir, "Cargo.toml"), "[package]\nname = \"example-extension\"\nversion = \"0.1.0\"\n")
+        File.write(File.join(extension_dir, "extconf.rb"), "")
+
+        spec = Gem::Specification.new do |gem_spec|
+          gem_spec.name = "example-extension"
+          gem_spec.version = "0.1.0"
+          gem_spec.files = Dir["ext/**/*"]
+          gem_spec.extensions = [File.join(extension_dir, "extconf.rb")]
+        end
+
+        yield Dir.pwd, spec
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

- let `RbSys::ExtensionTask` define compile tasks without running `cargo metadata` when `RB_SYS_FORCE_INSTALL_RUST_TOOLCHAIN` is enabled
- derive the extension manifest directory from the gemspec and use the standard Cargo target directory until the generated Makefile installs the requested toolchain
- preserve the existing metadata error when forced installation is not enabled
- handle missing stderr when the cargo executable itself cannot be spawned

## Testing

- `./script/run bundle exec ruby -Igem/test -Igem/lib gem/test/test_extensiontask.rb`
- `./script/run bundle exec rake test:gem`
- `./script/run bundle exec standardrb`
- direct ExtensionTask initialization with `CARGO` set to a missing executable and forced installation enabled

Fixes #550