### PR TITLE
ci: scope Rust matrix off docsite-only PRs, add docsite build check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,10 @@ on:
   push:
     branches:
       - main
-  pull_request: {}
+  pull_request:
+    paths-ignore:
+      - "docsite/**"
+      - "**/*.md"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/docsite.yml
+++ b/.github/workflows/docsite.yml
@@ -1,0 +1,42 @@
+---
+name: "Docsite"
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "docsite/**"
+      - ".github/workflows/docsite.yml"
+  pull_request:
+    paths:
+      - "docsite/**"
+      - ".github/workflows/docsite.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: 🏗️ Build docsite
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 20
+          cache: "npm"
+          cache-dependency-path: docsite/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: docsite
+
+      - name: Build docsite
+        run: npm run build
+        working-directory: docsite

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -6,7 +6,10 @@ on:
   push:
     branches:
       - main
-  pull_request: {}
+  pull_request:
+    paths-ignore:
+      - "docsite/**"
+      - "**/*.md"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Why

Docsite-only PRs currently run the full Rust CI matrix. `ci.yml` and `integration.yml` both trigger on bare `pull_request: {}`, so a lockfile-only change under `docsite/` fires ~58 CI jobs plus the integration matrix. The 15 docsite security PRs (#780–#794) would have burned ~870 checks between them.

Safe to filter here: `main` has no `required_status_checks` and no rulesets, so there is no "required check never reports" deadlock to fall into.

## The coverage hole this also fixes

Path-filtering on its own would have *removed* validation rather than redirected it. `publish-docs.yml` is the only workflow that runs `npm ci && npm run build` against `docsite/`, and it triggers on `push: main` only — so docsite changes get zero build validation until after they are merged. That is exactly what happened with #795: the docsite build was confirmed only post-merge.

So this adds `.github/workflows/docsite.yml` — the same install/build steps as `publish-docs.yml`, path-filtered to `docsite/**`, `permissions: contents: read`, no deploy step (deployment stays in `publish-docs.yml`).

## Changes

- `ci.yml`, `integration.yml`: `pull_request:` gains `paths-ignore: ["docsite/**", "**/*.md"]`. `push: main` untouched.
- `docsite.yml`: new, PR + push-to-main, filtered to `docsite/**` and itself.

## Note, not fixed here

`publish-docs.yml` uses a floating `actions/setup-node@v7` and `doctest.yml` a floating `actions/checkout@v7` — both unpinned, unlike every other action reference in this repo, which are SHA-pinned. Flagging rather than fixing silently; the new `docsite.yml` is SHA-pinned per convention.

## Caveat to remember

If required status checks are ever enabled on `main`, these path filters must be paired with skip-jobs reporting the same check names, or filtered PRs will hang unmergeable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)