### PR TITLE
Update mdast-util-to-hast to 13.2.1

### DIFF
--- a/docsite/package-lock.json
+++ b/docsite/package-lock.json
@@ -11615,9 +11615,9 @@
       }
     },
     "node_modules/mdast-util-to-hast": {
-      "version": "13.2.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.0.tgz",
-      "integrity": "sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",


### PR DESCRIPTION
Replaces #655 with a surgical lockfile update generated and verified against the npm 10 toolchain used with the Node 20 documentation workflow. This avoids the unrelated peer-metadata churn introduced when the old Dependabot branch was refreshed. Local npm ci and the production docsite build both pass.