### PR TITLE
Fix Cargo Dependabot group schema

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,8 +23,9 @@ updates:
       time: "09:00"
       timezone: "America/New_York"
     groups:
-      cargo-transitive:
-        dependency-type: "indirect"
+      cargo-minor-patch:
+        patterns:
+          - "*"
         update-types:
           - "minor"
           - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -61,6 +61,11 @@ updates:
       day: "friday"
       time: "09:00"
       timezone: "America/New_York"
+    ignore:
+      # Docusaurus 3.9.2 passes webpackbar options that webpack 5.109 rejects.
+      - dependency-name: "webpack"
+        versions:
+          - "5.109.x"
     groups:
       docsite-minor-patch:
         patterns:


### PR DESCRIPTION
Dependabot only accepts production or development for a group dependency-type. Group all Cargo minor and patch updates using a wildcard pattern instead.

Also ignore webpack 5.109.x for the docsite: an isolated npm ci succeeds, but Docusaurus 3.9.2 fails its production build because webpack 5.109 rejects the webpackbar progress options. The same grouped update builds successfully with webpack 5.99.8, and later webpack minor lines remain eligible.