### PR TITLE
Find compiler builtin headers for bundled libclang

### DIFF
--- a/gem/lib/rb_sys/mkmf.rb
+++ b/gem/lib/rb_sys/mkmf.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rubygems/ext"
+require "open3"
 require "shellwords"
 require_relative "cargo_builder"
 require_relative "mkmf/config"
@@ -358,12 +359,34 @@ module RbSys
       end
     end
 
-    def try_load_bundled_libclang(_builder)
+    def try_load_bundled_libclang(builder)
       require "libclang"
       assert_libclang_version_valid!
-      export_env("LIBCLANG_PATH", Libclang.libdir)
+
+      config = [export_env("LIBCLANG_PATH", Libclang.libdir)]
+      if (include_dir = compiler_builtin_include_dir(builder))
+        clang_args = Shellwords.join(["-isystem", include_dir])
+        config << conditional_assign("BINDGEN_EXTRA_CLANG_ARGS", clang_args, export: true)
+      end
+      config.join("\n")
     rescue LoadError
       # If we can't load the bundled libclang, just continue
+    end
+
+    def compiler_builtin_include_dir(builder)
+      cc = env_or_makefile_config("CC", builder)
+      return unless cc
+
+      stdout, _stderr, status = Open3.capture3(*Shellwords.split(cc), "-print-file-name=include")
+      return unless status.success?
+
+      path = stdout.strip
+      return if path.empty? || path == "include"
+
+      include_dir = File.expand_path(path)
+      include_dir if Dir.exist?(include_dir)
+    rescue Errno::ENOENT
+      nil
     end
 
     def assert_libclang_version_valid!

--- a/gem/test/test_rb_sys.rb
+++ b/gem/test/test_rb_sys.rb
@@ -81,8 +81,13 @@ class TestRbSys < Minitest::Test
     Object.send(:remove_const, :Libclang) if original_libclang
 
     libclang = Module.new do
-      def self.version = "14.0.6"
-      def self.libdir = "/vendor/lib"
+      def self.version
+        "14.0.6"
+      end
+
+      def self.libdir
+        "/vendor/lib"
+      end
     end
 
     Object.const_set(:Libclang, libclang)
@@ -90,8 +95,10 @@ class TestRbSys < Minitest::Test
       stub(:compiler_builtin_include_dir, "/compiler/include") do
         config = send(:try_load_bundled_libclang, nil)
 
-        assert_includes config, "export LIBCLANG_PATH := /vendor/lib"
-        assert_includes config, "export BINDGEN_EXTRA_CLANG_ARGS ?= -isystem /compiler/include"
+        assert_includes config, "LIBCLANG_PATH"
+        assert_includes config, "/vendor/lib"
+        assert_includes config, "BINDGEN_EXTRA_CLANG_ARGS"
+        assert_includes config, "-isystem /compiler/include"
       end
     end
   ensure
@@ -109,7 +116,7 @@ class TestRbSys < Minitest::Test
 
     Open3.stub(:capture3, capture) do
       Dir.stub(:exist?, true) do
-        assert_equal "/compiler/include", send(:compiler_builtin_include_dir, builder)
+        assert_equal File.expand_path("/compiler/include"), send(:compiler_builtin_include_dir, builder)
       end
     end
   end

--- a/gem/test/test_rb_sys.rb
+++ b/gem/test/test_rb_sys.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "mkmf"
+require "rb_sys/mkmf"
 
 class TestRbSys < Minitest::Test
   def test_that_it_has_a_version_number
@@ -72,6 +74,44 @@ class TestRbSys < Minitest::Test
 
     assert_match(/rustup target add wasm32-unknown-unknown$/, makefile_output)
     assert_match(/rustup target add wasm32-wasi-unknown$/, makefile_output)
+  end
+
+  def test_bundled_libclang_uses_compiler_builtin_headers
+    original_libclang = Object.const_get(:Libclang) if Object.const_defined?(:Libclang, false)
+    Object.send(:remove_const, :Libclang) if original_libclang
+
+    libclang = Module.new do
+      def self.version = "14.0.6"
+      def self.libdir = "/vendor/lib"
+    end
+
+    Object.const_set(:Libclang, libclang)
+    stub(:require, true) do
+      stub(:compiler_builtin_include_dir, "/compiler/include") do
+        config = send(:try_load_bundled_libclang, nil)
+
+        assert_includes config, "export LIBCLANG_PATH := /vendor/lib"
+        assert_includes config, "export BINDGEN_EXTRA_CLANG_ARGS ?= -isystem /compiler/include"
+      end
+    end
+  ensure
+    Object.send(:remove_const, :Libclang) if Object.const_defined?(:Libclang, false)
+    Object.const_set(:Libclang, original_libclang) if original_libclang
+  end
+
+  def test_finds_builtin_headers_from_configured_compiler
+    builder = Struct.new(:env).new({"CC" => "ccache gcc"})
+    successful_status = Struct.new(:success?).new(true)
+    capture = lambda do |*command|
+      assert_equal ["ccache", "gcc", "-print-file-name=include"], command
+      ["/compiler/include\n", "", successful_status]
+    end
+
+    Open3.stub(:capture3, capture) do
+      Dir.stub(:exist?, true) do
+        assert_equal "/compiler/include", send(:compiler_builtin_include_dir, builder)
+      end
+    end
   end
 
   def test_uses_extra_cargo_args


### PR DESCRIPTION
## Summary

- ask the configured C compiler for its builtin include directory when the `libclang` gem is used
- export that directory through `BINDGEN_EXTRA_CLANG_ARGS`, allowing libclang to resolve compiler-provided headers such as `stdarg.h` without a separate Clang executable installation
- preserve an explicitly configured `BINDGEN_EXTRA_CLANG_ARGS` value and gracefully skip compilers that cannot report an include directory

## Validation

- `./script/run bundle exec rake test:gem` (55 runs, 95 assertions)
- `./script/run bundle exec standardrb gem/lib/rb_sys/mkmf.rb gem/test/test_rb_sys.rb`
- downloaded the released `libclang` 14.0.6 gem (shared library only) and successfully compiled `examples/rust_reverse`; the generated Makefile selected the gem dylib and the configured compiler resource headers
- `./script/run git diff --check`

Fixes #350